### PR TITLE
Check that the DisplayImpl provides _show()

### DIFF
--- a/python/lsst/afw/display/interface.py
+++ b/python/lsst/afw/display/interface.py
@@ -92,7 +92,7 @@ def _makeDisplayImpl(display, backend, *args, **kwargs):
             # Copy the exception into outer scope
             exc = e
 
-    if not _disp:
+    if not _disp or not hasattr(_disp.DisplayImpl, "_show"):
         if exc is not None:
             # re-raise the final exception
             raise exc


### PR DESCRIPTION
In particular, this means that setDefaultBackend("ds9") will succeed iff
display_ds9 is setup.

N.b. lsst.afw.display.ds9 provides a DisplayImpl that throws when created,
but this allows us to check for a valid display without instantiating it.