### PR TITLE
DM-9140: Ensure __str__ and __repr__ copied from Swig

### DIFF
--- a/python/lsst/afw/coord/weather.cc
+++ b/python/lsst/afw/coord/weather.cc
@@ -20,6 +20,8 @@
  * see <https://www.lsstcorp.org/LegalNotices/>.
  */
 
+#include <sstream>
+
 #include <pybind11/pybind11.h>
 
 #include "lsst/afw/coord/Weather.h"
@@ -50,6 +52,13 @@ PYBIND11_PLUGIN(_weather) {
     cls.def("getAirPressure", &lsst::afw::coord::Weather::getAirPressure);
     cls.def("getAirTemperature", &lsst::afw::coord::Weather::getAirTemperature);
     cls.def("getHumidity", &lsst::afw::coord::Weather::getHumidity);
+    auto streamStr = [](Weather const &self) {
+        std::stringstream buffer;
+        buffer << self;
+        return buffer.str();
+    };
+    cls.def("__str__", streamStr);
+    cls.def("__repr__", streamStr);
 
     return mod.ptr();
 }

--- a/python/lsst/afw/detection/peak.cc
+++ b/python/lsst/afw/detection/peak.cc
@@ -23,6 +23,7 @@
 #include "pybind11/pybind11.h"
 
 #include <memory>
+#include <sstream>
 
 //#include <pybind11/stl.h>
 
@@ -66,6 +67,13 @@ void declarePeakRecord(PyPeakRecord & cls) {
     cls.def("getF", &PeakRecord::getF);
     cls.def("getPeakValue", &PeakRecord::getPeakValue);
     cls.def("setPeakValue", &PeakRecord::setPeakValue);
+    auto streamStr = [](PeakRecord const &self) {
+        std::stringstream buffer;
+        buffer << self;
+        return buffer.str();
+    };
+    cls.def("__str__", streamStr);
+    cls.def("__repr__", streamStr);
 }
 
 /**

--- a/python/lsst/afw/geom/angle/angle.cc
+++ b/python/lsst/afw/geom/angle/angle.cc
@@ -105,6 +105,14 @@ PYBIND11_PLUGIN(angle) {
         }
     );
 
+    auto streamStr = [](Angle const& self) {
+        std::stringstream buffer;
+        buffer << self;
+        return buffer.str();
+    };
+    clsAngle.def("__str__", streamStr);
+    clsAngle.def("__repr__", streamStr);
+
     clsAngle.def("asAngularUnits", &Angle::asAngularUnits);
     clsAngle.def("asRadians", &Angle::asRadians);
     clsAngle.def("asDegrees", &Angle::asDegrees);

--- a/python/lsst/afw/geom/ellipses/conformalShear.cc
+++ b/python/lsst/afw/geom/ellipses/conformalShear.cc
@@ -49,6 +49,9 @@ PYBIND11_PLUGIN(_conformalShear) {
     cls.def("getAxisRatio", &ConformalShear::getAxisRatio);
     cls.def("normalize", &ConformalShear::normalize);
     cls.def("getName", &ConformalShear::getName);
+    cls.def("__repr__", [](ConformalShear const& self) {
+        return py::str("%s(%g, %g)").format(self.getName(), self.getE1(), self.getE2());
+    });
 
     return mod.ptr();
 }

--- a/python/lsst/afw/geom/ellipses/distortion.cc
+++ b/python/lsst/afw/geom/ellipses/distortion.cc
@@ -49,6 +49,9 @@ PYBIND11_PLUGIN(_distortion) {
     cls.def("getAxisRatio", &Distortion::getAxisRatio);
     cls.def("normalize", &Distortion::normalize);
     cls.def("getName", &Distortion::getName);
+    cls.def("__repr__", [](Distortion const& self) {
+        return py::str("%s(%g, %g)").format(self.getName(), self.getE1(), self.getE2());
+    });
 
     return mod.ptr();
 }

--- a/python/lsst/afw/geom/ellipses/ellipticityBase.cc
+++ b/python/lsst/afw/geom/ellipses/ellipticityBase.cc
@@ -51,6 +51,9 @@ PYBIND11_PLUGIN(_ellipticityBase) {
     cls.def("getE2", &detail::EllipticityBase::getE2);
     cls.def("setE2", &detail::EllipticityBase::setE2);
     cls.def("getTheta", &detail::EllipticityBase::getTheta);
+    cls.def("__str__", [](detail::EllipticityBase const& self) {
+        return py::str("(%g, %g)").format(self.getE1(), self.getE2());
+    });
 
     return mod.ptr();
 }

--- a/python/lsst/afw/geom/ellipses/radii.cc
+++ b/python/lsst/afw/geom/ellipses/radii.cc
@@ -40,24 +40,48 @@ PYBIND11_PLUGIN(_radii) {
     clsDeterminantRadius.def(py::init<double>(), "value"_a=1.0);
     clsDeterminantRadius.def("normalize", &DeterminantRadius::normalize);
     clsDeterminantRadius.def_static("getName", DeterminantRadius::getName);
+    clsDeterminantRadius.def("__str__", [](DeterminantRadius const& self) {
+        return std::to_string(self);
+    });
+    clsDeterminantRadius.def("__repr__", [](DeterminantRadius const& self) {
+        return self.getName() + "(" + std::to_string(self) + ")";
+    });
 
     py::class_<TraceRadius> clsTraceRadius(mod, "TraceRadius");
     
     clsTraceRadius.def(py::init<double>(), "value"_a=1.0);
     clsTraceRadius.def("normalize", &TraceRadius::normalize);
     clsTraceRadius.def_static("getName", TraceRadius::getName);
+    clsTraceRadius.def("__str__", [](TraceRadius const& self) {
+        return std::to_string(self);
+    });
+    clsTraceRadius.def("__repr__", [](TraceRadius const& self) {
+        return self.getName() + "(" + std::to_string(self) + ")";
+    });
 
     py::class_<LogDeterminantRadius> clsLogDeterminantRadius(mod, "LogDeterminantRadius");
     
     clsLogDeterminantRadius.def(py::init<double>(), "value"_a=0.0);
     clsLogDeterminantRadius.def("normalize", &LogDeterminantRadius::normalize);
     clsLogDeterminantRadius.def_static("getName", LogDeterminantRadius::getName);
+    clsLogDeterminantRadius.def("__str__", [](LogDeterminantRadius const& self) {
+        return std::to_string(self);
+    });
+    clsLogDeterminantRadius.def("__repr__", [](LogDeterminantRadius const& self) {
+        return self.getName() + "(" + std::to_string(self) + ")";
+    });
 
     py::class_<LogTraceRadius> clsLogTraceRadius(mod, "LogTraceRadius");
     
     clsLogTraceRadius.def(py::init<double>(), "value"_a=0.0);
     clsLogTraceRadius.def("normalize", &LogTraceRadius::normalize);
     clsLogTraceRadius.def_static("getName", LogTraceRadius::getName);
+    clsLogTraceRadius.def("__str__", [](LogTraceRadius const& self) {
+        return std::to_string(self);
+    });
+    clsLogTraceRadius.def("__repr__", [](LogTraceRadius const& self) {
+        return self.getName() + "(" + std::to_string(self) + ")";
+    });
 
     return mod.ptr();
 }

--- a/python/lsst/afw/geom/ellipses/reducedShear.cc
+++ b/python/lsst/afw/geom/ellipses/reducedShear.cc
@@ -49,6 +49,9 @@ PYBIND11_PLUGIN(_reducedShear) {
     cls.def("getAxisRatio", &ReducedShear::getAxisRatio);
     cls.def("normalize", &ReducedShear::normalize);
     cls.def("getName", &ReducedShear::getName);
+    cls.def("__repr__", [](ReducedShear const& self) {
+        return py::str("%s(%g, %g)").format(self.getName(), self.getE1(), self.getE2());
+    });
 
     return mod.ptr();
 }

--- a/python/lsst/afw/geom/ellipses/separable.cc
+++ b/python/lsst/afw/geom/ellipses/separable.cc
@@ -79,6 +79,12 @@ void declareSeparable(py::module & mod, const std::string & suffix) {
     cls.def("transformInPlace", [](Class & self, lsst::afw::geom::LinearTransform const & t) {
        self.transform(t).inPlace();
     });
+    cls.def("__str__", [](Class & self) {
+       return py::str("(%s, %s)").format(self.getEllipticity(), self.getRadius());
+    });
+    cls.def("__repr__", [](Class & self) {
+       return py::str("Separable(%r, %r)").format(self.getEllipticity(), self.getRadius());
+    });
 }
 
 PYBIND11_PLUGIN(_separable) {

--- a/python/lsst/afw/table/schema/schema.cc
+++ b/python/lsst/afw/table/schema/schema.cc
@@ -62,6 +62,12 @@ using PyKey = py::class_<Key<T>, KeyBase<T>, FieldBase<T>>;
 template <typename T>
 using PySchemaItem = py::class_<SchemaItem<T>>;
 
+template <typename T>
+std::string streamStr(T const &self) {
+    std::ostringstream os;
+    os << self;
+    return os.str();
+}
 
 // Specializations for FieldBase
 
@@ -249,14 +255,8 @@ void declareSchemaType(py::module & mod) {
     clsField.def("getDoc", &Field<T>::getDoc);
     clsField.def("getUnits", &Field<T>::getUnits);
     clsField.def("copyRenamed", &Field<T>::copyRenamed);
-    clsField.def(
-        "__repr__",
-        [](Field<T> const & self) -> std::string {
-            std::ostringstream os;
-            os << self;
-            return os.str();
-        }
-    );
+    clsField.def("__str__", &streamStr<Field<T>>);
+    clsField.def("__repr__", &streamStr<Field<T>>);
 
     // Key
     PyKey<T> clsKey(mod, ("Key" + suffix).c_str());
@@ -274,14 +274,8 @@ void declareSchemaType(py::module & mod) {
     );
     clsKey.def("isValid", &Key<T>::isValid);
     clsKey.def("getOffset", &Key<T>::getOffset);
-    clsKey.def(
-        "__repr__",
-        [](Key<T> const & self) -> std::string {
-            std::ostringstream os;
-            os << self;
-            return os.str();
-        }
-    );
+    clsKey.def("__str__", &streamStr<Key<T>>);
+    clsKey.def("__repr__", &streamStr<Key<T>>);
     // The Key methods below actually wrap templated methods on Schema and
     // SchemaMapper.  Rather than doing many-type overload resolution by
     // wrapping those methods directly, we use the visitor pattern by having
@@ -337,6 +331,12 @@ void declareSchemaType(py::module & mod) {
         "__len__",
         [](py::object const & self) -> int {
             return 2;
+        }
+    );
+    clsSchemaItem.def(
+        "__str__",
+        [](py::object const & self) -> py::str {
+            return py::str(py::tuple(self));
         }
     );
     clsSchemaItem.def(
@@ -448,11 +448,8 @@ void declareSchema(py::module & mod) {
                                      std::string const &,
                                      std::string const &) const) &Schema::join,
             "a"_a, "b"_a, "c"_a, "d"_a);
-    cls.def("__repr__", [](Schema const & self) {
-        std::ostringstream os;
-        os << self;
-        return os.str();
-    });
+    cls.def("__str__", &streamStr<Schema>);
+    cls.def("__repr__", &streamStr<Schema>);
 }
 
 void declareSubSchema(py::module & mod) {


### PR DESCRIPTION
This commit adds `__str__` and `__repr__` implementations from the pre-merge `.i` files, with the exception of `SchemaItem.__repr__` (version added during pybind11 cleanup supersedes Swig edition) and `CoordinateBase.*` (difficult to implement and of questionable value). Conforming to RFC-298 is outside the scope of the ticket; these are just the string representations that were previously visible to the stack.