### PR TITLE
Add dependency on astropy

### DIFF
--- a/ups/afw.table
+++ b/ups/afw.table
@@ -10,6 +10,7 @@ setupRequired(eigen)
 setupRequired(gsl)
 setupRequired(fftw)
 setupRequired(utils)
+setupRequired(astropy)
 setupOptional(pyfits)
 setupOptional(matplotlib)
 


### PR DESCRIPTION
Tests appear to be depending on astropy; adding the astropy EUPS package as a dependency.