### PR TITLE
Review of DM-5206: Avoid writing garbage EQUINOX to FITS.

### DIFF
--- a/src/formatters/TanWcsFormatter.cc
+++ b/src/formatters/TanWcsFormatter.cc
@@ -185,7 +185,11 @@ afwForm::TanWcsFormatter::generatePropertySet(afwImg::TanWcs const& wcs) {
     }
 
     wcsProps->add("NAXIS", wcs._wcsInfo[0].naxis, "number of data axes");
-    wcsProps->add("EQUINOX", wcs._wcsInfo[0].equinox, "Equinox of coordinates");
+    // EQUINOX is "not relevant" (FITS definition, version 3.0, page 30) when
+    // dealing with ICRS, and may confuse readers. Don't write it.
+    if (strncmp(wcs._wcsInfo[0].radesys, "ICRS", 4) != 0) {
+        wcsProps->add("EQUINOX", wcs._wcsInfo[0].equinox, "Equinox of coordinates");
+    }
     wcsProps->add("RADESYS", std::string(wcs._wcsInfo[0].radesys), "Coordinate system for equinox");
     wcsProps->add("CRPIX1", wcs._wcsInfo[0].crpix[0], "WCS Coordinate reference pixel");
     wcsProps->add("CRPIX2", wcs._wcsInfo[0].crpix[1], "WCS Coordinate reference pixel");

--- a/src/formatters/WcsFormatter.cc
+++ b/src/formatters/WcsFormatter.cc
@@ -144,7 +144,11 @@ afwForm::WcsFormatter::generatePropertySet(afwImg::Wcs const& wcs) {
     assert(wcs._wcsInfo); // default ctor is private, so an uninitialized Wcs should not exist in the wild
 
     wcsProps->add("NAXIS", wcs._wcsInfo[0].naxis, "number of data axes");
-    wcsProps->add("EQUINOX", wcs._wcsInfo[0].equinox, "Equinox of coordinates");
+    // EQUINOX is "not relevant" (FITS definition, version 3.0, page 30) when
+    // dealing with ICRS, and may confuse readers. Don't write it.
+    if (strncmp(wcs._wcsInfo[0].radesys, "ICRS", 4) != 0) {
+        wcsProps->add("EQUINOX", wcs._wcsInfo[0].equinox, "Equinox of coordinates");
+    }
     wcsProps->add("RADESYS", std::string(wcs._wcsInfo[0].radesys), "Coordinate system for equinox");
     wcsProps->add("CRPIX1", wcs._wcsInfo[0].crpix[0], "WCS Coordinate reference pixel");
     wcsProps->add("CRPIX2", wcs._wcsInfo[0].crpix[1], "WCS Coordinate reference pixel");


### PR DESCRIPTION
For ICRS coordinates, EQUINOX is not required. Previously, we wrote a nonsense
number, but this confused some FITS readers (notably DS9 7.4). Now, we write
nothing.