### PR TITLE
DM-8105: Missing test case for SpherePoint

### DIFF
--- a/tests/testSpherePoint.cc
+++ b/tests/testSpherePoint.cc
@@ -22,15 +22,13 @@
  * see <http://www.lsstcorp.org/LegalNotices/>.
  */
 
-#include <iostream>
-#include <sstream>
-
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE SpherePointCpp
 
 #include "boost/test/unit_test.hpp"
 
 #include "lsst/afw/geom/SpherePoint.h"
+#include "lsst/pex/exceptions/Exception.h"
 
 /*
  * Unit tests for C++-only functionality in SpherePoint.
@@ -42,7 +40,7 @@ namespace afw {
 namespace geom {
 
     /**
-     * @brief Tests whether the result of SpherePoint::SpherePoint(SpherePoint const &)
+     * Tests whether the result of SpherePoint::SpherePoint(SpherePoint const &)
      * makes an identical but independent copy.
      */
     BOOST_AUTO_TEST_CASE(SpherePointCopyResult, *boost::unit_test::tolerance(1e-14))
@@ -61,6 +59,18 @@ namespace geom {
         BOOST_TEST(original != copy);
         BOOST_TEST(copy.getLongitude().asDegrees() == copyLon);
         BOOST_TEST(copy.getLatitude() .asDegrees() == copyLat);
+    }
+
+    /**
+     * Tests whether SpherePoint::operator[](size_t) handles invalid indices
+     * correctly.
+     */
+    BOOST_AUTO_TEST_CASE(getItemError)
+    {
+        SpherePoint point(Point3D(1.0, 1.0, 1.0));
+
+        BOOST_CHECK_THROW(point[2], pex::exceptions::OutOfRangeError);
+        BOOST_CHECK_THROW(point[-1], pex::exceptions::OutOfRangeError);
     }
 
     // TODO: add a test for propagation of ostream errors

--- a/tests/testSpherePoint.cc
+++ b/tests/testSpherePoint.cc
@@ -39,40 +39,39 @@ namespace lsst {
 namespace afw {
 namespace geom {
 
-    /**
-     * Tests whether the result of SpherePoint::SpherePoint(SpherePoint const &)
-     * makes an identical but independent copy.
-     */
-    BOOST_AUTO_TEST_CASE(SpherePointCopyResult, *boost::unit_test::tolerance(1e-14))
-    {
-        SpherePoint original(Point3D(0.34, -1.2, 0.97));
-        SpherePoint copy(original);
+/**
+ * Tests whether the result of SpherePoint::SpherePoint(SpherePoint const &)
+ * makes an identical but independent copy.
+ */
+BOOST_AUTO_TEST_CASE(SpherePointCopyResult, *boost::unit_test::tolerance(1e-14)) {
+    SpherePoint original(Point3D(0.34, -1.2, 0.97));
+    SpherePoint copy(original);
 
-        // Want exact equality, not floating-point equality
-        BOOST_TEST(original == copy);
+    // Want exact equality, not floating-point equality
+    BOOST_TEST(original == copy);
 
-        // Don't compare Angles in case there's aliasing of some sort
-        double const copyLon = copy.getLongitude().asDegrees();
-        double const copyLat = copy.getLatitude() .asDegrees();
+    // Don't compare Angles in case there's aliasing of some sort
+    double const copyLon = copy.getLongitude().asDegrees();
+    double const copyLat = copy.getLatitude().asDegrees();
 
-        original = SpherePoint(-42*degrees, 45*degrees);
-        BOOST_TEST(original != copy);
-        BOOST_TEST(copy.getLongitude().asDegrees() == copyLon);
-        BOOST_TEST(copy.getLatitude() .asDegrees() == copyLat);
-    }
+    original = SpherePoint(-42 * degrees, 45 * degrees);
+    BOOST_TEST(original != copy);
+    BOOST_TEST(copy.getLongitude().asDegrees() == copyLon);
+    BOOST_TEST(copy.getLatitude().asDegrees() == copyLat);
+}
 
-    /**
-     * Tests whether SpherePoint::operator[](size_t) handles invalid indices
-     * correctly.
-     */
-    BOOST_AUTO_TEST_CASE(getItemError)
-    {
-        SpherePoint point(Point3D(1.0, 1.0, 1.0));
+/**
+ * Tests whether SpherePoint::operator[](size_t) handles invalid indices
+ * correctly.
+ */
+BOOST_AUTO_TEST_CASE(getItemError) {
+    SpherePoint point(Point3D(1.0, 1.0, 1.0));
 
-        BOOST_CHECK_THROW(point[2], pex::exceptions::OutOfRangeError);
-        BOOST_CHECK_THROW(point[-1], pex::exceptions::OutOfRangeError);
-    }
+    BOOST_CHECK_THROW(point[2], pex::exceptions::OutOfRangeError);
+    BOOST_CHECK_THROW(point[-1], pex::exceptions::OutOfRangeError);
+}
 
-    // TODO: add a test for propagation of ostream errors
-
-}}} /* namespace lsst::afw::geom */
+// TODO: add a test for propagation of ostream errors
+}
+}
+} /* namespace lsst::afw::geom */


### PR DESCRIPTION
Adds a C++-only test for `operator[]`, since it obeys a different spec from `__getitem__` (which is already tested in `testSpherePoint.py`). This PR also adds a `clang-format` pass I missed in DM-9502; because it makes large changes to indentation, it may be useful to review this PR as two separate commits.