### PR TITLE
DM-9433 ds9.py error code not working as intended

### DIFF
--- a/python/lsst/afw/display/ds9.py
+++ b/python/lsst/afw/display/ds9.py
@@ -42,12 +42,20 @@ except NameError:
         # Let's define a version of getDisplay() which will throw an exception.
         e.args = ["%s (is display_ds9 setup?)" % e]
 
-        def getDisplay(*args, **kwargs):
-            raise e
+        # TODO: once we abandon Python 2 use the following simpler code:
+        # def getDisplay(*args, exception=e, **kwargs):
+        #     raise exception
+        class _RaiseException(object):
+            def __init__(self, exception):
+                self.exception = exception
+
+            def __call__(self, *args, **kwargs):
+                raise self.exception
+
+        getDisplay = _RaiseException(e)
 
         class DisplayImpl(object):
-            def __init__(self, *args, **kwargs):
-                raise e
+            __init__ = getDisplay
 
         loaded = False
     else:


### PR DESCRIPTION
When display_ds9 is not set up the code tries to print the exception. However, in Python 3 the exception no longer exists by the time it is needed, so explicitly bind the exception.

The code is a bit clumsy due to limitations of Python 2, but I include instructions for eventual simplification.

I tried using functools.partial but felt the results were less clear (thought slightly shorter) than the code I adopted.