### PR TITLE
Fixed build error

### DIFF
--- a/python/lsst/afw/math/functionLibrary.cc
+++ b/python/lsst/afw/math/functionLibrary.cc
@@ -27,7 +27,7 @@
 #include "lsst/afw/geom/Box.h"
 #include "lsst/afw/geom/Point.h"
 
-#include "lsst/afw/math/functionLibrary.h"
+#include "lsst/afw/math/FunctionLibrary.h"
 #include "lsst/afw/math/Function.h"
 
 namespace py = pybind11;


### PR DESCRIPTION
@pschella, trying to build the stack gives the following error:
bq. [2016-11-14T21:46:55.323114Z] python/lsst/afw/math/functionLibrary.cc:30:43: fatal error: lsst/afw/math/functionLibrary.h: No such file or directory