### PR TITLE
DM-8461: Wrap pipe_tasks with pybind11

### DIFF
--- a/include/lsst/afw/table/pybind11/catalog.h
+++ b/include/lsst/afw/table/pybind11/catalog.h
@@ -77,7 +77,7 @@ void declareCatalogOverloads(
     typedef CatalogT<RecordT> Catalog;
 
     cls.def("isSorted", (bool (Catalog::*)(Key<T> const &) const) &Catalog::isSorted);
-    cls.def("sort", (void (Catalog::*)(Key<T> const &)) &Catalog::sort);
+    cls.def("_sort", (void (Catalog::*)(Key<T> const &)) &Catalog::sort);
     cls.def(("_find_" + suffix).c_str(),
             [](Catalog & self, T const & value, Key<T> const & key)->std::shared_ptr<RecordT> {
         typename Catalog::const_iterator iter = self.find(value, key);

--- a/python/lsst/afw/geom/polygon/polygonLib.py
+++ b/python/lsst/afw/geom/polygon/polygonLib.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
 
+from lsst.afw.table.io import Persistable
 from ._polygon import *
 from .polygon import *

--- a/python/lsst/afw/image/exposure.cc
+++ b/python/lsst/afw/image/exposure.cc
@@ -25,6 +25,7 @@
 #include <pybind11/pybind11.h>
 //#include <pybind11/stl.h>
 
+#include "lsst/daf/base/Persistable.h"
 #include "lsst/afw/cameraGeom/Detector.h"
 #include "lsst/afw/image/Calib.h"
 #include "lsst/afw/image/Filter.h"
@@ -61,7 +62,7 @@ py::class_<Exposure<PixelT, MaskPixel, VariancePixel>,
     using ExposureT = Exposure<PixelT, MaskPixel, VariancePixel>;
     using MaskedImageT = typename ExposureT::MaskedImageT;
 
-    py::class_<ExposureT, std::shared_ptr<ExposureT>> cls(mod, ("Exposure" + suffix).c_str());
+    py::class_<ExposureT, std::shared_ptr<ExposureT>, lsst::daf::base::Persistable> cls(mod, ("Exposure" + suffix).c_str());
 
     mod.def("makeExposure", &makeExposure<PixelT, MaskPixel, VariancePixel>,
             "maskedImage"_a, "wcs"_a=std::shared_ptr<Wcs const>());

--- a/python/lsst/afw/math/kernel.cc
+++ b/python/lsst/afw/math/kernel.cc
@@ -91,10 +91,13 @@ PYBIND11_PLUGIN(_kernel) {
 
     py::class_<AnalyticKernel, std::shared_ptr<AnalyticKernel>, Kernel> clsAnalyticKernel(mod, "AnalyticKernel");
     clsAnalyticKernel.def(py::init<>());
+    // Workaround for NullSpatialFunction and py::arg not playing well with Citizen
+    clsAnalyticKernel.def(py::init<int, int, AnalyticKernel::KernelFunction const &>(),
+                          "width"_a, "height"_a, "kernelFunction"_a);
     clsAnalyticKernel.def(py::init<int, int, AnalyticKernel::KernelFunction const &, Kernel::SpatialFunction const &>(),
-                          "widht"_a, "height"_a, "kernelFunction"_a, "specialFuction"_a=Kernel::NullSpatialFunction());
+                          "width"_a, "height"_a, "kernelFunction"_a, "spatialFunction"_a);
     clsAnalyticKernel.def(py::init<int, int, AnalyticKernel::KernelFunction const &, std::vector<Kernel::SpatialFunctionPtr> const &>(),
-                          "widht"_a, "height"_a, "kernelFunction"_a, "specialFuctionList"_a);
+                          "width"_a, "height"_a, "kernelFunction"_a, "spatialFunctionList"_a);
     clsAnalyticKernel.def("clone", &AnalyticKernel::clone);
     clsAnalyticKernel.def("computeImage", &AnalyticKernel::computeImage,
                           "image"_a, "doNormalize"_a, "x"_a=0.0, "y"_a=0.0);
@@ -135,8 +138,11 @@ PYBIND11_PLUGIN(_kernel) {
     py::class_<SeparableKernel, std::shared_ptr<SeparableKernel>, Kernel> clsSeparableKernel(mod, "SeparableKernel");
 
     clsSeparableKernel.def(py::init<>());
+    // Workaround for NullSpatialFunction and py::arg not playing well with Citizen
+    clsSeparableKernel.def(py::init<int, int, SeparableKernel::KernelFunction const&, SeparableKernel::KernelFunction const&>(),
+                           "width"_a, "height"_a, "kernelColFunction"_a, "kernelRowFunction"_a);
     clsSeparableKernel.def(py::init<int, int, SeparableKernel::KernelFunction const&, SeparableKernel::KernelFunction const&, Kernel::SpatialFunction const&>(),
-                           "width"_a, "height"_a, "kernelColFunction"_a, "kernelRowFunction"_a, "spatialFunction"_a=Kernel::NullSpatialFunction());
+                           "width"_a, "height"_a, "kernelColFunction"_a, "kernelRowFunction"_a, "spatialFunction"_a);
     clsSeparableKernel.def(py::init<int, int, SeparableKernel::KernelFunction const&, SeparableKernel::KernelFunction const&, std::vector<Kernel::SpatialFunctionPtr> const&>(),
                            "width"_a, "height"_a, "kernelColFunction"_a, "kernelRowFunction"_a, "spatialFunctionList"_a);
     clsSeparableKernel.def("clone", &SeparableKernel::clone);

--- a/python/lsst/afw/table/base.cc
+++ b/python/lsst/afw/table/base.cc
@@ -68,6 +68,9 @@ template <typename T>
 void declareBaseRecordOverloads(PyBaseRecord & clsBaseRecord, std::string const & suffix) {
     clsBaseRecord.def(("_get_"+suffix).c_str(),
                       (typename Field<T>::Value (BaseRecord::*)(Key<T> const &) const) &BaseRecord::get);
+    // TODO: pybind11 backwards compatibility with Swig
+    clsBaseRecord.def(("get"+suffix).c_str(),
+                      (typename Field<T>::Value (BaseRecord::*)(Key<T> const &) const) &BaseRecord::get);
     clsBaseRecord.def("_getitem_", [](BaseRecord & self, Key<T> const & key)->typename Field<T>::Reference {
         /*
         Define the python __getitem__ method in python to return a baserecord for the requested key
@@ -81,6 +84,9 @@ void declareBaseRecordArrayOverloads(PyBaseRecord clsBaseRecord, std::string con
     typedef lsst::afw::table::Array<U> T;
     clsBaseRecord.def(("_get_"+suffix).c_str(),
                       (typename Field<T>::Value (BaseRecord::*)(Key<T> const &) const) &BaseRecord::get);
+    // TODO: pybind11 backwards compatibility with Swig
+    clsBaseRecord.def(("get"+suffix).c_str(),
+                      (typename Field<T>::Value (BaseRecord::*)(Key<T> const &) const) &BaseRecord::get);
     clsBaseRecord.def("_getitem_", [](BaseRecord & self, Key<T> const & key)->ndarray::Array<U,1,1> {
         /*
         Define the python __getitem__ method in python to return a baserecord for the requested key
@@ -92,6 +98,9 @@ void declareBaseRecordArrayOverloads(PyBaseRecord clsBaseRecord, std::string con
 template <typename T>
 void declareBaseRecordOverloadsFlag(PyBaseRecord clsBaseRecord, std::string const & suffix) {
     clsBaseRecord.def(("_get_"+suffix).c_str(),
+                      (typename Field<T>::Value (BaseRecord::*)(Key<T> const &) const) &BaseRecord::get);
+    // TODO: pybind11 backwards compatibility with Swig
+    clsBaseRecord.def(("get"+suffix).c_str(),
                       (typename Field<T>::Value (BaseRecord::*)(Key<T> const &) const) &BaseRecord::get);
 }
 

--- a/python/lsst/afw/table/catalog.py
+++ b/python/lsst/afw/table/catalog.py
@@ -172,6 +172,10 @@ def addCatalogMethods(cls):
         return lsst.afw.fits.reduceToFits(self)
     cls.__reduce__ = __reduce__
 
+    # sort is renamed so that it can be shadowed for sorted catalogs
+    # use the default implementation for unsorted catalogs
+    cls.sort = cls._sort
+
     def find(self, value, key):
         """Return the record for which record.get(key) == value
 

--- a/python/lsst/afw/table/exposure.py
+++ b/python/lsst/afw/table/exposure.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
-from .catalog import addCatalogMethods
-from ._exposure import ExposureCatalog
+from .sortedCatalog import addSortedCatalogMethods
+from ._exposure import _SortedBaseExposureCatalog
 
 __all__ = []  # import this module only for its side effects
 
-addCatalogMethods(ExposureCatalog)
+addSortedCatalogMethods(_SortedBaseExposureCatalog)

--- a/python/lsst/afw/table/sortedCatalog.py
+++ b/python/lsst/afw/table/sortedCatalog.py
@@ -21,10 +21,11 @@ def addSortedCatalogMethods(cls):
         return type(self).__base__.isSorted(self, key)
     cls.isSorted = isSorted
 
+    # emulate sort() using sort(key) to simplify python argument lookup
     def sort(self, key=None):
         if key is None:
             key = self.table.getIdKey()
-        type(self).__base__.sort(self, key)
+        self._sort(key)
     cls.sort = sort
 
     def find(self, value, key=None):


### PR DESCRIPTION
Various issues that occur in packages upstream from `afw`:
- The changes to polygonLib.py are to let `Polygon` be imported without needing other imports first.
- Making `Exposure` a `Persistable` is needed to allow calls to methods that expect a `Persistable`.
- The changes to `kernel.cc` take advantage of the fact that a method with a default argument is equivalent to two methods with no defaults. Using `py::init` is a bit risky, since strictly speaking it's only guaranteed to work if a constructor with a matching signature exists. Using a lambda to make a [custom constructor](http://pybind11.readthedocs.io/en/master/advanced/classes.html#custom-constructors) may be more forward-compatible.