### PR TITLE
Fix obsolete uses of cast and vector

### DIFF
--- a/examples/estimateBackground.py
+++ b/examples/estimateBackground.py
@@ -38,7 +38,7 @@ except NameError:
 
 def getImage():
     imagePath = os.path.join(lsst.utils.getPackageDir("afwdata"),
-                             "DC3a-Sim", "sci", "v5-e0", "v5-e0-c011-a00.sci_img.fits")
+                             "DC3a-Sim", "sci", "v5-e0", "v5-e0-c011-a00.sci.fits")
     return afwImage.MaskedImageF(imagePath)
 
 def simpleBackground(image):

--- a/examples/estimateBackground.py
+++ b/examples/estimateBackground.py
@@ -49,7 +49,7 @@ def simpleBackground(image):
 
     bkgd = afwMath.makeBackground(image, bctrl)
 
-    statsImage = afwMath.cast_BackgroundMI(bkgd).getStatsImage()
+    statsImage = bkgd.getStatsImage()
 
     image  -= bkgd.getImageF(afwMath.Interpolate.NATURAL_SPLINE)
 
@@ -74,7 +74,7 @@ def complexBackground(image):
 
     bkgd = afwMath.makeBackground(image, bctrl)
 
-    statsImage = afwMath.cast_BackgroundMI(bkgd).getStatsImage()
+    statsImage = bkgd.getStatsImage()
     ds9.mtv(statsImage.getVariance())
 
     bkdgImages = dict(SPLINE = bkgd.getImageF(afwMath.Interpolate.NATURAL_SPLINE),
@@ -94,7 +94,7 @@ def main():
 
     if display:
         ds9.mtv(image, frame=1)
-        ds9.mtv(afwMath.cast_BackgroundMI(bkgd).getStatsImage(), frame=2)
+        ds9.mtv(bkgd.getStatsImage(), frame=2)
 
     order = 2
     actrl = afwMath.ApproximateControl(afwMath.ApproximateControl.CHEBYSHEV, order, order)

--- a/examples/showCamera.py
+++ b/examples/showCamera.py
@@ -51,12 +51,12 @@ def main(camera, sample=20, showDistortion=True):
         dist = camera.getDistortion()
 
     for raft in camera:
-        raft = cameraGeom.cast_Raft(raft)
+        raft = raft
         for ccd in raft:
             if False and ccd.getId().getSerial() not in (0, 3):
                 continue
 
-            ccd = cameraGeom.cast_Ccd(ccd)
+            ccd = ccd
             ccd.setTrimmed(True)
 
             width, height = ccd.getAllPixels(True).getDimensions()

--- a/examples/simpleStacker.py
+++ b/examples/simpleStacker.py
@@ -43,7 +43,7 @@ def main():
     nImg = 10
     nX, nY = 64, 64
 
-    imgList = afwImage.vectorImageF()
+    imgList = []
     for iImg in range(nImg):
         imgList.push_back(afwImage.ImageF(afwGeom.Extent2I(nX, nY), iImg))
 

--- a/examples/spatialCellExample.py
+++ b/examples/spatialCellExample.py
@@ -68,7 +68,7 @@ def readImage(filename=None):
     else:
         bbox = None
 
-    mi = afwImage.MaskedImageF(filename, 0, None, bbox, afwImage.LOCAL)
+    mi = afwImage.MaskedImageF(filename, bbox=bbox, origin=afwImage.LOCAL)
     mi.setXY0(afwGeom.Point2I(0, 0))
     #
     # Subtract the background.  We'd use a canned procedure, but that's in meas/utils/sourceDetection.py. We
@@ -154,11 +154,7 @@ def SpatialCellSetDemo(filename=None):
 
         j = 0
         for cand in cell:
-            #
-            # Swig doesn't know that we're a SpatialCellImageCandidate;  all it knows is that we have
-            # a SpatialCellCandidate so we need an explicit (dynamic) cast
-            #
-            cand = testSpatialCellLib.cast_ExampleCandidate(cand)
+            cand = cand
 
             w, h = cand.getBBox().getDimensions()
             if w*h < 75:

--- a/examples/spatialCellExample.py
+++ b/examples/spatialCellExample.py
@@ -62,7 +62,7 @@ def readImage(filename=None):
         except Exception:
             raise RuntimeError("You must provide a filename or setup afwdata to run these examples")
 
-        filename = os.path.join(afwDataDir, "CFHT", "D4", "cal-53535-i-797722_1")
+        filename = os.path.join(afwDataDir, "CFHT", "D4", "cal-53535-i-797722_1.fits")
 
         bbox = afwGeom.Box2I(afwGeom.Point2I(270, 2530), afwGeom.Extent2I(512, 512))
     else:

--- a/python/lsst/afw/coord/coord.py
+++ b/python/lsst/afw/coord/coord.py
@@ -7,7 +7,6 @@ def __repr__(self):
     coordSystem = self.getCoordSystem()
     argList = ["%r*afwGeom.degrees" % (pos.asDegrees(),) for pos in self]
     if coordSystem == TOPOCENTRIC:
-#        topoCoord = TopocentricCoord.cast(self)
         argList += [
             repr(self.getEpoch()),
             "(%r)" % (self.getObservatory(),),

--- a/python/lsst/afw/geom/ellipses/__init__.py
+++ b/python/lsst/afw/geom/ellipses/__init__.py
@@ -36,8 +36,6 @@ Separable = {
     (ConformalShear, LogTraceRadius):SeparableConformalShearLogTraceRadius
 }
 
-#BaseCore.cast = lambda self: globals()[self.getName()].cast(self)
-
 class EllipseMatplotlibInterface(object):
     """An interface for drawing the ellipse using matplotlib.
 

--- a/python/lsst/afw/table/catalogMatches.py
+++ b/python/lsst/afw/table/catalogMatches.py
@@ -95,7 +95,7 @@ def copyIntoCatalog(catalog, target, sourceSchema=None, sourcePrefix=None, targe
 def matchesToCatalog(matches, matchMeta):
     """Denormalise matches into a Catalog of "unpacked matches"
 
-    \param[in] matches    unpacked matches, i.e. a std::vector of Match objects whose schema
+    \param[in] matches    unpacked matches, i.e. a list of Match objects whose schema
                           has "first" and "second" attributes which, resepectively, contain the
                           reference and source catalog entries, and a "distance" field (the
                           measured distance between the reference and source objects)

--- a/tests/testFunctorKeys.py
+++ b/tests/testFunctorKeys.py
@@ -376,7 +376,7 @@ class FunctorKeysTestCase(lsst.utils.tests.TestCase):
         b2 = schema.addField("b_2", type=fieldType, doc="invalid out-of-order array element")
         b1 = schema.addField("b_1", type=fieldType, doc="invalid out-of-order array element")
         c = schema.addField("c", type="Array%s" % fieldType, doc="old-style array", size=4)
-        k1 = FunctorKeyType([a0, a1, a2])  # construct from a vector of keys
+        k1 = FunctorKeyType([a0, a1, a2])  # construct from a list of keys
         k2 = FunctorKeyType(schema["a"])   # construct from SubSchema
         k3 = FunctorKeyType(c)             # construct from old-style Key<Array<T>>
         k4 = FunctorKeyType.addFields(schema, "d", "doc for d", "barn", 4)

--- a/tests/testHeavyFootprint.py
+++ b/tests/testHeavyFootprint.py
@@ -161,7 +161,6 @@ class HeavyFootprintTestCase(lsst.utils.tests.TestCase):
         omi.set((0, 0x0, 0))
 
         for foot in fs.getFootprints():
-#            afwDetect.cast_HeavyFootprint(foot, self.mi).insert(omi)
             foot.insert(omi)
 
         if display:
@@ -170,28 +169,6 @@ class HeavyFootprintTestCase(lsst.utils.tests.TestCase):
 
         submi = self.mi.Factory(self.mi, bbox, afwImage.LOCAL)
         self.assertFloatsEqual(submi.getImage().getArray(), omi.getImage().getArray())
-
-    @unittest.skip("pybind11 does not need casting")
-    def testCast_HeavyFootprint(self):
-        """Test that we can cast a Footprint to a HeavyFootprint"""
-
-        hfoot = afwDetect.makeHeavyFootprint(self.foot, self.mi)
-
-        ctrl = afwDetect.HeavyFootprintCtrl(afwDetect.HeavyFootprintCtrl.NONE)
-        hfoot = afwDetect.makeHeavyFootprint(self.foot, self.mi, ctrl)
-        #
-        # This isn't quite a full test, as hfoot is already a HeavyFootprint,
-        # the complete test is in testMakeHeavy
-        #
-        self.assertNotEqual(afwDetect.cast_HeavyFootprint(hfoot, self.mi), None,
-                            "Cast to the right sort of HeavyFootprint")
-        self.assertNotEqual(afwDetect.HeavyFootprintF.cast(hfoot), None,
-                            "Cast to the right sort of HeavyFootprint")
-
-        self.assertEqual(afwDetect.cast_HeavyFootprint(self.foot, self.mi), None,
-                         "Can't cast a Footprint to a HeavyFootprint")
-        self.assertEqual(afwDetect.HeavyFootprintI.cast(hfoot), None,
-                         "Cast to the wrong sort of HeavyFootprint")
 
     def testMergeHeavyFootprints(self):
         mi = afwImage.MaskedImageF(20, 10)


### PR DESCRIPTION
These changes fall into 3 categories:
- Fix examples (or in the case of one test, fix what I can and file a ticket to fix the rest)
- Remove obsolete code that was commented out
- Remove a skipped test that will pybind11 compatible.