### PR TITLE
DM-10292: The FrameSet returned by Transform.getFrameSet can change the contained FrameSet in Python

### DIFF
--- a/python/lsst/afw/geom/transform/transform.cc
+++ b/python/lsst/afw/geom/transform/transform.cc
@@ -84,7 +84,11 @@ void declareTransform(py::module &mod, std::string const &fromName, std::string 
     cls.def("hasInverse", &Class::hasInverse);
 
     cls.def("getFromEndpoint", &Class::getFromEndpoint);
-    cls.def("getFrameSet", &Class::getFrameSet);
+    // Return a copy of the contained FrameSet in order to assure changing the returned FrameSet
+    // will not affect the contained FrameSet (since Python ignores constness)
+    cls.def("getFrameSet", [](Class const &self) {
+        return self.getFrameSet()->copy();
+    });
     cls.def("getToEndpoint", &Class::getToEndpoint);
 
     cls.def("tranForward", (ToArray (Class::*)(FromArray const &) const) & Class::tranForward, "array"_a);

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -739,6 +739,19 @@ class TransformTestCase(lsst.utils.tests.TestCase):
                     self.checkOf(fromName, midName, toName)
         self.checkOfChaining()
 
+    def testFrameSetIndependence(self):
+        """Test that the FrameSet returned by getFrameSet is independent of the contained FrameSet
+        """
+        baseFrame = makeGoodFrame("Generic", 2)
+        currFrame = makeGoodFrame("Generic", 2)
+        initialFrameSet = makeFrameSet(baseFrame, currFrame)
+        initialIdent = "Initial Ident"
+        initialFrameSet.setIdent(initialIdent)
+        transform = afwGeom.TransformGenericToGeneric(initialFrameSet)
+        extractedFrameSet = transform.getFrameSet()
+        extractedFrameSet.setIdent("Extracted Ident")
+        self.assertEqual(initialIdent, transform.getFrameSet().getIdent())
+
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):
     pass


### PR DESCRIPTION
In Python make sure the FrameSet returned by Transform.getFrameSet
is independent of the contained FrameSet by returning a copy.
Add a test for this.
The C++ API is unchanged because it returns a const FrameSet.
(Python does not respect `const`).