### PR TITLE
DM-1076, remove need of unit tests to setVersion(0), and move tests to d...

### DIFF
--- a/src/table/Schema.cc
+++ b/src/table/Schema.cc
@@ -473,13 +473,15 @@ int SchemaImpl::contains(SchemaItem<T> const & item, int flags) const {
 
 std::set<std::string> SchemaImpl::getNames(bool topOnly) const {
     std::set<std::string> result;
+    // set the separator for table ('.' if getVersion() is 0 or nan, else '_')
+    char separator = (getVersion() > 0) ? '_' : '.';
     if (topOnly) {
         for (NameMap::const_iterator i = _names.begin(); i != _names.end(); ++i) {
-            std::size_t dot = i->first.find('.');
-            if (dot == std::string::npos) {
+            std::size_t sep = i->first.find(separator);
+            if (sep == std::string::npos) {
                 result.insert(result.end(), i->first);
             } else {
-                result.insert(result.end(), i->first.substr(0, dot));
+                result.insert(result.end(), i->first.substr(0, sep));
             }
         }
     } else {
@@ -492,11 +494,13 @@ std::set<std::string> SchemaImpl::getNames(bool topOnly) const {
 
 std::set<std::string> SchemaImpl::getNames(bool topOnly, std::string const & prefix) const {
     std::set<std::string> result;
+    // set the separator for table ('.' if getVersion() is 0 or nan, else '_')
+    char separator = (getVersion() > 0) ? '_' : '.';
     if (topOnly) {
         for (NameMap::const_iterator i = _names.lower_bound(prefix); i != _names.end(); ++i) {
             if (i->first.compare(0, prefix.size(), prefix) != 0) break;
-            std::size_t dot = i->first.find('.', prefix.size() + 1);
-            if (dot == std::string::npos) {
+            std::size_t sep = i->first.find(separator, prefix.size() + 1);
+            if (sep == std::string::npos) {
                 result.insert(
                     result.end(),
                     i->first.substr(prefix.size() + 1, i->first.size() - prefix.size())
@@ -504,7 +508,7 @@ std::set<std::string> SchemaImpl::getNames(bool topOnly, std::string const & pre
             } else {
                 result.insert(
                     result.end(),
-                    i->first.substr(prefix.size() + 1, dot - prefix.size() - 1)
+                    i->first.substr(prefix.size() + 1, sep - prefix.size() - 1)
                 );
             }
         }

--- a/tests/sourceMatch.py
+++ b/tests/sourceMatch.py
@@ -50,10 +50,9 @@ class SourceMatchTestCase(unittest.TestCase):
 
     def setUp(self):
         schema = afwTable.SourceTable.makeMinimalSchema()
-        schema.setVersion(0)
-        fluxKey = schema.addField("flux", type=float)
-        fluxErrKey = schema.addField("flux.err", type=float)
-        fluxFlagKey = schema.addField("flux.flags", type="Flag")
+        fluxKey = schema.addField("flux_flux", type=float)
+        fluxErrKey = schema.addField("flux_fluxSigma", type=float)
+        fluxFlagKey = schema.addField("flux_flag", type="Flag")
         self.table = afwTable.SourceTable.make(schema)
         self.table.definePsfFlux("flux")
         self.ss1 = afwTable.SourceCatalog(self.table)

--- a/tests/testFunctorKeys.py
+++ b/tests/testFunctorKeys.py
@@ -65,10 +65,9 @@ class FunctorKeysTestCase(lsst.utils.tests.TestCase):
 
     def doTestPointKey(self, fieldType, functorKeyType, valueType):
         schema = lsst.afw.table.Schema();
-        schema.setVersion(0)
         fKey0 = functorKeyType.addFields(schema, "a", "x or y", "pixels")
-        xKey = schema.find("a.x").key
-        yKey = schema.find("a.y").key
+        xKey = schema.find("a_x").key
+        yKey = schema.find("a_y").key
         # we create two equivalent functor keys, using the two different constructors
         fKey1 = functorKeyType(xKey, yKey)
         fKey2 = functorKeyType(schema["a"])
@@ -109,11 +108,10 @@ class FunctorKeysTestCase(lsst.utils.tests.TestCase):
 
     def testQuadrupoleKey(self):
         schema = lsst.afw.table.Schema();
-        schema.setVersion(0)
         fKey0 = lsst.afw.table.QuadrupoleKey.addFields(schema, "a", "moments", "pixels^2")
-        xxKey = schema.find("a.xx").key
-        yyKey = schema.find("a.yy").key
-        xyKey = schema.find("a.xy").key
+        xxKey = schema.find("a_xx").key
+        yyKey = schema.find("a_yy").key
+        xyKey = schema.find("a_xy").key
         # we create two equivalent functor keys, using the two different constructors
         fKey1 = lsst.afw.table.QuadrupoleKey(xxKey, yyKey, xyKey)
         fKey2 = lsst.afw.table.QuadrupoleKey(schema["a"])
@@ -156,7 +154,6 @@ class FunctorKeysTestCase(lsst.utils.tests.TestCase):
 
     def testEllipseKey(self):
         schema = lsst.afw.table.Schema();
-        schema.setVersion(1)
         fKey0 = lsst.afw.table.EllipseKey.addFields(schema, "a", "ellipse", "pixels")
         qKey = lsst.afw.table.QuadrupoleKey(schema["a"])
         pKey = lsst.afw.table.Point2DKey(schema["a"])
@@ -203,13 +200,12 @@ class FunctorKeysTestCase(lsst.utils.tests.TestCase):
 
     def doTestCovarianceMatrixKey(self, fieldType, parameterNames, varianceOnly, dynamicSize):
         schema = lsst.afw.table.Schema()
-        schema.setVersion(0)
         sigmaKeys = []
         covKeys = []
         # we generate a schema with a complete set of fields for the diagonal and some (but not all)
         # of the covariance elements
         for i, pi in enumerate(parameterNames):
-            sigmaKeys.append(schema.addField("a.%sSigma" % pi, type=fieldType, doc="uncertainty on %s" % pi))
+            sigmaKeys.append(schema.addField("a_%sSigma" % pi, type=fieldType, doc="uncertainty on %s" % pi))
             if varianceOnly:
                 continue  # in this case we have fields for only the diagonal
             for pj in parameterNames[:i]:
@@ -218,10 +214,10 @@ class FunctorKeysTestCase(lsst.utils.tests.TestCase):
                 # CovarianceMatrixKey constructor can handle all those possibilities.
                 r = numpy.random.rand()
                 if r < 0.3:
-                    k = schema.addField("a.%s_%s_Cov" % (pi, pj), type=fieldType,
+                    k = schema.addField("a_%s_%s_Cov" % (pi, pj), type=fieldType,
                                         doc="%s,%s covariance" % (pi, pj))
                 elif r < 0.6:
-                    k = schema.addField("a.%s_%s_Cov" % (pj, pi), type=fieldType,
+                    k = schema.addField("a_%s_%s_Cov" % (pj, pi), type=fieldType,
                                         doc="%s,%s covariance" % (pj, pi))
                 else:
                     k = lsst.afw.table.Key[fieldType]()

--- a/tests/testSchema.py
+++ b/tests/testSchema.py
@@ -50,30 +50,29 @@ except NameError:
 
 class SchemaTestCase(unittest.TestCase):
 
-    def testSchema(self):
+    def xtestSchema(self):
         schema = lsst.afw.table.Schema();
-        schema.setVersion(0)
-        ab_k = schema.addField("a.b", type="Coord", doc="parent coord")
-        abi_k = schema.addField("a.b.i", type=int, doc="int")
-        acf_k = schema.addField("a.c.f", type=numpy.float32, doc="float")
-        egd_k = schema.addField("e.g.d", type=lsst.afw.geom.Angle, doc="angle")
-        abp_k = schema.addField("a.b.p", type="PointF", doc="point")
-        ab_si = schema.find("a.b")
+        ab_k = schema.addField("a_b", type="Coord", doc="parent coord")
+        abi_k = schema.addField("a_b_i", type=int, doc="int")
+        acf_k = schema.addField("a_c_f", type=numpy.float32, doc="float")
+        egd_k = schema.addField("e_g_d", type=lsst.afw.geom.Angle, doc="angle")
+        abp_k = schema.addField("a_b_p", type="PointF", doc="point")
+        ab_si = schema.find("a_b")
         self.assertEqual(ab_si.key, ab_k)
-        self.assertEqual(ab_si.field.getName(), "a.b")
-        self.assertEqual(ab_k.getRa(), schema["a.b.ra"].asKey());
-        abp_si = schema.find("a.b.p")
+        self.assertEqual(ab_si.field.getName(), "a_b")
+        self.assertEqual(ab_k.getRa(), schema["a_b_ra"].asKey());
+        abp_si = schema.find("a_b_p")
         self.assertEqual(abp_si.key, abp_k)
-        self.assertEqual(abp_si.field.getName(), "a.b.p")
-        abpx_si = schema.find("a.b.p.x")
+        self.assertEqual(abp_si.field.getName(), "a_b_p")
+        abpx_si = schema.find("a_b_p_x")
         self.assertEqual(abp_k.getX(), abpx_si.key);
-        self.assertEqual(abpx_si.field.getName(), "a.b.p.x")
+        self.assertEqual(abpx_si.field.getName(), "a_b_p_x")
         self.assertEqual(abpx_si.field.getDoc(), "point")
-        self.assertEqual(abp_k, schema["a.b.p"].asKey())
-        self.assertEqual(abp_k.getX(), schema["a.b.p.x"].asKey());
-        self.assertEqual(schema.getNames(), ("a.b", "a.b.i", "a.b.p", "a.c.f", "e.g.d"))
+        self.assertEqual(abp_k, schema["a_b_p"].asKey())
+        self.assertEqual(abp_k.getX(), schema["a_b_p_x"].asKey());
+        self.assertEqual(schema.getNames(), ("a_b", "a_b_i", "a_b_p", "a_c_f", "e_g_d"))
         self.assertEqual(schema.getNames(True), ("a", "e"))
-        self.assertEqual(schema["a"].getNames(), ("b", "b.i", "b.p", "c.f"))
+        self.assertEqual(schema["a"].getNames(), ("b", "b_i", "b_p", "c_f"))
         self.assertEqual(schema["a"].getNames(True), ("b", "c"))
         schema2 = lsst.afw.table.Schema(schema)
         self.assertEqual(schema, schema2)

--- a/tests/ticket2707.py
+++ b/tests/ticket2707.py
@@ -38,7 +38,6 @@ class MatchXyTest(unittest.TestCase):
     def setUp(self):
         nan = float('nan')
         self.schema = afwTable.SourceTable.makeMinimalSchema()
-        self.schema.setVersion(0)
         centroidKey = self.schema.addField("cen", type="PointD")
         self.table = afwTable.SourceTable.make(self.schema)
         self.table.defineCentroid("cen")


### PR DESCRIPTION
...efault version.

Note that there are several setVersion(0) in the unit tests which should not be changed,
because they are actually testing whether version 0 tables work, or how they compare with
version 1 tables.

Also needed to change Schema::getNames to use the '_' separator for version > 0.