### PR TITLE
DM-8465: wrap meas_modelfit with pybind11

### DIFF
--- a/python/lsst/afw/geom/ellipses/ellipse.cc
+++ b/python/lsst/afw/geom/ellipses/ellipse.cc
@@ -33,6 +33,7 @@
 #include "lsst/afw/geom/Point.h"
 #include "lsst/afw/geom/ellipses/GridTransform.h"
 #include "lsst/afw/geom/ellipses/Ellipse.h"
+#include "lsst/afw/geom/ellipses/Transformer.h"
 
 namespace py = pybind11;
 using namespace pybind11::literals;
@@ -85,7 +86,13 @@ PYBIND11_PLUGIN(_ellipse) {
     clsEllipse.def("shift", &Ellipse::shift);
     clsEllipse.def("getParameterVector", &Ellipse::getParameterVector);
     clsEllipse.def("setParameterVector", &Ellipse::setParameterVector);
-//    clsEllipse.def("transform", (Transformer const (Ellipse::*)(AffineTransform const &) const) &Ellipse::transform);
+    clsEllipse.def(
+        "transform",
+        [](Ellipse const & self, AffineTransform const & t) -> Ellipse {
+            return self.transform(t);
+        },
+        "transform"_a
+    );
 //    clsEllipse.def("convolve", (Convolution const (Ellipse::*)(Ellipse const &) const) &Ellipse::convolve);
     clsEllipse.def("getGridTransform", [](Ellipse & self) -> AffineTransform {
         return self.getGridTransform(); // delibarate conversion to AffineTransform

--- a/python/lsst/afw/table/aggregates.cc
+++ b/python/lsst/afw/table/aggregates.cc
@@ -81,9 +81,9 @@ void declareCovarianceMatrixKey(py::module &mod, const::std::string & suffix) {
     py::class_<CovarianceMatrixKey<T,N>> cls(mod, ("CovarianceMatrix"+suffix+"Key").c_str());
     
     cls.def(py::init<>());
+    cls.def(py::init<SubSchema const &, NameArray const &>());
     cls.def(py::init<SigmaKeyArray const &, CovarianceKeyArray const &>(),
             "sigma"_a, "cov"_a=CovarianceKeyArray());
-    cls.def(py::init<SubSchema const &, NameArray const &>());
 
     cls.def("__eq__", &CovarianceMatrixKey<T,N>::operator==, py::is_operator());
     cls.def("__ne__", &CovarianceMatrixKey<T,N>::operator!=, py::is_operator());

--- a/python/lsst/afw/table/arrays.cc
+++ b/python/lsst/afw/table/arrays.cc
@@ -47,8 +47,8 @@ void declareArrayKey(py::module & mod, std::string const & suffix) {
     
     clsArrayKey.def(py::init<>());
     clsArrayKey.def(py::init<Key<Array<T>> const &>());
-    clsArrayKey.def(py::init<std::vector< Key<T> > const &>());
     clsArrayKey.def(py::init<SubSchema const &>());
+    clsArrayKey.def(py::init<std::vector< Key<T> > const &>());
     
     clsArrayKey.def_static("addFields", (ArrayKey<T> (*)(
         Schema &,

--- a/python/lsst/afw/table/schema.cc
+++ b/python/lsst/afw/table/schema.cc
@@ -200,6 +200,7 @@ PYBIND11_PLUGIN(_schema) {
     
     clsSubSchema.def("getNames", &SubSchema::getNames, "topOnly"_a=false);
     clsSubSchema.def("getPrefix", &SubSchema::getPrefix);
+    clsSubSchema.def("__getitem__", &SubSchema::operator[]);
     
     declareSubSchemaOverloads<std::uint16_t>(clsSubSchema, "U");
     declareSubSchemaOverloads<std::int32_t>(clsSubSchema, "I");


### PR DESCRIPTION
This adds wrappers for two afw methods that are apparently first used in meas_modelfit (lack of test coverage has been noted).