### PR TITLE
Skip test if afwdata is not available

### DIFF
--- a/tests/background.cc
+++ b/tests/background.cc
@@ -95,7 +95,12 @@ BOOST_AUTO_TEST_CASE(BackgroundTestImages, * utf::description("requires afwdata 
         //imgfiles.push_back("v2_i2_p_m9_u16.fits");
 
         std::string afwdata_dir;
-        afwdata_dir = lsst::utils::getPackageDir("afwdata");
+        try {
+            afwdata_dir = lsst::utils::getPackageDir("afwdata");
+        } catch (lsst::pex::exceptions::NotFoundError) {
+            cerr << "Skipping: Test requires afwdata to be available" << endl;
+            return;
+        }
         for (vector<string>::iterator imgfile = imgfiles.begin(); imgfile != imgfiles.end(); ++imgfile) {
 
             string img_path = afwdata_dir + "/Statistics/" + *imgfile;

--- a/tests/statistics.cc
+++ b/tests/statistics.cc
@@ -263,7 +263,12 @@ BOOST_AUTO_TEST_CASE(StatisticsTestImages, * utf::description("requires afwdata 
         imgfiles.push_back("v2_i2_p_m9_u16.fits");
 
         std::string afwdata_dir;
-        afwdata_dir = lsst::utils::getPackageDir("afwdata");
+        try {
+            afwdata_dir = lsst::utils::getPackageDir("afwdata");
+        } catch (lsst::pex::exceptions::NotFoundError) {
+            cerr << "Skipping: Test requires afwdata to be available" << endl;
+            return;
+        }
         for (vector<string>::iterator imgfile = imgfiles.begin(); imgfile != imgfiles.end(); ++imgfile) {
 
             string img_path = afwdata_dir + "/Statistics/" + *imgfile;


### PR DESCRIPTION
There is logic in the SConscript file to disable tests that use
afwdata but this logic does not get enabld when testExectuables.py
is run or if a user runs the test from the command line. This
patch adds additional skipping logic inside the test without
affecting the scons logic.