### PR TITLE
Add computeBBox method to Psf classes

### DIFF
--- a/include/lsst/afw/detection/GaussianPsf.h
+++ b/include/lsst/afw/detection/GaussianPsf.h
@@ -100,6 +100,10 @@ private:
         geom::Point2D const & position, image::Color const & color
     ) const;
 
+    virtual geom::Box2I doComputeBBox(
+        geom::Point2D const & position, image::Color const & color
+    ) const;
+
     geom::Extent2I _dimensions;
     double _sigma;
 };

--- a/include/lsst/afw/detection/Psf.h
+++ b/include/lsst/afw/detection/Psf.h
@@ -226,6 +226,14 @@ public:
     virtual geom::Point2D getAveragePosition() const;
 
     /**
+     *  @brief Return the bounding box of the image returned by computeKernelImage()
+     */
+    geom::Box2I computeBBox(
+        geom::Point2D position = makeNullPoint(),
+        image::Color color = image::Color()
+    ) const;
+
+    /**
      * Helper function for Psf::doComputeImage(): converts a kernel image (centered at (0,0) when xy0
      * is taken into account) to an image centered at position when xy0 is taken into account.
      *
@@ -280,6 +288,9 @@ private:
         double radius, geom::Point2D const & position, image::Color const & color
     ) const = 0;
     virtual geom::ellipses::Quadrupole doComputeShape(
+        geom::Point2D const & position, image::Color const & color
+    ) const = 0;
+    virtual geom::Box2I doComputeBBox(
         geom::Point2D const & position, image::Color const & color
     ) const = 0;
     //@}

--- a/src/detection/GaussianPsf.cc
+++ b/src/detection/GaussianPsf.cc
@@ -138,9 +138,8 @@ void GaussianPsf::write(OutputArchiveHandle & handle) const {
 PTR(GaussianPsf::Image) GaussianPsf::doComputeKernelImage(
     geom::Point2D const &, image::Color const &
 ) const {
-    PTR(Image) r(new Image(_dimensions));
+    PTR(Image) r(new Image(computeBBox()));
     Image::Array array = r->getArray();
-    r->setXY0(geom::Point2I(-_dimensions / 2)); // integer truncation intentional
     double sum = 0.0;
     for (int yIndex = 0, y = r->getY0(); yIndex < _dimensions.getY(); ++yIndex, ++y) {
         Image::Array::Reference row = array[yIndex];
@@ -162,6 +161,13 @@ geom::ellipses::Quadrupole GaussianPsf::doComputeShape(
     geom::Point2D const & position, image::Color const & color
 ) const {
     return geom::ellipses::Quadrupole(_sigma*_sigma, _sigma*_sigma, 0.0);
+}
+
+geom::Box2I GaussianPsf::doComputeBBox(
+        geom::Point2D const & position,
+        image::Color const & color
+) const {
+    return geom::Box2I(geom::Point2I(-_dimensions/2), _dimensions);  // integer truncation intentional
 }
 
 }}} // namespace lsst::afw::detection

--- a/src/detection/Psf.cc
+++ b/src/detection/Psf.cc
@@ -87,6 +87,12 @@ PTR(Psf::Image) Psf::computeKernelImage(
     return result;
 }
 
+geom::Box2I Psf::computeBBox(geom::Point2D position, image::Color color) const {
+    if (isPointNull(position)) position = getAveragePosition();
+    if (color.isIndeterminate()) color = getAverageColor();
+    return doComputeBBox(position, color);
+}
+
 PTR(math::Kernel const) Psf::getLocalKernel(geom::Point2D position, image::Color color) const {
     if (isPointNull(position)) position = getAveragePosition();
     if (color.isIndeterminate()) color = getAverageColor();

--- a/tests/testGaussianPsf.py
+++ b/tests/testGaussianPsf.py
@@ -74,7 +74,8 @@ def computeNaiveApertureFlux(image, radius, xc=0.0, yc=0.0):
 class GaussianPsfTestCase(lsst.utils.tests.TestCase):
 
     def setUp(self):
-        self.psf = lsst.afw.detection.GaussianPsf(51, 51, 4.0)
+        self.kernelSize = 51
+        self.psf = lsst.afw.detection.GaussianPsf(self.kernelSize, self.kernelSize, 4.0)
 
     def tearDown(self):
         del self.psf
@@ -108,6 +109,18 @@ class GaussianPsfTestCase(lsst.utils.tests.TestCase):
             psf = lsst.afw.detection.GaussianPsf.readFits(filename)
             self.assertEqual(self.psf.getSigma(), psf.getSigma())
             self.assertEqual(self.psf.getDimensions(), psf.getDimensions())
+
+    def testBBox(self):
+
+        self.assertEqual(self.psf.computeKernelImage().getBBox(),
+                         self.psf.computeBBox())
+
+        self.assertEqual(self.psf.computeBBox().getWidth(), self.kernelSize)
+
+        # Test interface. GaussianPsf does not vary spatially
+        self.assertEqual(self.psf.computeKernelImage(lsst.afw.geom.Point2D(0.0, 0.0)).getBBox(),
+                         self.psf.computeBBox(lsst.afw.geom.Point2D(0.0, 0.0)))
+
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):

--- a/tests/testTableArchivesLib.i
+++ b/tests/testTableArchivesLib.i
@@ -86,6 +86,14 @@ protected:
         return lsst::afw::geom::ellipses::Quadrupole();
     }
 
+    virtual lsst::afw::geom::Box2I doComputeBBox(
+        lsst::afw::geom::Point2D const & position,
+        lsst::afw::image::Color const & color
+    ) const {
+        return lsst::afw::geom::Box2I(lsst::afw::geom::Point2I(-1, -1),
+                                      lsst::afw::geom::Point2I(1, 1));
+    }
+
     virtual std::string getPersistenceName() const { return "DummyPsf"; }
 
     virtual std::string getPythonModule() const { return "testTableArchivesLib"; }


### PR DESCRIPTION
which computes the BBox to be returned by computeKernelImage. Pure virtual worker
method doComputeBBox must be implemented by derived classes. 