### PR TITLE
DM-10105: Avoid loss of precision in Wcs persistence.

### DIFF
--- a/src/image/Wcs.cc
+++ b/src/image/Wcs.cc
@@ -1082,7 +1082,8 @@ void Wcs::write(OutputArchiveHandle & handle) const {
     WcsPersistenceHelper const & keys = WcsPersistenceHelper::get();
     afw::table::BaseCatalog catalog = handle.makeCatalog(keys.schema);
     PTR(afw::table::BaseRecord) record = catalog.addNew();
-    record->set(keys.crval, getSkyOrigin()->getPosition(afw::geom::degrees));
+    record->set(keys.crval.getX(), _wcsInfo[0].crval[0]);
+    record->set(keys.crval.getY(), _wcsInfo[0].crval[1]);
     record->set(keys.crpix, getPixelOrigin());
     Eigen::Matrix2d cdIn = getCDMatrix();
     Eigen::Map<Eigen::Matrix2d> cdOut((*record)[keys.cd].getData());

--- a/tests/testWcsFitsTable.py
+++ b/tests/testWcsFitsTable.py
@@ -192,6 +192,32 @@ class WcsFitsTableTestCase(unittest.TestCase):
             exp2 = lsst.afw.image.ExposureF(fileName)
             self.assertEqual(exp.getWcs(), exp2.getWcs())
 
+    def testSkyOriginPrecision(self):
+        """Test that we don't lose precision in CRVAL when round-tripping
+        (DM-10105), using a WCS in which we previously did.
+        """
+        metadata = lsst.daf.base.PropertyList()
+        metadata.add('CD1_1', -4.66666666666667e-05)
+        metadata.add('CD1_2', 0.0)
+        metadata.add('CD2_1', 0.0)
+        metadata.add('CD2_2', 4.66666666666667e-05)
+        metadata.add('CRPIX1', 18000.0)
+        metadata.add('CRPIX2', 18000.0)
+        metadata.add('CRVAL1', 247.5)
+        metadata.add('CRVAL2', -87.0247933884297)
+        metadata.add('CTYPE1', 'RA---TAN')
+        metadata.add('CTYPE2', 'DEC--TAN')
+        metadata.add('CUNIT1', 'deg')
+        metadata.add('CUNIT2', 'deg')
+        metadata.add('NAXIS', 2)
+        metadata.add('RADESYS', 'ICRS')
+        wcs1 = lsst.afw.image.makeWcs(metadata)
+        with lsst.utils.tests.getTempFilePath(".fits") as fileName:
+            wcs1.writeFits(fileName)
+            wcs2 = lsst.afw.image.Wcs.readFits(fileName)
+            self.assertEqual(wcs1, wcs2)
+
+
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):
     pass


### PR DESCRIPTION
The old implementation round-tripped CRVAL through radians because it used Angle, which resulted in a loss of precision and inexactly persisted WCSs.