### PR TITLE
Add cbegin, cend routines to Catalog.

### DIFF
--- a/include/lsst/afw/table/Catalog.h
+++ b/include/lsst/afw/table/Catalog.h
@@ -388,6 +388,8 @@ public:
     iterator end() { return iterator(_internal.end()); }
     const_iterator begin() const { return const_iterator(_internal.begin()); }
     const_iterator end() const { return const_iterator(_internal.end()); }
+    const_iterator cbegin() const { return begin(); }
+    const_iterator cend() const { return end(); }
     //@}
 
     /// Return true if the catalog has no records.


### PR DESCRIPTION
This is a duplicate of the const_iterator begin, end which formerly
existed.  This const protects the PTR(Record), but not the Record
contents.