### PR TITLE
Migrate boost::tuple to std::tuple

### DIFF
--- a/include/lsst/afw/geom/CoordinateBase.h
+++ b/include/lsst/afw/geom/CoordinateBase.h
@@ -29,11 +29,11 @@
 #ifndef LSST_AFW_GEOM_COORDINATEBASE_H
 #define LSST_AFW_GEOM_COORDINATEBASE_H
 
+#include <iostream>
+#include <tuple>
 #include <utility>
 
 #include "Eigen/Core"
-#include <iostream>
-#include "boost/tuple/tuple.hpp"
 
 namespace lsst { namespace afw { namespace geom {
 
@@ -131,8 +131,8 @@ public:
     /// \brief Return a std::pair representation of the coordinate object.
     std::pair<T,T> asPair() const { return std::make_pair(_vector.x(),_vector.y()); }
 
-    /// \brief Return a boost::tuple representation of the coordinate object.
-    boost::tuple<T,T> asTuple() const { return boost::make_tuple(_vector.x(),_vector.y()); }
+    /// \brief Return a std::tuple representation of the coordinate object.
+    std::tuple<T,T> asTuple() const { return std::make_tuple(_vector.x(),_vector.y()); }
 
 protected:
 
@@ -180,9 +180,9 @@ public:
     void setY(T y) { _vector.y() = y; }
     void setZ(T z) { _vector.z() = z; }
 
-    /// \brief Return a boost::tuple representation of the coordinate object.
-    boost::tuple<T,T,T> asTuple() const {
-        return boost::make_tuple(_vector.x(), _vector.y(), _vector.z()); 
+    /// \brief Return a std::tuple representation of the coordinate object.
+    std::tuple<T,T,T> asTuple() const {
+        return std::make_tuple(_vector.x(), _vector.y(), _vector.z()); 
     }
 
 protected:

--- a/include/lsst/afw/geom/Extent.h
+++ b/include/lsst/afw/geom/Extent.h
@@ -29,6 +29,8 @@
 #ifndef LSST_AFW_GEOM_EXTENT_H
 #define LSST_AFW_GEOM_EXTENT_H
 
+#include <tuple>
+
 #include <boost/type_traits/is_integral.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/type_traits/is_same.hpp>
@@ -248,9 +250,9 @@ public:
     /// @brief Construct from a std::pair.
     explicit Extent(std::pair<T,T> const & xy) : Super(EigenVector(xy.first, xy.second)) {}
 
-    /// @brief Construct from boost::tuple.
-    explicit Extent(boost::tuple<T,T> const & xy) : 
-        Super(EigenVector(xy.template get<0>(), xy.template get<1>())) {}
+    /// @brief Construct from std::tuple.
+    explicit Extent(std::tuple<T,T> const & xy) : 
+        Super(EigenVector(std::get<0>(xy), std::get<1>(xy))) {}
 
 #ifdef SWIG
     T getX() const;
@@ -294,9 +296,9 @@ public:
     /// @brief Construct from a two-element array.
     explicit Extent(T const xyz[3]) : Super(EigenVector(xyz[0], xyz[1], xyz[2])) {}
 
-    /// @brief Construct from boost::tuple.
-    explicit Extent(boost::tuple<T,T,T> const & xyz) : 
-        Super(EigenVector(xyz.template get<0>(), xyz.template get<1>(), xyz.template get<2>())) {}
+    /// @brief Construct from std::tuple.
+    explicit Extent(std::tuple<T,T,T> const & xyz) : 
+        Super(EigenVector(std::get<0>(xyz), std::get<1>(xyz), std::get<2>(xyz))) {}
 
 #ifdef SWIG
     T getX() const;

--- a/include/lsst/afw/geom/Point.h
+++ b/include/lsst/afw/geom/Point.h
@@ -29,6 +29,8 @@
 #ifndef LSST_AFW_GEOM_POINT_H
 #define LSST_AFW_GEOM_POINT_H
 
+#include <tuple>
+
 #include "lsst/afw/geom/CoordinateBase.h"
 #include "lsst/afw/geom/CoordinateExpr.h"
 #include "lsst/afw/geom/Extent.h"
@@ -213,9 +215,9 @@ public:
     /// @brief Construct from a std::pair.
     explicit Point(std::pair<T,T> const & xy) : Super(EigenVector(xy.first, xy.second)) {}
 
-    /// @brief Construct from boost::tuple.
-    explicit Point(boost::tuple<T,T> const & xy) : 
-        Super(EigenVector(xy.template get<0>(), xy.template get<1>())) {}
+    /// @brief Construct from std::tuple.
+    explicit Point(std::tuple<T,T> const & xy) : 
+        Super(EigenVector(std::get<0>(xy), std::get<1>(xy))) {}
 
 #ifdef SWIG
     T getX() const;
@@ -263,9 +265,9 @@ public:
     /// @brief Construct from a two-element array.
     explicit Point(T const xyz[3]) : Super(EigenVector(xyz[0], xyz[1], xyz[2])) {}
 
-    /// @brief Construct from boost::tuple.
-    explicit Point(boost::tuple<T,T,T> const & xyz) : 
-        Super(EigenVector(xyz.template get<0>(), xyz.template get<1>(), xyz.template get<2>())) {}
+    /// @brief Construct from std::tuple.
+    explicit Point(std::tuple<T,T,T> const & xyz) : 
+        Super(EigenVector(std::get<0>(xyz), std::get<1>(xyz), std::get<2>(xyz))) {}
 
 #ifdef SWIG
     T getX() const;

--- a/include/lsst/afw/image/MaskedImage.h
+++ b/include/lsst/afw/image/MaskedImage.h
@@ -30,14 +30,15 @@
 #ifndef LSST_IMAGE_MASKEDIMAGE_H
 #define LSST_IMAGE_MASKEDIMAGE_H
 
-#include <ostream>
 #include <list>
 #include <map>
+#include <memory>
+#include <ostream>
 #include <string>
 
-#include <memory>
 #include "boost/mpl/at.hpp"
 #include "boost/iterator/zip_iterator.hpp"
+#include "boost/tuple/tuple.hpp" // cannot convert to std::tuple (yet) because of use with boost::gil
 
 #include "lsst/daf/base/Citizen.h"
 #include "lsst/daf/base/Persistable.h"

--- a/src/math/Statistics.cc
+++ b/src/math/Statistics.cc
@@ -30,11 +30,13 @@
  * @author Steve Bickerton
  * @ingroup afw
  */
+#include <cassert>
+#include <cmath>
 #include <iostream>
 #include <limits>
-#include <cmath>
-#include <cassert>
 #include <memory>
+#include <tuple>
+
 #include "lsst/pex/exceptions.h"
 #include "lsst/afw/image/Image.h"
 #include "lsst/afw/math/Statistics.h"
@@ -151,7 +153,7 @@ namespace {
 
     /*********************************************************************************************************/
     // return type for processPixels
-    typedef boost::tuple<int,                        // n
+    typedef std::tuple<int,                        // n
                          double,                     // sum
                          afwMath::Statistics::Value, // mean
                          afwMath::Statistics::Value, // variance
@@ -439,8 +441,8 @@ namespace {
                                               weightsAreMultiplicative, andMask, calcErrorFromInputVariance,
                                               doCheckFinite, doGetWeighted,
                                               maskPropagationThresholds);
-        nCrude = values.get<0>();
-        double sumCrude = values.get<1>();
+        nCrude = std::get<0>(values);
+        double sumCrude = std::get<1>(values);
         
         meanCrude = 0.0;
         if (nCrude > 0) {
@@ -581,7 +583,7 @@ namespace {
  * @param quartile  the desired percentile.
  *
  */
-    typedef boost::tuple<double, double, double> MedianQuartileReturn;
+    typedef std::tuple<double, double, double> MedianQuartileReturn;
 
     template<typename Pixel>
     MedianQuartileReturn medianAndQuartiles(std::vector<Pixel> &img)
@@ -837,13 +839,13 @@ void afwMath::Statistics::doStatistics(
                                           _sctrl.getNanSafe(), _sctrl.getWeighted(),
                                           _sctrl._maskPropagationThresholds);
 
-    _n = standard.get<0>();
-    _sum = standard.get<1>();
-    _mean = standard.get<2>();
-    _variance = standard.get<3>();
-    _min = standard.get<4>();
-    _max = standard.get<5>();
-    _allPixelOrMask = standard.get<6>();
+    _n = std::get<0>(standard);
+    _sum = std::get<1>(standard);
+    _mean = std::get<2>(standard);
+    _variance = std::get<3>(standard);
+    _min = std::get<4>(standard);
+    _max = std::get<5>(standard);
+    _allPixelOrMask = std::get<6>(standard);
 
     // ==========================================================
     // now only calculate it if it's specifically requested - these all cost more!
@@ -864,8 +866,8 @@ void afwMath::Statistics::doStatistics(
             _median = Value(percentile(*imgcp, 0.5), NaN);
         } else {
             MedianQuartileReturn mq = medianAndQuartiles(*imgcp);
-            _median = Value(mq.get<0>(), NaN);
-            _iqrange = mq.get<2>() - mq.get<1>();
+            _median = Value(std::get<0>(mq), NaN);
+            _iqrange = std::get<2>(mq) - std::get<1>(mq);
         }
         
         
@@ -884,9 +886,9 @@ void afwMath::Statistics::doStatistics(
                                                      _sctrl.getNanSafe(), _sctrl.getWeighted(),
                                                      _sctrl._maskPropagationThresholds);
                 
-                int const nClip = clipped.get<0>();
-                _meanclip = clipped.get<2>();     // clipped mean
-                double const varClip = clipped.get<3>().first;  // clipped variance
+                int const nClip = std::get<0>(clipped);
+                _meanclip = std::get<2>(clipped);     // clipped mean
+                double const varClip = std::get<3>(clipped).first;  // clipped variance
 
                 _varianceclip = Value(varClip, varianceError(varClip, nClip));
                 // ... ignore other values


### PR DESCRIPTION
Excludes MaskedImage.h due to problems with boost::gil