### PR TITLE
DM-6613: Typo in afw/display/interface.py

### DIFF
--- a/python/lsst/afw/display/interface.py
+++ b/python/lsst/afw/display/interface.py
@@ -537,7 +537,7 @@ class Display(object):
             k, x, y = ev.k, ev.x, ev.y      # for now
 
             try:
-                if self.callbacks[k](k, x, y):
+                if self._callbacks[k](k, x, y):
                     break
             except KeyError:
                 print >> sys.stderr, "No callback is registered for %s" % k

--- a/python/lsst/afw/display/interface.py
+++ b/python/lsst/afw/display/interface.py
@@ -29,6 +29,9 @@ import sys
 import importlib
 import lsst.afw.geom  as afwGeom
 import lsst.afw.image as afwImage
+import lsst.log
+
+logger = lsst.log.Log.getLogger("afw.display.interface")
 
 __all__ = (
     "WHITE", "BLACK", "RED", "GREEN", "BLUE", "CYAN", "MAGENTA", "YELLOW", "ORANGE",
@@ -526,24 +529,23 @@ class Display(object):
 
     def interact(self):
         """!Enter an interactive loop, listening for key presses in display and firing callbacks.
-
-        Exit with q, \c CR, or \c ESC
-    """
-
-        while True:
+            Exit with q, \c CR, \c ESC, or any other callback function that returns a ``True`` value.
+        """
+        interactFinished = False
+        
+        while not interactFinished:
             ev = self._impl._getEvent()
             if not ev:
                 continue
             k, x, y = ev.k, ev.x, ev.y      # for now
-
-            try:
-                if self._callbacks[k](k, x, y):
-                    break
-            except KeyError:
-                print >> sys.stderr, "No callback is registered for %s" % k
-            except Exception, e:
-                print >> sys.stderr, "Display.callbacks[%s](%s, %s, %s) failed: %s" % \
-                    (k, k, x, y, e)
+            
+            if k not in self._callbacks:
+                logger.warn("No callback registered for {0}".format(k))
+            else:
+                try:
+                    interactFinished = self._callbacks[k](k, x, y)
+                except Exception as e:
+                    logger.error("Display._callbacks[{0}]({0},{1},{2}) failed: {3}".format(k, x, y, e))
 
     def setCallback(self, k, func=None, noRaise=False):
         """!Set the callback for key k to be func, returning the old callback

--- a/tests/display.py
+++ b/tests/display.py
@@ -159,6 +159,14 @@ class DisplayTestCase(unittest.TestCase):
 
             im = afwImage.MaskU(self.fileName, 3)
             dummy.mtv(im)
+    
+    def testInteract(self):
+        """Check that interact exits when a q, \c CR, or \c ESC is pressed, or if a callback function
+        returns a ``True`` value.
+        If this is run using the virtualDevice a "q" is automatically triggered.
+        If running the tests using ds9 you will be expected to do this manually.
+        """
+        self.display0.interact()
 
 #-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 

--- a/ups/afw.table
+++ b/ups/afw.table
@@ -1,6 +1,8 @@
 setupRequired(daf_base)
 setupRequired(daf_persistence)
 setupRequired(pex_config)
+setupRequired(pex_logging)
+setupRequired(log)
 setupRequired(ndarray)
 setupRequired(cfitsio)
 setupRequired(wcslib)


### PR DESCRIPTION
_callbacks property was missing an underscore.