### PR TITLE
Make stripping WCS metadata reliable

### DIFF
--- a/src/image/makeWcs.cc
+++ b/src/image/makeWcs.cc
@@ -113,8 +113,8 @@ afwImg::Wcs::Ptr afwImg::makeWcs(
         wcs = afwImg::Wcs::Ptr(new afwImg::Wcs(metadata));
     }
 
-    //If keywords LTV[1,2] are present, the image on disk is already a subimage, so
-    //we should shift the wcs to allow for this.
+    // If keywords LTV[1,2] are present, the image on disk is already a subimage, so
+    // we should shift the wcs to allow for this.
     std::string key = "LTV1";
     if (metadata->exists(key)) {
         wcs->shiftReferencePixel(-metadata->getAsDouble(key), 0);

--- a/src/image/makeWcs.cc
+++ b/src/image/makeWcs.cc
@@ -126,7 +126,7 @@ afwImg::Wcs::Ptr afwImg::makeWcs(
     }
 
     if (stripMetadata) {
-        afwImg::detail::stripWcsKeywords(metadata, wcs);
+        afwImg::detail::stripWcsKeywords(_metadata, wcs);
     }
 
     return wcs;


### PR DESCRIPTION
Make `makeWcs(metadata, stripMetadata)` reliably strip
metadata (if the `stripMetadata` is true) by stripping
the argument, rather than an internal copy that may be
a deep copy.