### PR TITLE
Add dependency on astropy

### DIFF
--- a/ups/afw.table
+++ b/ups/afw.table
@@ -10,6 +10,7 @@ setupRequired(eigen)
 setupRequired(gsl)
 setupRequired(fftw)
 setupRequired(utils)
+setupRequired(astropy)
 setupOptional(pyfits)
 setupOptional(matplotlib)
 


### PR DESCRIPTION
Tests appear to be depending on astropy; adding the astropy EUPS package as a dependency.

Otherwise I get issues such as:
```
...
Traceback (most recent call last):
  File "tests/testSchema.py", line 40, in <module>
    import lsst.afw.table
  File "/home/centos/conda-lsst/miniconda/conda-bld/work/python/lsst/afw/table/__init__.py", line 1, in <module>
    from .tableLib import *
  File "/home/centos/conda-lsst/miniconda/conda-bld/work/python/lsst/afw/table/tableLib.py", line 606, in <module>
    import astropy.units
ImportError: No module named astropy.units
tests/warpExposure.py
...
```

when building in a clean environment. This passed Jenkins (https://ci.lsst.codes/job/stack-os-matrix/11198/).