### PR TITLE
DM-5529: Implement SphPoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ tests/stacker
 tests/statistics
 tests/statisticsSpeed
 tests/testLib.py
+tests/testSpherePoint
 tests/testTrapezoidalPacker
 tests/testWcs
 tests/testWarpGpu

--- a/include/lsst/afw/geom/SpherePoint.h
+++ b/include/lsst/afw/geom/SpherePoint.h
@@ -1,0 +1,337 @@
+// -*- LSST-C++ -*-
+
+/*
+ * LSST Data Management System
+ * See COPYRIGHT file at the top of the source tree.
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program. If not,
+ * see <http://www.lsstcorp.org/LegalNotices/>.
+ */
+
+#ifndef LSST_AFW_GEOM_SPHEREPOINT_H_
+#define LSST_AFW_GEOM_SPHEREPOINT_H_
+
+#include <ostream>
+#include <utility>
+
+#include "lsst/afw/geom/Angle.h"
+#include "lsst/afw/geom/Point.h"
+
+namespace lsst {
+namespace afw {
+namespace geom {
+
+    /**
+     * @brief Point in an unspecified spherical coordinate system.
+     *
+     * This class represents a point on a sphere in the mathematical rather
+     * than the astronomical sense. It does not refer to any astronomical
+     * reference frame, nor does it have any concept of (radial) distance.
+     *
+     * Points can be represented either as spherical coordinates or as a unit
+     * vector. The adopted convention for converting between these two systems
+     * is that (0, 0) corresponds to <1, 0, 0>, that (&pi;/2, 0) corresponds
+     * to <0, 1, 0>, and that (0, &pi;/2) corresponds to <0, 0, 1>.
+     *
+     * To keep usage simple, SpherePoint does not support modification of existing
+     * values; transformations of SpherePoints should be expressed as a new object.
+     * To support cases where a SpherePoint *must* be updated in-place, SpherePoint
+     * supports assignment to an existing object. One example is in containers
+     * of SpherePoints; no STL container has an atomic element-replacement method,
+     * so complicated constructions would need to be used if you couldn't
+     * overwrite an existing element.
+     *
+     * @see @ref coord::Coord
+     */
+    class SpherePoint
+#ifndef SWIG
+    final
+#endif
+    {
+    public:
+        /**
+         * @brief Construct a SpherePoint from a longitude and latitude.
+         *
+         * @param longitude The longitude of the point.
+         * @param latitude The latitude of the point. Must be in the
+         *                 interval [-&pi;/2, &pi;/2] radians.
+         *
+         * @throws OutOfRangeError Thrown if @c latitude is out of range.
+         *
+         * @exceptsafe The program state shall be unchanged in the event of an
+         *             exception.
+         */
+        SpherePoint(Angle const & longitude, Angle const & latitude);
+
+        /**
+         * @brief Construct a SpherePoint from a vector representing a direction.
+         *
+         * @param vector A position whose direction will be stored as a SpherePoint.
+         *               Must not be the zero vector. Need not be normalized,
+         *               and the norm will not affect the value of the point.
+         *
+         * @throws InvalidParameterError Thrown if @c vector is the zero vector.
+         *
+         * @exceptsafe The program state shall be unchanged in the event of an
+         *             exception.
+         */
+        explicit SpherePoint(Point3D const & vector);
+
+        /**
+         * @brief Create a copy of a SpherePoint.
+         *
+         * @param other The point to copy.
+         *
+         * @exceptsafe The program state shall be unchanged in the event of an
+         *             exception.
+         */
+        SpherePoint(SpherePoint const & other) = default;
+
+        /**
+         * Overwrite this object with the value of another SpherePoint.
+         *
+         * This is the only method that can alter the state of a SpherePoint after
+         * its construction, and is provided to allow in-place replacement of
+         * SpherePoints where swapping is not possible.
+         *
+         * @param other The object with which to overwrite this one.
+         * @return a reference to this object.
+         *
+         * @exceptsafe This operator shall not throw exceptions.
+         */
+        SpherePoint& operator=(SpherePoint const & other) = default;
+
+        /*
+         * Accessors
+         */
+
+        /**
+         * @brief The longitude of this point.
+         *
+         * If this point is at a coordinate pole, the longitude is undefined, and
+         * this method may return any value. If the SpherePoint implementation
+         * allows multiple values of longitude from a pole, they shall all be
+         * treated as valid representations of the same point.
+         *
+         * @return the longitude, in the interval [0, 2&pi;) radians.
+         *
+         * @exceptsafe This method shall not throw exceptions.
+         */
+        Angle getLongitude() const noexcept { return _longitude*radians; };
+
+        /**
+         * @brief The latitude of this point.
+         *
+         * @return the latitude, in the interval [-&pi;/2, &pi;/2] radians.
+         *
+         * @exceptsafe This method shall not throw exceptions.
+         */
+        Angle getLatitude() const noexcept { return _latitude*radians; };
+
+        /**
+         * @brief A unit vector representation of this point.
+         *
+         * @return a unit vector whose direction corresponds to this point
+         *
+         * @exceptsafe This method shall not throw exceptions.
+         */
+        Point3D getVector() const noexcept;
+
+        /**
+         * @brief Longitude and latitude by index.
+         *
+         * @param index the index of the spherical coordinate to return. Must
+         *              be either 0 or 1.
+         *
+         * @return @ref getLongitude() if @c index = 0, or @ref getLatitude()
+         *         if @c index = 1
+         *
+         * @throws OutOfRangeError Thrown if @c index is neither 0 nor 1.
+         *
+         * @exceptsafe The program state shall be unchanged in the event of an
+         *             exception.
+         */
+        Angle operator[](size_t index) const;
+
+        /**
+         * @brief @c true if this point is either coordinate pole.
+         *
+         * @return @c true if this point is at the north or south pole,
+         *         @c false otherwise
+         *
+         * @exceptsafe This method shall not throw exceptions.
+         */
+        bool atPole() const noexcept {
+            // Unit tests indicate we don't need to worry about epsilon-errors
+            // Objects constructed from lat=90*degrees, <0,0,1>, etc. all have
+            // atPole() = true. More complex operations like bearingTo have also
+            // been tested near the poles with no ill effects
+            return fabs(_latitude) >= HALFPI;
+        }
+
+
+        /**
+         * @brief @c true if this point is a well-defined position.
+         *
+         * @return @c true if @ref getLongitude(), @ref getLatitude(), and
+         *         @ref getVector() return finite floating-point values;
+         *         @c false if any return NaN or infinity.
+         *
+         * @exceptsafe This method shall not throw exceptions.
+         */
+        bool isFinite() const noexcept;
+
+        /*
+         * Comparisons between points
+         */
+
+        /**
+         * @brief Return @c true if two points represent the same position.
+         *
+         * Points are considered equal if and only if they represent the same
+         * location, regardless of how they were constructed. In particular,
+         * representations of the north or south pole with different longitudes
+         * are considered equal.
+         *
+         * @param other the point to test for equality
+         * @return true if this point matches @c other exactly, false otherwise
+         *
+         * @exceptsafe This operator shall not throw exceptions.
+         *
+         * @warning Points whose @ref getLongitude(), @ref getLatitude(), or
+         *          @ref getVector() methods return @c NaN shall not compare
+         *          equal to any point, including themselves. This may break
+         *          algorithms that assume object equality is reflexive; use
+         *          @ref isFinite() to filter objects if necessary.
+         */
+        bool operator==(SpherePoint const & other) const noexcept;
+
+        /**
+         * @brief Return @c false if two points represent the same position.
+         *
+         * This operator shall always return the logical negation of @c ==; see
+         * its documentation for a detailed specification.
+         */
+        bool operator!=(SpherePoint const & other) const noexcept;
+
+        /**
+         * @brief Direction from one point to another.
+         *
+         * This method finds the shortest (great-circle) arc between two
+         * points, and characterizes its direction by the angle between
+         * it and a line of latitude passing through this point. 0 represents
+         * due east, &pi;/2 represents due north. If the points are on
+         * opposite sides of the sphere, the bearing may be any value.
+         *
+         * @param other the point to which to measure the bearing
+         * @return the direction, as defined above, in the interval [0, 2&pi;).
+         *
+         * @throws DomainError Thrown if <tt>this.atPole()</tt>.
+         *
+         * @exceptsafe The program state shall be unchanged in the event of an
+         *             exception.
+         *
+         * @note For two points @c A and @c B, <tt>A.bearingTo(B)</tt> will in
+         *       general not be 180 degrees away from <tt>B.bearingTo(A)</tt>
+         */
+        Angle bearingTo(SpherePoint const & other) const;
+
+        /**
+         * @brief Angular distance between two points.
+         *
+         * @param other the point to which to measure the separation
+         * @return the length of the shortest (great circle) arc between the
+         *         two points. Shall not be negative.
+         *
+         * @exceptsafe This method shall not throw exceptions.
+         */
+        Angle separation(SpherePoint const & other) const noexcept;
+
+        /*
+         * Transformations of points
+         */
+
+        /**
+         * @brief Return a point rotated from this one around an axis.
+         *
+         * @param axis a point defining the north pole of the rotation axis.
+         * @param amount the amount of rotation, where positive values
+         *               represent right-handed rotations around @c axis.
+         * @return a new point created by rotating this point
+         *
+         * @exceptsafe This method shall not throw exceptions.
+         */
+        SpherePoint rotated(SpherePoint const & axis, Angle const & amount) const noexcept;
+
+        /**
+         * @brief Return a point offset from this one along a great circle.
+         *
+         * For any point @c A not at a coordinate pole, and any two angles @c b
+         * and @c delta, <tt>A.bearingTo(A.offset(b, delta))</tt> = @c b and
+         * <tt>A.separationTo(A.offset(b, delta))</tt> = @c delta.
+         *
+         * @param bearing the direction in which to move this point, following
+         *                the conventions described in @ref bearingTo.
+         * @param amount the distance by which to move along the great
+         *               circle defined by @c bearing
+         * @return a new point created by shifting this point
+         *
+         * @throws DomainError Thrown if <tt>this.atPole()</tt>.
+         * @throws OutOfRangeError Thrown if @c amount is negative.
+         *
+         * @exceptsafe The program state shall be unchanged in the event of an
+         *             exception.
+         */
+        SpherePoint offset(Angle const & bearing, Angle const & amount) const;
+
+    private:
+        // For compatibility with Starlink AST, the implementation must be a
+        // pair of floating-point numbers, with no other data. Do not change
+        // the implementation without an RFC.
+        double _longitude;      // radians
+        double _latitude;       // radians
+    };
+
+    /*
+     * Object-level display
+     */
+
+    /**
+     * @brief Print the value of a point to a stream.
+     *
+     * The exact details of the string representation are unspecified and
+     * subject to change, but the following may be regarded as typical:
+     * <tt>"(10.543250, +32.830583)"</tt>.
+     *
+     * @param os the stream to which to print @c point
+     * @param point the point to print to the stream
+     * @return a reference to @c os
+     *
+     * @throws std::ostream::failure Thrown if an I/O state flag was set that
+     *      was registered with <tt>os.exceptions()</tt>. See the documentation
+     *      of std::ostream for more details.
+     *
+     * @exceptsafe All objects shall be left in valid states, with no resource
+     *             leaks, in the event of an exception.
+     *
+     * @relatesalso SpherePoint
+     */
+    std::ostream& operator<<(std::ostream& os, SpherePoint const & point);
+
+}}} /* namespace lsst::afw::geom */
+
+#endif /* LSST_AFW_GEOM_SPHEREPOINT_H_ */

--- a/python/lsst/afw/geom/SpherePoint.i
+++ b/python/lsst/afw/geom/SpherePoint.i
@@ -1,0 +1,87 @@
+// -*- lsst-c++ -*-
+
+/*
+ * LSST Data Management System
+ * See COPYRIGHT file at the top of the source tree.
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program. If not,
+ * see <http://www.lsstcorp.org/LegalNotices/>.
+ */
+
+
+%{
+#include "lsst/afw/geom/SpherePoint.h"
+%}
+
+%include "lsst/afw/geom/Angle.h"
+%include "lsst/afw/geom/Point.h"
+
+%useValueEquality(lsst::afw::geom::SpherePoint);
+
+%include "lsst/afw/geom/SpherePoint.h"
+
+// add __str__ and __repr__ methods
+%extend lsst::afw::geom::SpherePoint {
+    std::string __str__() const {
+        std::ostringstream os;
+        os << std::fixed << (*self);
+        return os.str();
+    }
+    %pythoncode %{
+def __repr__(self):
+    argList = ["%r*afwGeom.degrees" % (pos.asDegrees(),) for pos in self]
+    return "SpherePoint(%s)" % (", ".join(argList))
+    %}
+}
+
+// Allow negative indices in Python but not C++
+%extend lsst::afw::geom::SpherePoint {
+    lsst::afw::geom::Angle _getItemImpl(size_t index) const {
+        return (*self)[index];
+    }
+    %pythoncode %{
+def __getitem__(self, index):
+    if index < -len(self) or index > 1:
+        raise IndexError("Invalid index: %d" % index)
+    try:
+        if index >= 0:
+            return self._getItemImpl(index)
+        else:
+            return self._getItemImpl(len(self) + index)
+    except lsst.pex.exceptions.OutOfRangeError as e:
+        raise_from(IndexError(), e)
+    %}
+}
+
+// Add __iter__ to allow  'ra,dec = point' statement in Python
+%extend lsst::afw::geom::SpherePoint {
+    %pythoncode %{
+def __iter__(self):
+    for i in (0, 1):
+        yield self[i]
+def __len__(self):
+    return 2
+    %}
+}
+
+// Add __reduce__
+%extend lsst::afw::geom::SpherePoint {
+    %pythoncode %{
+def __reduce__(self):
+    return (SpherePoint, (self.getLongitude(), self.getLatitude()))
+    %}
+}

--- a/python/lsst/afw/geom/geomLib.i
+++ b/python/lsst/afw/geom/geomLib.i
@@ -171,6 +171,8 @@ Python interface to lsst::afw::geom classes
 %include "XYTransform.i"
 %include "TransformMap.i"
 
+%include "SpherePoint.i"
+
 %import "lsst/pex/exceptions/exceptionsLib.i"
 
 %declareException(SingularTransformException, lsst.pex.exceptions.RuntimeError,

--- a/src/geom/SpherePoint.cc
+++ b/src/geom/SpherePoint.cc
@@ -1,0 +1,233 @@
+// -*- LSST-C++ -*-
+
+/*
+ * LSST Data Management System
+ * See COPYRIGHT file at the top of the source tree.
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program. If not,
+ * see <http://www.lsstcorp.org/LegalNotices/>.
+ */
+
+#include <cmath>
+#include <string>
+#include <sstream>
+
+#include "Eigen/Geometry"
+
+#include "lsst/afw/geom/SpherePoint.h"
+#include "lsst/pex/exceptions.h"
+
+namespace pexExcept = lsst::pex::exceptions;
+using namespace std;
+
+namespace lsst {
+namespace afw {
+namespace geom {
+    /** Static implementation details for SpherePoint. */
+    namespace {
+        /**
+         * Wraps an angle to the interval [0, 2&pi;).
+         *
+         * @param angle the angle to be wrapped
+         * @return an angle equivalent to @c angle, but forced into the
+         *         interval [0, 2&pi;). May be the same object as @c angle if
+         *         no wrapping was required.
+         */
+        Angle wrap(Angle const & angle) {
+            Angle copy(angle);
+            copy.wrap();
+            return copy;
+        }
+
+        /**
+         * Angular distance between two points using the Haversine formula.
+         *
+         * Besides the differences between the two coordinates, we also input the
+         * cosine of the two declinations, so as to be thrifty with the use of
+         * trigonometric functions.
+         *
+         * @param deltaLon Difference between longitudes.
+         * @param deltaLat Difference between latitudes. Must be in the same
+         *                 sense as @c deltaLon.
+         * @param cosLat1, cosLat2 Cosines of the two points' latitudes.
+         * @return the distance between the two points
+         */
+        Angle haversine(Angle const & deltaLon,
+                        Angle const & deltaLat,
+                        double cosLat1,
+                        double cosLat2
+        ) {
+            double const sinLat = sin(deltaLat/2.0);
+            double const sinLon = sin(deltaLon/2.0);
+            double const havDDelta = sinLat * sinLat;
+            double const havDAlpha = sinLon * sinLon;
+            double const havD = havDDelta + cosLat1 * cosLat2 * havDAlpha;
+            double const sinDHalf = sqrt(havD);
+            return (2.0 * asin(sinDHalf)) * radians;
+        }
+    }
+
+    SpherePoint::SpherePoint(Angle const & longitude, Angle const & latitude) :
+                    _longitude(wrap(longitude).asRadians()),
+                    _latitude(latitude.asRadians()) {
+        if (fabs(_latitude) > HALFPI) {
+            throw pexExcept::OutOfRangeError("Angle " + to_string(latitude.asDegrees()) +
+                " is not a valid latitude.");
+        }
+    }
+
+    SpherePoint::SpherePoint(Point3D const & vector) {
+        double norm = vector.asEigen().norm();
+        if (norm <= 0.0) {
+            stringstream buffer;
+            buffer << "Vector " << vector << " has zero norm and cannot be normalized.";
+            throw pexExcept::InvalidParameterError(buffer.str());
+        }
+        // To avoid unexpected behavior from mixing finite elements and infinite norm
+        if (!isfinite(norm)) {
+            norm = NAN;
+        }
+
+        double const x = vector.getX() / norm;
+        double const y = vector.getY() / norm;
+        double const z = vector.getZ() / norm;
+
+        // Need to convert to Angle, Angle::wrap, and convert back to radians
+        //     to handle _longitude = -1e-16 without code duplication
+        _longitude = wrap(atan2(y, x) * radians).asRadians();
+        _latitude = asin(z);
+    }
+
+    Point3D SpherePoint::getVector() const noexcept {
+        return Point3D(cos(_longitude)*cos(_latitude),
+                       sin(_longitude)*cos(_latitude),
+                                       sin(_latitude));
+    }
+
+    Angle SpherePoint::operator[](size_t index) const {
+        switch (index) {
+          case 0:
+            return getLongitude();
+          case 1:
+            return getLatitude();
+          default:
+            throw pexExcept::OutOfRangeError("Index " + to_string(index) + " must be 0 or 1.");
+        }
+    }
+
+    bool SpherePoint::isFinite() const noexcept {
+        return isfinite(_longitude) && isfinite(_latitude);
+    }
+
+    bool SpherePoint::operator==(SpherePoint const & other) const noexcept {
+        // Deliberate override of Style Guide 5-12
+        // Approximate FP comparison would make object equality intransitive
+        if (atPole()) {
+            return _latitude == other._latitude;
+        } else {
+            return _longitude == other._longitude && _latitude == other._latitude;
+        }
+    }
+
+    bool SpherePoint::operator!=(SpherePoint const & other) const noexcept {
+        return !(*this == other);
+    }
+
+    Angle SpherePoint::bearingTo(SpherePoint const & other) const {
+        if (atPole()) {
+            stringstream buffer;
+            buffer << "Cannot calculate offset from pole " << *this << ".";
+            throw pexExcept::DomainError(buffer.str());
+        }
+
+        Angle const deltaLon = other.getLongitude()- this->getLongitude();
+
+        double const sinDelta1 = sin(      getLatitude().asRadians());
+        double const sinDelta2 = sin(other.getLatitude().asRadians());
+        double const cosDelta1 = cos(      getLatitude().asRadians());
+        double const cosDelta2 = cos(other.getLatitude().asRadians());
+
+        // Adapted from http://www.movable-type.co.uk/scripts/latlong.html
+        double const y = sin(deltaLon)*cosDelta2;
+        double const x = cosDelta1*sinDelta2 - sinDelta1*cosDelta2*cos(deltaLon);
+        return wrap(90.0*degrees - atan2(y, x)*radians);
+    }
+
+    Angle SpherePoint::separation(SpherePoint const & other) const noexcept {
+        return haversine(getLongitude() - other.getLongitude(),
+                         getLatitude()  - other.getLatitude(),
+                         cos(getLatitude().asRadians()),
+                         cos(other.getLatitude().asRadians())
+        );
+    }
+
+    SpherePoint SpherePoint::rotated(SpherePoint const & axis, Angle const & amount) const noexcept {
+        auto const rotation = Eigen::AngleAxisd(amount.asRadians(), axis.getVector().asEigen()).matrix();
+        auto const x = getVector().asEigen();
+        auto const xprime = rotation * x;
+        return SpherePoint(Point3D(xprime));
+    }
+
+    SpherePoint SpherePoint::offset(Angle const & bearing, Angle const & amount) const {
+        double const phi = bearing.asRadians();
+        if (atPole()) {
+            stringstream buffer;
+            buffer << "Cannot define offset direction from pole " << *this << ".";
+            throw pexExcept::DomainError(buffer.str());
+        }
+
+        // let v = vector in the direction bearing points (tangent to surface of sphere)
+        // To do the rotation, use rotate() method.
+        // - must provide an axis of rotation: take the cross product r x v to get that axis (pole)
+
+        Eigen::Vector3d r = getVector().asEigen();
+
+        // Get the vector v:
+        //  let u = unit vector lying on a parallel of declination
+        //  let w = unit vector along line of longitude = r x u
+        // the vector v must satisfy the following:
+        //  r . v = 0
+        //  u . v = cos(phi)
+        //  w . v = sin(phi)
+
+        // v is a linear combination of u and w
+        // v = cos(phi)*u + sin(phi)*w
+        auto u = Eigen::Vector3d(-sin(_longitude), cos(_longitude), 0.0);
+        auto w = r.cross(u);
+        Eigen::Vector3d v = cos(phi)*u + sin(phi)*w;
+
+        // take r x v to get the axis
+        SpherePoint axis = SpherePoint(Point3D(r.cross(v)));
+
+        return rotated(axis, amount);
+    }
+
+    ostream& operator <<(ostream & os, SpherePoint const & point) {
+        // Can't provide atomic guarantee anyway for I/O, so ok to be sloppy.
+        auto oldFlags = os.setf(ostream::fixed);
+        auto oldPrecision = os.precision(6);
+
+        os << "(" << point.getLongitude().asDegrees() << ", ";
+        os.setf(ostream::showpos);
+        os << point.getLatitude().asDegrees() << ")";
+
+        os.flags(oldFlags);
+        os.precision(oldPrecision);
+        return os;
+    }
+
+}}} /* namespace lsst::afw::geom */

--- a/tests/testSpherePoint.cc
+++ b/tests/testSpherePoint.cc
@@ -1,0 +1,68 @@
+// -*- LSST-C++ -*-
+
+/*
+ * LSST Data Management System
+ * See COPYRIGHT file at the top of the source tree.
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program. If not,
+ * see <http://www.lsstcorp.org/LegalNotices/>.
+ */
+
+#include <iostream>
+#include <sstream>
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE SpherePointCpp
+
+#include "boost/test/unit_test.hpp"
+
+#include "lsst/afw/geom/SpherePoint.h"
+
+/*
+ * Unit tests for C++-only functionality in SpherePoint.
+ *
+ * See testSpherePoint.py for remaining unit tests.
+ */
+namespace lsst {
+namespace afw {
+namespace geom {
+
+    /**
+     * @brief Tests whether the result of SpherePoint::SpherePoint(SpherePoint const &)
+     * makes an identical but independent copy.
+     */
+    BOOST_AUTO_TEST_CASE(SpherePointCopyResult, *boost::unit_test::tolerance(1e-14))
+    {
+        SpherePoint original(Point3D(0.34, -1.2, 0.97));
+        SpherePoint copy(original);
+
+        // Want exact equality, not floating-point equality
+        BOOST_TEST(original == copy);
+
+        // Don't compare Angles in case there's aliasing of some sort
+        double const copyLon = copy.getLongitude().asDegrees();
+        double const copyLat = copy.getLatitude() .asDegrees();
+
+        original = SpherePoint(-42*degrees, 45*degrees);
+        BOOST_TEST(original != copy);
+        BOOST_TEST(copy.getLongitude().asDegrees() == copyLon);
+        BOOST_TEST(copy.getLatitude() .asDegrees() == copyLat);
+    }
+
+    // TODO: add a test for propagation of ostream errors
+
+}}} /* namespace lsst::afw::geom */

--- a/tests/testSpherePoint.py
+++ b/tests/testSpherePoint.py
@@ -1,0 +1,801 @@
+#
+# LSST Data Management System
+# See COPYRIGHT file at the top of the source tree.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
+# -*- python -*-
+"""
+Unit tests for SpherePoint
+
+Run with:
+   python testSpherePoint.py
+or
+   python
+   >>> import testSpherePoint
+   >>> testSpherePoint.run()
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import copy
+import math
+import re
+import unittest
+
+import numpy as np
+
+import lsst.utils.tests
+import lsst.afw.geom as afwGeom
+import lsst.pex.exceptions as pexEx
+
+from lsst.afw.geom import degrees, radians, SpherePoint
+from numpy import nan, inf
+
+
+class SpherePointTestSuite(lsst.utils.tests.TestCase):
+
+    def setUp(self):
+        self._dataset = SpherePointTestSuite.positions()
+        self._poleLatitudes = [
+            afwGeom.HALFPI*afwGeom.radians,
+            6.0*afwGeom.hours,
+            90.0*afwGeom.degrees,
+            5400.0*afwGeom.arcminutes,
+            324000.0*afwGeom.arcseconds,
+        ]
+
+    @staticmethod
+    def positions():
+        """Provide valid coordinates for nominal-case testing.
+
+        Returns
+        -------
+        positions : `iterable`
+            An iterable of pairs of Angles, each representing the
+            longitude and latitude (in that order) of a test point.
+        """
+        nValidPoints = 100
+        rng = np.random.RandomState(42)
+        ra = rng.uniform(0.0, 360.0, nValidPoints)
+        dec = rng.uniform(-90.0, 90.0, nValidPoints)
+
+        points = list(zip(ra*degrees, dec*degrees))
+        # Ensure corner cases are tested.
+        points += [
+            (0.0*degrees, 0.0*degrees),
+            (afwGeom.PI*radians, -6.0*degrees),
+            (42.0*degrees, -90.0*degrees),
+            (172.0*degrees, afwGeom.HALFPI*radians),
+            (360.0*degrees, 45.0*degrees),
+            (-278.0*degrees, -42.0*degrees),
+            (765.0*degrees, 0.25*afwGeom.PI*radians),
+            (180.0*degrees, nan*radians),
+            (inf*degrees, 45.0*degrees),
+            (nan*degrees, -8.3*degrees),
+        ]
+        return points
+
+    def testInit2ArgErrors(self):
+        """Test if 2-argument form of __init__ handles invalid input.
+        """
+        # Latitude should be checked for out-of-range.
+        for lat in self._poleLatitudes:
+            with self.assertRaises(pexEx.OutOfRangeError):
+                SpherePoint(0.0*degrees, self.nextUp(lat))
+            with self.assertRaises(pexEx.OutOfRangeError):
+                SpherePoint(0.0*degrees, self.nextDown(0.0*radians - lat))
+
+        # Longitude should not be checked for out of range.
+        SpherePoint(360.0*degrees, 45.0*degrees)
+        SpherePoint(-42.0*degrees, 45.0*degrees)
+        SpherePoint(391.0*degrees, 45.0*degrees)
+
+        # Infinite latitude is not allowed.
+        with self.assertRaises(pexEx.OutOfRangeError):
+            SpherePoint(-42.0*degrees, inf*degrees)
+        with self.assertRaises(pexEx.OutOfRangeError):
+            SpherePoint(-42.0*degrees, -inf*degrees)
+
+    def testInit1ArgErrors(self):
+        """Test if 1-argument form of __init__ handles invalid input.
+        """
+        # Only one singularity, at zero
+        with self.assertRaises(pexEx.InvalidParameterError):
+            SpherePoint(afwGeom.Point3D(0.0, 0.0, 0.0))
+        SpherePoint(afwGeom.Point3D(0.0, -0.2, 0.0))
+        SpherePoint(afwGeom.Point3D(0.0, 0.0, 1.0))
+        SpherePoint(afwGeom.Point3D(42.78, -46.29, 38.27))
+
+    def testInitNArgFail(self):
+        """Tests if only 1- or 2-argument initializers are allowed.
+        """
+        with self.assertRaises(NotImplementedError):
+            SpherePoint()
+        with self.assertRaises(NotImplementedError):
+            SpherePoint("Rotund", "Bovine")
+        with self.assertRaises(NotImplementedError):
+            SpherePoint(42)
+        with self.assertRaises(NotImplementedError):
+            SpherePoint("ICRS", 34.0, -56.0)
+
+    def testGetLongitudeValue(self):
+        """Test if getLongitude() returns the expected value.
+        """
+        for lon, lat in self._dataset:
+            point = SpherePoint(lon, lat)
+            self.assertIsInstance(point.getLongitude(), afwGeom.Angle)
+            # Behavior for non-finite points is undefined; depends on internal data representation
+            if point.isFinite():
+                self.assertGreaterEqual(point.getLongitude().asDegrees(), 0.0)
+                self.assertLess(point.getLongitude().asDegrees(), 360.0)
+
+                # Longitude not guaranteed to match input at pole
+                if not point.atPole():
+                    # assertAnglesNearlyEqual handles angle wrapping internally
+                    self.assertAnglesNearlyEqual(lon, point.getLongitude())
+
+        # Vector construction should return valid longitude even in edge cases.
+        point = SpherePoint(afwGeom.Point3D(0.0, 0.0, -1.0))
+        self.assertGreaterEqual(point.getLongitude().asDegrees(), 0.0)
+        self.assertLess(point.getLongitude().asDegrees(), 360.0)
+
+    def testTicket1394(self):
+        """Regression test for Ticket 1761.
+
+        Checks that negative longitudes within epsilon of lon=0 lead
+        are correctly bounded and rounded.
+        """
+        # The problem was that the coordinate is less than epsilon
+        # close to RA == 0 and bounds checking was getting a
+        # negative RA.
+        point = SpherePoint(afwGeom.Point3D(0.6070619982, -1.264309928e-16, 0.7946544723))
+
+        self.assertEqual(point[0].asDegrees(), 0.0)
+
+    def testGetLatitudeValue(self):
+        """Test if getLatitude() returns the expected value.
+        """
+        for lon, lat in self._dataset:
+            point = SpherePoint(lon, lat)
+            self.assertIsInstance(point.getLatitude(), afwGeom.Angle)
+            # Behavior for non-finite points is undefined; depends on internal data representation
+            if point.isFinite():
+                self.assertGreaterEqual(point.getLatitude().asDegrees(), -90.0)
+                self.assertLessEqual(point.getLatitude().asDegrees(), 90.0)
+                self.assertAnglesNearlyEqual(lat, point.getLatitude())
+
+    def testGetVectorValue(self):
+        """Test if getVector() returns the expected value.
+
+        The test includes conformance to vector-angle conventions.
+        """
+        pointList = [
+            ((0.0, 0.0), afwGeom.Point3D(1.0, 0.0, 0.0)),
+            ((90.0, 0.0), afwGeom.Point3D(0.0, 1.0, 0.0)),
+            ((0.0, 90.0), afwGeom.Point3D(0.0, 0.0, 1.0)),
+        ]
+
+        for lonLat, vector in pointList:
+            # Convert to Point3D.
+            point = SpherePoint(lonLat[0]*degrees, lonLat[1]*degrees)
+            newVector = point.getVector()
+            self.assertIsInstance(newVector, afwGeom.Point3D)
+            for oldElement, newElement in zip(vector, newVector):
+                self.assertAlmostEqual(oldElement, newElement)
+
+            # Convert back to spherical.
+            newLon, newLat = SpherePoint(newVector)
+            self.assertAlmostEqual(newLon.asDegrees(), lonLat[0])
+            self.assertAlmostEqual(newLat.asDegrees(), lonLat[1])
+
+        # Try some un-normalized ones, too.
+        pointList = [
+            ((0.0, 0.0), afwGeom.Point3D(1.3, 0.0, 0.0)),
+            ((90.0, 0.0), afwGeom.Point3D(0.0, 1.2, 0.0)),
+            ((0.0, 90.0), afwGeom.Point3D(0.0, 0.0, 2.3)),
+            ((0.0, 0.0), afwGeom.Point3D(0.5, 0.0, 0.0)),
+            ((90.0, 0.0), afwGeom.Point3D(0.0, 0.7, 0.0)),
+            ((0.0, 90.0), afwGeom.Point3D(0.0, 0.0, 0.9)),
+        ]
+
+        for lonLat, vector in pointList:
+            # Only convert from vector to spherical.
+            point = SpherePoint(vector)
+            newLon, newLat = point
+            self.assertAlmostEqual(lonLat[0], newLon.asDegrees())
+            self.assertAlmostEqual(lonLat[1], newLat.asDegrees())
+            self.assertAlmostEqual(1.0, point.getVector().distanceSquared(afwGeom.Point3D(0.0, 0.0, 0.0)))
+
+        # Ill-defined points should be all NaN after normalization
+        cleanVector = afwGeom.Point3D(0.5, -0.3, 0.2)
+        badValues = [nan, inf, -inf]
+        for i in range(3):
+            for badValue in badValues:
+                # Ensure each subtest is independent
+                dirtyVector = copy.deepcopy(cleanVector)
+                dirtyVector[i] = badValue
+                for element in SpherePoint(dirtyVector).getVector():
+                    self.assertTrue(math.isnan(element))
+
+    def testTicket1761(self):
+        """Regression test for Ticket 1761.
+
+        Checks for math errors caused by unnormalized vectors.
+        """
+        refPoint = SpherePoint(afwGeom.Point3D(0, 1, 0))
+
+        point1 = SpherePoint(afwGeom.Point3D(0.1, 0.1, 0.1))
+        point2 = SpherePoint(afwGeom.Point3D(0.6, 0.6, 0.6))
+        sep1 = refPoint.separation(point1)
+        sep2 = refPoint.separation(point2)
+        sepTrue = 54.735610317245339*degrees
+
+        self.assertAnglesNearlyEqual(sepTrue, sep1)
+        self.assertAnglesNearlyEqual(sepTrue, sep2)
+
+    def testAtPoleValue(self):
+        """Test if atPole() returns the expected value.
+        """
+        poleList = [SpherePoint(42.0*degrees, lat) for lat in self._poleLatitudes] + \
+            [SpherePoint(42.0*degrees, 0.0*radians - lat) for lat in self._poleLatitudes] + [
+            SpherePoint(afwGeom.Point3D(0.0, 0.0, 1.0)),
+            SpherePoint(afwGeom.Point3D(0.0, 0.0, -1.0)),
+        ]
+        nonPoleList = [SpherePoint(42.0*degrees, self.nextDown(lat)) for lat in self._poleLatitudes] + \
+            [SpherePoint(42.0*degrees, self.nextUp(0.0*radians - lat)) for lat in self._poleLatitudes] + [
+            SpherePoint(afwGeom.Point3D(9.9e-7, 0.0, 1.0)),
+            SpherePoint(afwGeom.Point3D(9.9e-7, 0.0, -1.0)),
+            SpherePoint(0.0*degrees, nan*degrees),
+        ]
+
+        for pole in poleList:
+            self.assertIsInstance(pole.atPole(), bool)
+            self.assertTrue(pole.atPole())
+
+        for nonPole in nonPoleList:
+            self.assertIsInstance(nonPole.atPole(), bool)
+            self.assertFalse(nonPole.atPole())
+
+    def testIsFiniteValue(self):
+        """Test if isFinite() returns the expected value.
+        """
+        finiteList = [
+            SpherePoint(0.0*degrees, -90.0*degrees),
+            SpherePoint(afwGeom.Point3D(0.1, 0.2, 0.3)),
+        ]
+        nonFiniteList = [
+            SpherePoint(0.0*degrees, nan*degrees),
+            SpherePoint(nan*degrees, 0.0*degrees),
+            SpherePoint(inf*degrees, 0.0*degrees),
+            SpherePoint(-inf*degrees, 0.0*degrees),
+            SpherePoint(afwGeom.Point3D(nan, 0.2, 0.3)),
+            SpherePoint(afwGeom.Point3D(0.1, inf, 0.3)),
+            SpherePoint(afwGeom.Point3D(0.1, 0.2, -inf)),
+        ]
+
+        for finite in finiteList:
+            self.assertIsInstance(finite.isFinite(), bool)
+            self.assertTrue(finite.isFinite())
+
+        for nonFinite in nonFiniteList:
+            self.assertIsInstance(nonFinite.isFinite(), bool)
+            self.assertFalse(nonFinite.isFinite())
+
+    def testGetItemError(self):
+        """Test if indexing correctly handles invalid input.
+        """
+        point = SpherePoint(afwGeom.Point3D(1.0, 1.0, 1.0))
+
+        with self.assertRaises(IndexError):
+            point[2]
+        with self.assertRaises(IndexError):
+            point[-3]
+
+    def testGetItemValue(self):
+        """Test if indexing returns the expected value.
+        """
+        for lon, lat in self._dataset:
+            point = SpherePoint(lon, lat)
+            self.assertIsInstance(point[-2], afwGeom.Angle)
+            self.assertIsInstance(point[-1], afwGeom.Angle)
+            self.assertIsInstance(point[0], afwGeom.Angle)
+            self.assertIsInstance(point[1], afwGeom.Angle)
+
+            if not math.isnan(point.getLongitude().asRadians()):
+                self.assertEqual(point.getLongitude(), point[-2])
+                self.assertEqual(point.getLongitude(), point[0])
+            else:
+                self.assertTrue(math.isnan(point[-2].asRadians()))
+                self.assertTrue(math.isnan(point[0].asRadians()))
+            if not math.isnan(point.getLatitude().asRadians()):
+                self.assertEqual(point.getLatitude(), point[-1])
+                self.assertEqual(point.getLatitude(), point[1])
+            else:
+                self.assertTrue(math.isnan(point[-1].asRadians()))
+                self.assertTrue(math.isnan(point[1].asRadians()))
+
+    def testEquality(self):
+        """Test if tests for equality treat SpherePoints as values.
+        """
+        # (In)equality is determined by value, not identity.
+        # See DM-2347, DM-2465. These asserts are testing the
+        # functionality of `==` and `!=` and should not be changed.
+        for lon1, lat1 in self._dataset:
+            point1 = SpherePoint(lon1, lat1)
+            self.assertIsInstance(point1 == point1, bool)
+            self.assertIsInstance(point1 != point1, bool)
+            if point1.isFinite():
+                self.assertTrue(point1 == point1)
+                self.assertFalse(point1 != point1)
+
+                pointCopy = copy.deepcopy(point1)
+                self.assertIsNot(pointCopy, point1)
+                self.assertEqual(pointCopy, point1)
+                self.assertEqual(point1, pointCopy)
+                self.assertFalse(pointCopy != point1)
+                self.assertFalse(point1 != pointCopy)
+            else:
+                self.assertFalse(point1 == point1)
+                self.assertTrue(point1 != point1)
+
+            for lon2, lat2 in self._dataset:
+                if lon1 == lon2 and lat1 == lat2:
+                    continue
+                point2 = SpherePoint(lon2, lat2)
+                self.assertTrue(point2 != point1)
+                self.assertTrue(point1 != point2)
+                self.assertFalse(point2 == point1)
+                self.assertFalse(point1 == point2)
+
+        # Test for transitivity (may be assumed by algorithms).
+        for delta in [10.0**(0.1*x) for x in range(-150, -49, 5)]:
+            self.checkTransitive(delta*radians)
+
+    def checkTransitive(self, delta):
+        """Test if equality is transitive even for close points.
+
+        This test prevents misuse of approximate floating-point
+        equality -- if `__eq__` is implemented using AFP, then this
+        test will fail for some value of `delta`. Testing multiple
+        values is recommended.
+
+        Parameters
+        ----------
+        delta : `number`
+            The separation, in degrees, at which point equality may
+            become intransitive.
+        """
+        for lon, lat in self._dataset:
+            point1 = SpherePoint(lon - delta, lat)
+            point2 = SpherePoint(lon, lat)
+            point3 = SpherePoint(lon + delta, lat)
+
+            self.assertTrue(point1 != point2 or point2 != point3 or point1 == point3)
+            self.assertTrue(point3 != point1 or point1 != point2 or point3 == point2)
+            self.assertTrue(point2 == point3 or point3 != point1 or point2 == point1)
+
+    def testEqualityAlias(self):
+        """Test if == handles coordinate degeneracies correctly.
+        """
+        # Longitude wrapping
+        self.assertEqual(SpherePoint(360.0*degrees, -42.0*degrees),
+                         SpherePoint(0.0*degrees, -42.0*degrees))
+        self.assertEqual(SpherePoint(-90.0*degrees, -42.0*degrees),
+                         SpherePoint(270.0*degrees, -42.0*degrees))
+
+        # Polar degeneracy
+        self.assertEqual(SpherePoint(42.0*degrees, 90.0*degrees),
+                         SpherePoint(270.0*degrees, 90.0*degrees))
+        self.assertEqual(SpherePoint(-42.0*degrees, -90.0*degrees),
+                         SpherePoint(83.0*degrees, -90.0*degrees))
+
+        self.assertNotEqual(SpherePoint(83.0*degrees, 90.0*degrees),
+                            SpherePoint(83.0*degrees, -90.0*degrees))
+        # White-box test: how are pole/non-pole comparisons handled?
+        self.assertNotEqual(SpherePoint(42.0*degrees, 90.0*degrees),
+                            SpherePoint(42.0*degrees, 0.0*degrees))
+
+    def testInquality(self):
+        """Test if == and != give mutually consistent results.
+        """
+        for lon1, lat1 in self._dataset:
+            point1 = SpherePoint(lon1, lat1)
+            for lon2, lat2 in self._dataset:
+                point2 = SpherePoint(lon2, lat2)
+                self.assertEqual((point1 == point2), (point2 == point1))
+                self.assertEqual((point1 != point2), (point2 != point1))
+                self.assertNotEqual((point1 == point2), (point1 != point2))
+
+    def testBearingToError(self):
+        """Test if bearingTo() correctly handles invalid input.
+        """
+        northPole = SpherePoint(0.0*degrees, 90.0*degrees)
+        southPole = SpherePoint(0.0*degrees, -90.0*degrees)
+        safe = SpherePoint(0.0*degrees, 0.0*degrees)
+
+        with self.assertRaises(pexEx.DomainError):
+            northPole.bearingTo(safe)
+        with self.assertRaises(pexEx.DomainError):
+            southPole.bearingTo(safe)
+
+    def testBearingToValue(self):
+        """Test if bearingTo() returns the expected value.
+        """
+        lon0 = 90.0
+        lat0 = 0.0   # These tests only work from the equator.
+        arcLen = 10.0
+
+        trials = [
+            # Along celestial equator
+            dict(lon=lon0, lat=lat0, bearing=0.0, lonEnd=lon0+arcLen, latEnd=lat0),
+            # Along a meridian
+            dict(lon=lon0, lat=lat0, bearing=90.0, lonEnd=lon0, latEnd=lat0+arcLen),
+            # 180 degree arc (should go to antipodal point)
+            dict(lon=lon0, lat=lat0, bearing=45.0, lonEnd=lon0+180.0, latEnd=-lat0),
+            #
+            dict(lon=lon0, lat=lat0, bearing=45.0, lonEnd=lon0+90.0, latEnd=lat0 + 45.0),
+            dict(lon=lon0, lat=lat0, bearing=225.0, lonEnd=lon0-90.0, latEnd=lat0 - 45.0),
+            dict(lon=lon0, lat=np.nextafter(-90.0, inf), bearing=90.0, lonEnd=lon0, latEnd=0.0),
+            dict(lon=lon0, lat=np.nextafter(-90.0, inf), bearing=0.0, lonEnd=lon0 + 90.0, latEnd=0.0),
+            # Argument at a pole should work
+            dict(lon=lon0, lat=lat0, bearing=270.0, lonEnd=lon0, latEnd=-90.0),
+            # Support for non-finite values
+            dict(lon=lon0, lat=nan, bearing=nan, lonEnd=lon0, latEnd=45.0),
+            dict(lon=lon0, lat=lat0, bearing=nan, lonEnd=nan, latEnd=90.0),
+            dict(lon=inf, lat=lat0, bearing=nan, lonEnd=lon0, latEnd=42.0),
+            dict(lon=lon0, lat=lat0, bearing=nan, lonEnd=-inf, latEnd=42.0),
+        ]
+
+        for trial in trials:
+            origin = SpherePoint(trial['lon']*degrees, trial['lat']*degrees)
+            end = SpherePoint(trial['lonEnd']*degrees, trial['latEnd']*degrees)
+            bearing = origin.bearingTo(end)
+
+            self.assertIsInstance(bearing, afwGeom.Angle)
+            if origin.isFinite() and end.isFinite():
+                self.assertGreaterEqual(bearing.asDegrees(), 0.0)
+                self.assertLess(bearing.asDegrees(), 360.0)
+            if origin.separation(end).asDegrees() != 180.0:
+                if not math.isnan(trial['bearing']):
+                    self.assertAlmostEqual(trial['bearing'], bearing.asDegrees(), 12)
+                else:
+                    self.assertTrue(math.isnan(bearing.asRadians()))
+
+    def testBearingToValueSingular(self):
+        """White-box test: bearingTo() may be unstable if points are near opposite poles.
+
+        This test is motivated by an error analysis of the `bearingTo`
+        implementation. It may become irrelevant if the implementation
+        changes.
+        """
+        southPole = SpherePoint(0.0*degrees, self.nextUp(-90.0*degrees))
+        northPoleSame = SpherePoint(0.0*degrees, self.nextDown(90.0*degrees))
+        # Don't let it be on exactly the opposite side.
+        northPoleOpposite = SpherePoint(180.0*degrees, self.nextDown(northPoleSame.getLatitude()))
+
+        self.assertAnglesNearlyEqual(southPole.bearingTo(northPoleSame), afwGeom.HALFPI*afwGeom.radians)
+        self.assertAnglesNearlyEqual(southPole.bearingTo(northPoleOpposite),
+                                     (afwGeom.PI + afwGeom.HALFPI)*afwGeom.radians)
+
+    def testSeparationValueGeneric(self):
+        """Test if separation() returns the correct value.
+        """
+        # This should cover arcs over the meridian, across the pole, etc.
+        # Do not use sphgeom as an oracle, in case SpherePoint uses it
+        # internally.
+        for lon1, lat1 in self._dataset:
+            point1 = SpherePoint(lon1, lat1)
+            x1, y1, z1 = SpherePointTestSuite.toVector(lon1, lat1)
+            for lon2, lat2 in self._dataset:
+                point2 = SpherePoint(lon2, lat2)
+                if lon1 != lon2 or lat1 != lat2:
+                    # Numerically unstable at small angles, but that's ok.
+                    x2, y2, z2 = SpherePointTestSuite.toVector(lon2, lat2)
+                    expected = math.acos(x1*x2 + y1*y2 + z1*z2)
+                else:
+                    expected = 0.0
+
+                sep = point1.separation(point2)
+                self.assertIsInstance(sep, afwGeom.Angle)
+                if point1.isFinite() and point2.isFinite():
+                    self.assertGreaterEqual(sep.asDegrees(), 0.0)
+                    self.assertLessEqual(sep.asDegrees(), 180.0)
+                    self.assertAlmostEqual(expected, sep.asRadians())
+                    self.assertAnglesNearlyEqual(sep, point2.separation(point1))
+                else:
+                    self.assertTrue(math.isnan(sep.asRadians()))
+                    self.assertTrue(math.isnan(point2.separation(point1).asRadians()))
+
+    def testSeparationValueAbsolute(self):
+        """Test if separation() returns specific values.
+        """
+        # Test from "Meeus, p. 110" (test originally written for coord::Coord; don't know exact reference)
+        spica = SpherePoint(201.2983*degrees, -11.1614*degrees)
+        arcturus = SpherePoint(213.9154*degrees, 19.1825*degrees)
+
+        # Verify to precision of quoted distance and positions.
+        self.assertAlmostEqual(32.7930, spica.separation(arcturus).asDegrees(), 4)
+
+        # Verify small angles: along a constant ra, add an arcsec to spica dec.
+        epsilon = 1.0*afwGeom.arcseconds
+        spicaPlus = SpherePoint(spica.getLongitude(), spica.getLatitude() + epsilon)
+
+        self.assertAnglesNearlyEqual(epsilon, spicaPlus.separation(spica))
+
+    def testSeparationPoles(self):
+        """White-box test: all representations of a pole should have the same distance to another point.
+        """
+        southPole1 = SpherePoint(-30.0*degrees, -90.0*degrees)
+        southPole2 = SpherePoint(183.0*degrees, -90.0*degrees)
+        regularPoint = SpherePoint(42.0*degrees, 45.0*degrees)
+        expectedSep = (45.0+90.0)*degrees
+
+        self.assertAnglesNearlyEqual(expectedSep, southPole1.separation(regularPoint))
+        self.assertAnglesNearlyEqual(expectedSep, regularPoint.separation(southPole1))
+        self.assertAnglesNearlyEqual(expectedSep, southPole2.separation(regularPoint))
+        self.assertAnglesNearlyEqual(expectedSep, regularPoint.separation(southPole2))
+
+    @staticmethod
+    def toVector(longitude, latitude):
+        """Converts a set of spherical coordinates to a 3-vector.
+
+        The conversion shall not be performed by any library, to ensure
+        that the test case does not duplicate the code being tested.
+
+        Parameters
+        ----------
+        longitude : `Angle`
+            The longitude (right ascension, azimuth, etc.) of the
+            position.
+        latitude : `Angle`
+            The latitude (declination, elevation, etc.) of the
+            position.
+
+        Returns
+        -------
+        x, y, z : `number`
+            Components of the unit vector representation of
+            `(longitude, latitude)`
+        """
+        alpha = longitude.asRadians()
+        delta = latitude.asRadians()
+        if math.isnan(alpha) or math.isinf(alpha) or math.isnan(delta) or math.isinf(delta):
+            return (nan, nan, nan)
+
+        x = math.cos(alpha)*math.cos(delta)
+        y = math.sin(alpha)*math.cos(delta)
+        z = math.sin(delta)
+        return (x, y, z)
+
+    def testRotatedValue(self):
+        """Test if rotated() returns the expected value.
+        """
+        # Try rotating about the equatorial pole (ie. along a parallel).
+        longitude = 90.0
+        latitudes = [0.0, 30.0, 60.0]
+        arcLen = 10.0
+        pole = SpherePoint(0.0*degrees, 90.0*degrees)
+        for latitude in latitudes:
+            point = SpherePoint(longitude*degrees, latitude*degrees)
+            newPoint = point.rotated(pole, arcLen*degrees)
+
+            self.assertIsInstance(newPoint, SpherePoint)
+            self.assertAlmostEqual(longitude + arcLen, newPoint.getLongitude().asDegrees())
+            self.assertAlmostEqual(latitude, newPoint.getLatitude().asDegrees())
+
+        # Try with pole = vernal equinox and rotate up the 90 degree meridian.
+        pole = SpherePoint(0.0*degrees, 0.0*degrees)
+        for latitude in latitudes:
+            point = SpherePoint(longitude*degrees, latitude*degrees)
+            newPoint = point.rotated(pole, arcLen*degrees)
+
+            self.assertAlmostEqual(longitude, newPoint.getLongitude().asDegrees())
+            self.assertAlmostEqual(latitude + arcLen, newPoint.getLatitude().asDegrees())
+
+        # Test accuracy close to coordinate pole
+        point = SpherePoint(90.0*degrees, np.nextafter(90.0, -inf)*degrees)
+        newPoint = point.rotated(pole, 90.0*degrees)
+        self.assertAlmostEqual(270.0, newPoint.getLongitude().asDegrees())
+        self.assertAlmostEqual(90.0 - np.nextafter(90.0, -inf), newPoint.getLatitude().asDegrees())
+
+        # Generic pole; can't predict position, but test for rotation invariant.
+        pole = SpherePoint(283.5*degrees, -23.6*degrees)
+        for lon, lat in self._dataset:
+            point = SpherePoint(lon, lat)
+            dist = point.separation(pole)
+            newPoint = point.rotated(pole, -32.4*afwGeom.radians)
+
+            self.assertNotAlmostEqual(point.getLongitude().asDegrees(), newPoint.getLongitude().asDegrees())
+            self.assertNotAlmostEqual(point.getLatitude().asDegrees(), newPoint.getLatitude().asDegrees())
+            self.assertAnglesNearlyEqual(dist, newPoint.separation(pole))
+
+        # Non-finite values give undefined rotations
+        for latitude in latitudes:
+            point = SpherePoint(longitude*degrees, latitude*degrees)
+            nanPoint = point.rotated(pole, nan*degrees)
+            infPoint = point.rotated(pole, inf*degrees)
+
+            self.assertTrue(math.isnan(nanPoint.getLongitude().asRadians()))
+            self.assertTrue(math.isnan(nanPoint.getLatitude().asRadians()))
+            self.assertTrue(math.isnan(infPoint.getLongitude().asRadians()))
+            self.assertTrue(math.isnan(infPoint.getLatitude().asRadians()))
+
+        # Non-finite points rotate into non-finite points
+        for point in [
+            SpherePoint(-inf*degrees, 1.0*radians),
+            SpherePoint(32.0*degrees, nan*radians),
+        ]:
+            newPoint = point.rotated(pole, arcLen*degrees)
+            self.assertTrue(math.isnan(nanPoint.getLongitude().asRadians()))
+            self.assertTrue(math.isnan(nanPoint.getLatitude().asRadians()))
+            self.assertTrue(math.isnan(infPoint.getLongitude().asRadians()))
+            self.assertTrue(math.isnan(infPoint.getLatitude().asRadians()))
+
+        # Rotation around non-finite poles undefined
+        for latitude in latitudes:
+            point = SpherePoint(longitude*degrees, latitude*degrees)
+            for pole in [
+                SpherePoint(-inf*degrees, 1.0*radians),
+                SpherePoint(32.0*degrees, nan*radians),
+            ]:
+                newPoint = point.rotated(pole, arcLen*degrees)
+                self.assertTrue(math.isnan(nanPoint.getLongitude().asRadians()))
+                self.assertTrue(math.isnan(nanPoint.getLatitude().asRadians()))
+                self.assertTrue(math.isnan(infPoint.getLongitude().asRadians()))
+                self.assertTrue(math.isnan(infPoint.getLatitude().asRadians()))
+
+    def testRotatedAlias(self):
+        """White-box test: all representations of a pole should rotate into the same point.
+        """
+        longitudes = [0.0, 90.0, 242.0]
+        latitude = 90.0
+        arcLen = 10.0
+        pole = SpherePoint(90.0*degrees, 0.0*degrees)
+        for longitude in longitudes:
+            point = SpherePoint(longitude*degrees, latitude*degrees)
+            newPoint = point.rotated(pole, arcLen*degrees)
+
+            self.assertAlmostEqual(0.0, newPoint.getLongitude().asDegrees())
+            self.assertAlmostEqual(80.0, newPoint.getLatitude().asDegrees())
+
+    def testOffsetError(self):
+        """Test if offset() correctly handles invalid input.
+        """
+        northPole = SpherePoint(0.0*degrees, 90.0*degrees)
+        southPole = SpherePoint(0.0*degrees, -90.0*degrees)
+
+        with self.assertRaises(pexEx.DomainError):
+            northPole.offset(-90.0*degrees, 10.0*degrees)
+        with self.assertRaises(pexEx.DomainError):
+            southPole.offset(90.0*degrees, 0.1*degrees)
+
+    def testOffsetValue(self):
+        """Test if offset() returns the expected value.
+        """
+        # This should cover arcs over the meridian, across the pole, etc.
+        for lon1, lat1 in self._dataset:
+            point1 = SpherePoint(lon1, lat1)
+            if point1.atPole():
+                continue
+            for lon2, lat2 in self._dataset:
+                if lon1 == lon2 and lat1 == lat2:
+                    continue
+                point2 = SpherePoint(lon2, lat2)
+                bearing = point1.bearingTo(point2)
+                distance = point1.separation(point2)
+
+                newPoint = point1.offset(bearing, distance)
+                self.assertIsInstance(newPoint, SpherePoint)
+                if point1.isFinite() and point2.isFinite():
+                    if not point2.atPole():
+                        self.assertAnglesNearlyEqual(point2.getLongitude(), newPoint.getLongitude())
+                    self.assertAnglesNearlyEqual(point2.getLatitude(), newPoint.getLatitude())
+                else:
+                    self.assertTrue(math.isnan(newPoint.getLongitude().asRadians()))
+                    self.assertTrue(math.isnan(newPoint.getLatitude().asRadians()))
+
+        # Test precision near the poles
+        lon = 123.0*degrees
+        almostPole = SpherePoint(lon, self.nextDown(90.0*degrees))
+        goSouth = almostPole.offset(-90.0*degrees, 90.0*degrees)
+        self.assertAnglesNearlyEqual(lon, goSouth.getLongitude())
+        self.assertAnglesNearlyEqual(0.0*degrees, goSouth.getLatitude())
+        goEast = almostPole.offset(0.0*degrees, 90.0*degrees)
+        self.assertAnglesNearlyEqual(lon + 90.0*degrees, goEast.getLongitude())
+        self.assertAnglesNearlyEqual(0.0*degrees, goEast.getLatitude())
+
+    def testIterResult(self):
+        """Test if iteration returns the expected values.
+        """
+        for lon, lat in self._dataset:
+            point = SpherePoint(lon, lat)
+            if point.isFinite():
+                # Test mechanics directly
+                it = iter(point)
+                self.assertEqual(point.getLongitude(), next(it))
+                self.assertEqual(point.getLatitude(), next(it))
+                with self.assertRaises(StopIteration):
+                    next(it)
+
+                # Intended use case
+                lon, lat = point
+                self.assertEqual(point.getLongitude(), lon)
+                self.assertEqual(point.getLatitude(), lat)
+
+    def testStrValue(self):
+        """Test if __str__ produces output consistent with its spec.
+
+        This is necessarily a loose test, as the behavior of __str__
+        is (deliberately) incompletely specified.
+        """
+        for lon, lat in self._dataset:
+            point = SpherePoint(lon, lat)
+            numbers = re.findall(r'(?:\+|-)?(?:[\d.]+|nan|inf)', str(point))
+            self.assertEqual(2, len(numbers),
+                             "String '%s' should have exactly two coordinates." % (point,))
+
+            # Low precision to allow for only a few digits in string.
+            if not math.isnan(point.getLongitude().asRadians()):
+                self.assertAlmostEqual(point.getLongitude().asDegrees(), float(numbers[0]), delta=1e-6)
+            else:
+                self.assertRegexpMatches(numbers[0], r'-?nan')
+            if not math.isnan(point.getLatitude().asRadians()):
+                self.assertAlmostEqual(point.getLatitude().asDegrees(), float(numbers[1]), delta=1e-6)
+            else:
+                self.assertRegexpMatches(numbers[1], r'\+|-nan')
+
+            # Latitude must be signed
+            self.assertTrue(numbers[1].startswith("+") or numbers[1].startswith("-"))
+
+    def testReprValue(self):
+        """Test if __repr__ is a machine-readable representation.
+        """
+        for lon, lat in self._dataset:
+            point = SpherePoint(lon, lat)
+            pointRepr = repr(point)
+            self.assertIn("degrees", pointRepr)
+            self.assertEqual(2, len(pointRepr.split(",")))
+
+            copy = eval(pointRepr)
+            self.assertAnglesNearlyEqual(point.getLongitude(), copy.getLongitude())
+            self.assertAnglesNearlyEqual(point.getLatitude(), copy.getLatitude())
+
+    def nextUp(self, angle):
+        """Returns the smallest angle that is larger than the argument.
+        """
+        return np.nextafter(angle.asRadians(), inf)*radians
+
+    def nextDown(self, angle):
+        """Returns the largest angle that is smaller than the argument.
+        """
+        return np.nextafter(angle.asRadians(), -inf)*radians
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
`afw::geom::SphPoint` has been implemented as discussed in [DM-5529](https://jira.lsstcorp.org/browse/DM-5529). The one substantial change is the replacement of `offsetTo(SphPoint) -> pair<Angle, Angle>` with `bearingTo(SphPoint) -> Angle`, as discussed previously with @r-owen.

Unit tests are a combination of existing tests for `afw::coord::Coord` and new tests.

Class documentation has been written in the format proposed in [RFC-225](https://jira.lsstcorp.org/browse/RFC-225) for forward-compatibility.