### PR TITLE
DM-9939: Stop transposing data in Mapping.tranForward and tranInverse

### DIFF
--- a/include/lsst/afw/geom/Endpoint.h
+++ b/include/lsst/afw/geom/Endpoint.h
@@ -44,15 +44,13 @@ Endpoints transform points and lists of points from LSST-specific data types,
 such as Point2D and SpherePoint, to a form accepted by ast::Mapping.tran.
 Each type of endpoint is used for a particular LSST data type, for example:
 - Point2Endpoint is used for Point2D data
-- Point3Endpoint is used for Point3D data
 - SpherePointEndpoint for SpherePoint data
 - GenericEndpoint is used when no other form will do; its LSST data type
-  is identical to the type used for ast::Mapping.tran.
+  is identical to the type used for ast::Mapping.tranForward.
 
-Endpoints use the following form of data for ast::Mapping.tran
-(other forms are possible, but this is the one chosen):
+Endpoints use the following forms of data for raw data:
 - std::vector<double> for a single point
-- ndarray<double, 2, 2> for an array of points
+- ndarray<double, 2, 2> with dimensions number of axes x number of points for an array of points
 
 Endpoints are designed as helper classes for Transform. Each transform has a two endpoints:
 one for input data and one for output data.
@@ -99,8 +97,8 @@ public:
     Get raw data from an array of points
 
     @param[in] arr  Array of points
-    @returns the data as a 2-D ndarray array [nPoints, nAxes] in C order,
-        so the in-memory view is, for example, x0, y0, x1, y1, x2, y2, ...
+    @returns the data as a 2-D ndarray array [nAxes, nPoints] in C order,
+        so the in-memory view is, for example, x0, x1, x2, ..., y0, y1, y2, ...
 
     @throws lsst::pex::exceptions::InvalidParameterError if the array has the wrong nAxes dimension
     */
@@ -151,20 +149,22 @@ protected:
 
     void _assertNAxes(int nAxes) const;
 
-    int _getNAxes(ndarray::Array<double, 2, 2> const &data) const { return data.getSize<1>(); }
+    int _getNAxes(ndarray::Array<double, 2, 2> const &data) const { return data.getSize<0>(); }
 
     int _getNAxes(ndarray::Array<double, 1, 1> const &data) const { return data.getSize<0>(); }
 
     int _getNAxes(std::vector<double> const &data) const { return data.size(); }
 
-    int _getNPoints(ndarray::Array<double, 2, 2> const &data) const { return data.getSize<0>(); }
+    int _getNPoints(ndarray::Array<double, 2, 2> const &data) const { return data.getSize<1>(); }
 
 private:
     int _nAxes;  /// number of axes in a point
 };
 
 /**
-Base class for endpoints with Array = std::vector<Point>
+Base class for endpoints with Array = std::vector<Point> where Point has 2 dimensions
+
+@note Subclasses must provide `arrayFromData` 
 */
 template <typename PointT>
 class BaseVectorEndpoint : public BaseEndpoint<PointT, std::vector<PointT>> {
@@ -186,8 +186,6 @@ public:
     virtual ndarray::Array<double, 2, 2> dataFromArray(Array const &arr) const override;
 
     virtual Point pointFromData(std::vector<double> const &data) const override;
-
-    virtual Array arrayFromData(ndarray::Array<double, 2, 2> const &data) const override;
 
 protected:
     /**
@@ -224,7 +222,7 @@ public:
 
     virtual ~GenericEndpoint(){};
 
-    virtual int getNPoints(Array const &arr) const override { return arr.getSize<0>(); }
+    virtual int getNPoints(Array const &arr) const override { return arr.getSize<1>(); }
 
     virtual std::vector<double> dataFromPoint(Point const &point) const override;
 
@@ -236,25 +234,22 @@ public:
 };
 
 /**
-An endpoint for Point<double, N>
-
-@tparam N  number of axes in a point; the only allowed values are 2 or 3
+An endpoint for Point2D
 */
-template <int N>
-class PointEndpoint : public BaseVectorEndpoint<Point<double, N>> {
+class Point2Endpoint : public BaseVectorEndpoint<Point2D> {
 public:
-    PointEndpoint(PointEndpoint const &) = default;
-    PointEndpoint(PointEndpoint &&) = default;
-    PointEndpoint &operator=(PointEndpoint const &) = default;
-    PointEndpoint &operator=(PointEndpoint &&) = default;
+    Point2Endpoint(Point2Endpoint const &) = default;
+    Point2Endpoint(Point2Endpoint &&) = default;
+    Point2Endpoint &operator=(Point2Endpoint const &) = default;
+    Point2Endpoint &operator=(Point2Endpoint &&) = default;
 
     /**
-    Construct a PointEndpoint
+    Construct a Point2Endpoint
     */
-    explicit PointEndpoint() : BaseVectorEndpoint<Point<double, N>>(N) {}
+    explicit Point2Endpoint() : BaseVectorEndpoint<Point2D>(2) {}
 
     /**
-    Construct a PointEndpoint with nAxes specified; nAxes must equal template parameter N
+    Construct a Point2Endpoint with nAxes specified; nAxes must equal template parameter N
 
     This constructor is primarily used by Transform; other users are encouraged
     to use the default constructor.
@@ -263,14 +258,16 @@ public:
 
     @throws lsst.pex.exceptions.InvalidParameterError if nAxes != N
     */
-    explicit PointEndpoint(int nAxes);
+    explicit Point2Endpoint(int nAxes);
 
-    virtual ~PointEndpoint(){};
+    virtual ~Point2Endpoint(){};
+
+    virtual Array arrayFromData(ndarray::Array<double, 2, 2> const &data) const override;
 
     /**
     Check that framePtr points to a Frame, not a subclass
 
-    Subclasses are forbidden because Point<double, N> is assumed to be cartesian
+    Subclasses are forbidden because Point2D is assumed to be cartesian
     and subclasses of Frame are not (e.g. SkyFrame, SpecFrame and TimeFrame).
     Note that SpecFrame and TimeFrame are 1-dimensional so they cannot be used
     in any case. A CmpFrame could be cartesian, but we play it safe and reject these
@@ -278,10 +275,6 @@ public:
     */
     virtual void normalizeFrame(std::shared_ptr<ast::Frame> framePtr) const override;
 };
-
-// Aliases for the only allowed <N> of PointEndpoint
-using Point2Endpoint = PointEndpoint<2>;
-using Point3Endpoint = PointEndpoint<3>;
 
 /**
 An endpoint for SpherePoint
@@ -314,6 +307,8 @@ public:
 
     virtual ~SpherePointEndpoint(){};
 
+    virtual Array arrayFromData(ndarray::Array<double, 2, 2> const &data) const override;
+
     /**
     Create a Frame that can be used with this end point in a Transform
     */
@@ -332,9 +327,6 @@ std::ostream &operator<<(std::ostream &os, GenericEndpoint const &endpoint);
 
 /// Print "Point2Endpoint()" to the ostream
 std::ostream &operator<<(std::ostream &os, Point2Endpoint const &endpoint);
-
-/// Print "Point3Endpoint()" to the ostream
-std::ostream &operator<<(std::ostream &os, Point3Endpoint const &endpoint);
 
 /// Print "SpherePointEndpoint()" to the ostream
 std::ostream &operator<<(std::ostream &os, SpherePointEndpoint const &endpoint);

--- a/include/lsst/afw/geom/Transform.h
+++ b/include/lsst/afw/geom/Transform.h
@@ -145,6 +145,10 @@ public:
 
     /**
     Transform an array of points in the forward direction ("from" to "to")
+
+    The first dimension of the array must match the number of input axes, and the data order is
+    values for the first axis, then values for the next axis, and so on, e.g. for 2 axes:
+        x0, x1, x2, ..., y0, y1, y2...
     */
     ToArray tranForward(FromArray const &array) const;
 
@@ -155,6 +159,10 @@ public:
 
     /**
     Transform an array of points in the inverse direction ("to" to "from")
+
+    The first dimension of the array must match the number of output axes, and the data order is
+    values for the first axis, then values for the next axis, and so on, e.g. for 2 axes:
+        x0, x1, x2, ..., y0, y1, y2...
     */
     FromArray tranInverse(ToArray const &array) const;
 
@@ -230,7 +238,7 @@ Print a Transform to an ostream
 
 The format is "Transform<_fromEndpoint_, _toEndpoint_>"
 where _fromEndpoint_ and _toEndpoint_ are the appropriate endpoint printed to the ostream;
-for example "Transform<GenericEndpoint(4), Point3Endpoint()>"
+for example "Transform<GenericEndpoint(4), Point2Endpoint()>"
 */
 template <class FromEndpoint, class ToEndpoint>
 std::ostream &operator<<(std::ostream &os, Transform<FromEndpoint, ToEndpoint> const &transform);

--- a/python/lsst/afw/geom/endpoint.cc
+++ b/python/lsst/afw/geom/endpoint.cc
@@ -107,8 +107,7 @@ void addEquals(PyClass& cls) {
 template <typename SelfClass, typename PyClass>
 void addAllEquals(PyClass& cls) {
     addEquals<SelfClass, GenericEndpoint>(cls);
-    addEquals<SelfClass, PointEndpoint<2>>(cls);
-    addEquals<SelfClass, PointEndpoint<3>>(cls);
+    addEquals<SelfClass, Point2Endpoint>(cls);
     addEquals<SelfClass, SpherePointEndpoint>(cls);
 }
 
@@ -161,11 +160,10 @@ void declareGenericEndpoint(py::module& mod) {
 }
 
 /// @internal declare PointNEndpoint (for N = 2 or 3) and all subclasses
-template <int N>
-void declarePointEndpoint(py::module& mod) {
-    using Class = PointEndpoint<N>;
+void declarePoint2Endpoint(py::module& mod) {
+    using Class = Point2Endpoint;
     using Point = typename Class::Point;
-    std::string const pointNumStr = "Point" + std::to_string(N);
+    std::string const pointNumStr = "Point2";
     std::string const pyClassName = pointNumStr + "Endpoint";
 
     declareBaseVectorEndpoint<Point>(mod, pointNumStr);
@@ -209,8 +207,7 @@ PYBIND11_PLUGIN(endpoint) {
     }
 
     declareGenericEndpoint(mod);
-    declarePointEndpoint<2>(mod);
-    declarePointEndpoint<3>(mod);
+    declarePoint2Endpoint(mod);
     declareSpherePointEndpoint(mod);
 
     return mod.ptr();

--- a/python/lsst/afw/geom/python/transform.py
+++ b/python/lsst/afw/geom/python/transform.py
@@ -31,8 +31,8 @@ lsst::afw::geom::Transform<FromEndpoint, ToEndpoint>
 and subclasses, such as lsst::afw::geom::SkyWcs.
 
 In Python the templated Transform classes have names such as
-`lsst.afw.geom.TransformSpherePointToPoint3` for
-`lsst::afw::geom::Transform<SpherePointEndpoint, Point3Endpoint>`
+`lsst.afw.geom.TransformSpherePointToPoint2` for
+`lsst::afw::geom::Transform<SpherePointEndpoint, Point2Endpoint>`
 """
 
 from __future__ import absolute_import, division, print_function

--- a/python/lsst/afw/geom/transform/transform.cc
+++ b/python/lsst/afw/geom/transform/transform.cc
@@ -42,7 +42,7 @@ namespace geom {
 namespace {
 
 // Return a string consisting of "_pythonClassName_[_fromNAxes_->_toNAxes_]",
-// for example "TransformGenericToPoint3[4->3]"
+// for example "TransformGenericToPoint2[4->2]"
 template <class Class>
 std::string formatStr(Class const &self, std::string const &pyClassName) {
     std::ostringstream os;
@@ -65,7 +65,7 @@ void declareMethodTemplates(PyClass &cls) {
 
 // Declare Transform<FromEndpoint, ToEndpoint> using python class name TransformFrom<X>To<Y>
 // where <X> and <Y> are the name of the from endpoint and to endpoint class, respectively,
-// for example TransformFromGenericToPoint3
+// for example TransformFromGenericToPoint2
 template <class FromEndpoint, class ToEndpoint>
 void declareTransform(py::module &mod, std::string const &fromName, std::string const &toName) {
     using Class = Transform<FromEndpoint, ToEndpoint>;
@@ -101,7 +101,6 @@ void declareTransform(py::module &mod, std::string const &fromName, std::string 
 
     declareMethodTemplates<GenericEndpoint, FromEndpoint, ToEndpoint>(cls);
     declareMethodTemplates<Point2Endpoint, FromEndpoint, ToEndpoint>(cls);
-    declareMethodTemplates<Point3Endpoint, FromEndpoint, ToEndpoint>(cls);
     declareMethodTemplates<SpherePointEndpoint, FromEndpoint, ToEndpoint>(cls);
 
     // str(self) = "<Python class name>[<nIn>-><nOut>]"
@@ -125,19 +124,12 @@ PYBIND11_PLUGIN(transform) {
 
     declareTransform<GenericEndpoint, GenericEndpoint>(mod, "Generic", "Generic");
     declareTransform<GenericEndpoint, Point2Endpoint>(mod, "Generic", "Point2");
-    declareTransform<GenericEndpoint, Point3Endpoint>(mod, "Generic", "Point3");
     declareTransform<GenericEndpoint, SpherePointEndpoint>(mod, "Generic", "SpherePoint");
     declareTransform<Point2Endpoint, GenericEndpoint>(mod, "Point2", "Generic");
     declareTransform<Point2Endpoint, Point2Endpoint>(mod, "Point2", "Point2");
-    declareTransform<Point2Endpoint, Point3Endpoint>(mod, "Point2", "Point3");
     declareTransform<Point2Endpoint, SpherePointEndpoint>(mod, "Point2", "SpherePoint");
-    declareTransform<Point3Endpoint, GenericEndpoint>(mod, "Point3", "Generic");
-    declareTransform<Point3Endpoint, Point2Endpoint>(mod, "Point3", "Point2");
-    declareTransform<Point3Endpoint, Point3Endpoint>(mod, "Point3", "Point3");
-    declareTransform<Point3Endpoint, SpherePointEndpoint>(mod, "Point3", "SpherePoint");
     declareTransform<SpherePointEndpoint, GenericEndpoint>(mod, "SpherePoint", "Generic");
     declareTransform<SpherePointEndpoint, Point2Endpoint>(mod, "SpherePoint", "Point2");
-    declareTransform<SpherePointEndpoint, Point3Endpoint>(mod, "SpherePoint", "Point3");
     declareTransform<SpherePointEndpoint, SpherePointEndpoint>(mod, "SpherePoint", "SpherePoint");
 
     return mod.ptr();

--- a/python/lsst/afw/geom/transform/transformContinued.py
+++ b/python/lsst/afw/geom/transform/transformContinued.py
@@ -26,7 +26,7 @@ from . import transform
 
 __all__ = []
 
-endpoints = ("Generic", "Point2", "Point3", "SpherePoint")
+endpoints = ("Generic", "Point2", "SpherePoint")
 
 for fromPoint in endpoints:
     for toPoint in endpoints:

--- a/python/lsst/afw/geom/utils.py
+++ b/python/lsst/afw/geom/utils.py
@@ -38,7 +38,7 @@ import numpy as np
 
 import lsst.utils.tests
 from .angle import arcseconds
-from .endpoint import GenericEndpoint, Point2Endpoint, Point3Endpoint, SpherePointEndpoint
+from .endpoint import GenericEndpoint, Point2Endpoint, SpherePointEndpoint
 
 
 def extraMsg(msg):
@@ -208,7 +208,7 @@ def makeEndpoints(testCase):
         code. Each invocation of this method shall return independent objects.
     """
     return [GenericEndpoint(n) for n in range(1, 6)] + \
-           [Point2Endpoint(), Point3Endpoint(), SpherePointEndpoint()]
+           [Point2Endpoint(), SpherePointEndpoint()]
 
 
 @lsst.utils.tests.inTestCase

--- a/src/geom/Transform.cc
+++ b/src/geom/Transform.cc
@@ -166,7 +166,6 @@ std::ostream &operator<<(std::ostream &os, Transform<FromEndpoint, ToEndpoint> c
     template class Transform<FromEndpoint, ToEndpoint>;                  \
     INSTANTIATE_OVERLOADS(FromEndpoint, ToEndpoint, GenericEndpoint)     \
     INSTANTIATE_OVERLOADS(FromEndpoint, ToEndpoint, Point2Endpoint)      \
-    INSTANTIATE_OVERLOADS(FromEndpoint, ToEndpoint, Point3Endpoint)      \
     INSTANTIATE_OVERLOADS(FromEndpoint, ToEndpoint, SpherePointEndpoint) \
     template std::ostream &operator<<<FromEndpoint, ToEndpoint>(         \
             std::ostream &os, Transform<FromEndpoint, ToEndpoint> const &transform);
@@ -174,19 +173,12 @@ std::ostream &operator<<(std::ostream &os, Transform<FromEndpoint, ToEndpoint> c
 // explicit instantiations
 INSTANTIATE_TRANSFORM(GenericEndpoint, GenericEndpoint);
 INSTANTIATE_TRANSFORM(GenericEndpoint, Point2Endpoint);
-INSTANTIATE_TRANSFORM(GenericEndpoint, Point3Endpoint);
 INSTANTIATE_TRANSFORM(GenericEndpoint, SpherePointEndpoint);
 INSTANTIATE_TRANSFORM(Point2Endpoint, GenericEndpoint);
 INSTANTIATE_TRANSFORM(Point2Endpoint, Point2Endpoint);
-INSTANTIATE_TRANSFORM(Point2Endpoint, Point3Endpoint);
 INSTANTIATE_TRANSFORM(Point2Endpoint, SpherePointEndpoint);
-INSTANTIATE_TRANSFORM(Point3Endpoint, GenericEndpoint);
-INSTANTIATE_TRANSFORM(Point3Endpoint, Point2Endpoint);
-INSTANTIATE_TRANSFORM(Point3Endpoint, Point3Endpoint);
-INSTANTIATE_TRANSFORM(Point3Endpoint, SpherePointEndpoint);
 INSTANTIATE_TRANSFORM(SpherePointEndpoint, GenericEndpoint);
 INSTANTIATE_TRANSFORM(SpherePointEndpoint, Point2Endpoint);
-INSTANTIATE_TRANSFORM(SpherePointEndpoint, Point3Endpoint);
 INSTANTIATE_TRANSFORM(SpherePointEndpoint, SpherePointEndpoint);
 
 }  // geom


### PR DESCRIPTION
astshim point data is now in standard AST order:
x0, x1, ...xnPts, y0, y1, ..., ynPts, ...
which is the transposition of the previous order.
Update Transform and Endpoint accordingly.
Drop support for Point3Endpoint because it will require extra code
and we have no immediate use case.