### PR TITLE
Specify time system when needed

### DIFF
--- a/src/image/Calib.cc
+++ b/src/image/Calib.cc
@@ -104,7 +104,8 @@ Calib::Calib(CONST_PTR(lsst::daf::base::PropertySet) metadata) {
 
     std::string key = "TIME-MID";
     if (metadata->exists(key)) {
-        midTime  = lsst::daf::base::DateTime(boost::algorithm::trim_right_copy(metadata->getAsString(key)));
+        midTime  = lsst::daf::base::DateTime(boost::algorithm::trim_right_copy(metadata->getAsString(key)),
+                                             lsst::daf::base::DateTime::UTC);
     }
 
     key = "EXPTIME";

--- a/src/image/ExposureInfo.cc
+++ b/src/image/ExposureInfo.cc
@@ -209,7 +209,7 @@ ExposureInfo::_startWriteFits(afw::geom::Point2I const & xy0) const {
     /**
      * We need to define these keywords properly! XXX
      */
-    data.metadata->set("TIME-MID", getCalib()->getMidTime().toString());
+    data.metadata->set("TIME-MID", getCalib()->getMidTime().toString(daf::base::DateTime::UTC));
     data.metadata->set("EXPTIME", getCalib()->getExptime());
     data.metadata->set("FLUXMAG0", getCalib()->getFluxMag0().first);
     data.metadata->set("FLUXMAG0ERR", getCalib()->getFluxMag0().second);

--- a/tests/testColor.py
+++ b/tests/testColor.py
@@ -60,8 +60,8 @@ class CalibTestCase(lsst.utils.tests.TestCase):
         """Test the exposure time information"""
 
         isoDate = "1995-01-26T07:32:00.000000000Z"
-        self.calib.setMidTime(dafBase.DateTime(isoDate))
-        self.assertEqual(isoDate, self.calib.getMidTime().toString())
+        self.calib.setMidTime(dafBase.DateTime(isoDate, dafBase.DateTime.UTC))
+        self.assertEqual(isoDate, self.calib.getMidTime().toString(dafBase.DateTime.UTC))
         self.assertAlmostEqual(self.calib.getMidTime().get(), 49743.3142245)
 
         dt = 123.4
@@ -153,7 +153,7 @@ class CalibTestCase(lsst.utils.tests.TestCase):
 
         self.calib = afwImage.Calib(metadata)
 
-        self.assertEqual(isoDate, self.calib.getMidTime().toString())
+        self.assertEqual(isoDate, self.calib.getMidTime().toString(dafBase.DateTime.UTC))
         self.assertAlmostEqual(self.calib.getMidTime().get(), 49743.3142245)
         self.assertEqual(self.calib.getExptime(), exptime)
 


### PR DESCRIPTION
Specify time system for DateTime(isoString, system)
and DateTime.toString(system)