### PR TITLE
Review for DM-1680: Change Background to use the xy0 of the image bbox

### DIFF
--- a/src/math/Background.cc
+++ b/src/math/Background.cc
@@ -60,7 +60,7 @@ Background::Background(ImageT const& img,              ///< ImageT (or MaskedIma
                        BackgroundControl const& bgCtrl ///< Control how the Background is estimated
                       ) :
     lsst::daf::base::Citizen(typeid(this)),
-    _imgBBox(img.getBBox(image::LOCAL)),
+    _imgBBox(img.getBBox()),
     _bctrl(bgCtrl),
     _asUsedInterpStyle(Interpolate::UNKNOWN),
     _asUsedUndersampleStyle(THROW_EXCEPTION),


### PR DESCRIPTION
Background discarded the xy0 of the image when it was constructed from an image
and calling getImage(bbox) required that bbox be local, as well. This fixes that problem.

tests/background.py includes two new tests for these changes, plus some minor tweaks
to make the pyflakes linter happier.

Improve a change to a test to make the linter happier