### PR TITLE
SourceCatalog: test assumption on sort order for getChildren

### DIFF
--- a/python/lsst/afw/table/Source.i
+++ b/python/lsst/afw/table/Source.i
@@ -84,6 +84,8 @@ def getChildren(self, parent, *args):
     of self (i.e. zip(self, *args) is valid) will be subset using the same slice object
     used on self, and these subsets will be returned along with the subset of self.
     """
+    if not self.isSorted(SourceTable.getParentKey()):
+        raise AssertionError("The table is not sorted by parent, so cannot getChildren")
     s = self.equal_range(parent, SourceTable.getParentKey())
     if args:
         return (self[s],) + tuple(arg[s] for arg in args)

--- a/tests/testSourceTable.py
+++ b/tests/testSourceTable.py
@@ -396,6 +396,12 @@ class SourceTableTestCase(lsst.utils.tests.TestCase):
                 self.assertEqual(child.getParent(), parent.getId())
                 self.assertEqual(child.getId(), id)
 
+        # Check detection of unsorted catalog
+        self.catalog.sort(self.fluxKey)
+        self.assertRaises(AssertionError, self.catalog.getChildren, 0)
+        self.catalog.sort(parentKey)
+        self.catalog.getChildren(0) # Just care this succeeds
+
     def testFitsReadBackwardsCompatibility(self):
         cat = lsst.afw.table.SourceCatalog.readFits("tests/data/empty-v0.fits")
         self.assertTrue(cat.getPsfFluxSlot().isValid())


### PR DESCRIPTION
SourceCatalog.getChildren assumes that the catalog is sorted by
parent, but did not check this assumption, which can lead to
misleading results if the assumption is not true.  Test the
assumption and raise an AssertionError if it fails.
