### PR TITLE
DM-9764:  SOURCE_IO_NO_FOOTPRINTS and related enums should be properly wrapped in pybind11

### DIFF
--- a/python/lsst/afw/table/source/source.cc
+++ b/python/lsst/afw/table/source/source.cc
@@ -222,10 +222,12 @@ PYBIND11_PLUGIN(source) {
             return nullptr;
     };
 
-    py::enum_<SourceFitsFlags>(mod, "SourceFitsFlags")
-        .value("SOURCE_IO_NO_FOOTPRINTS", SourceFitsFlags::SOURCE_IO_NO_FOOTPRINTS)
-        .value("SOURCE_IO_NO_HEAVY_FOOTPRINTS", SourceFitsFlags::SOURCE_IO_NO_HEAVY_FOOTPRINTS)
-        .export_values();
+    // SourceFitsFlags enum values are used as integer masks, so wrap as attributes instead of an enum
+    // static_cast is required to avoid an import error (py::cast and py::int_ do not work by themselves
+    // and are not required with the static_cast)
+    mod.attr("SOURCE_IO_NO_FOOTPRINTS") = static_cast<int>(SourceFitsFlags::SOURCE_IO_NO_FOOTPRINTS);
+    mod.attr("SOURCE_IO_NO_HEAVY_FOOTPRINTS") =
+            static_cast<int>(SourceFitsFlags::SOURCE_IO_NO_HEAVY_FOOTPRINTS);
 
     auto clsSourceRecord = declareSourceRecord(mod);
     auto clsSourceTable = declareSourceTable(mod);


### PR DESCRIPTION
SourceFitsFlags values are used as ints so should be wrapped
as individual attributes instead of as an enum.
This proved slightly tricky because module-level enums cannot be
wrapped using `py::cast` or `py::int_` with our version of pybind11:
the code compiles but causes an import error.