### PR TITLE
DM-10541: Add properties to image classes

### DIFF
--- a/include/lsst/afw/image/MaskedImage.h
+++ b/include/lsst/afw/image/MaskedImage.h
@@ -959,8 +959,35 @@ public:
     /// Return a (shared_ptr to) the MaskedImage's %image
     ImagePtr getImage() const { return _image; }
 
+    /**
+     *  Set the image plane's pixel values to those of another Image.
+     *
+     *  This copies pixel values, not pointers.
+     *
+     *  @throws pex::exceptions::LengthError if dimensions do not match.
+     */
+    void setImage(Image const & other) { _image->assign(other); }
+
     /// Return a (shared_ptr to) the MaskedImage's %mask
     MaskPtr getMask() const { return _mask; }
+
+    /**
+     *  Set the mask plane's pixel values to those of another Mask.
+     *
+     *  This copies pixel values, not pointers.
+     *
+     *  @throws pex::exceptions::LengthError if dimensions do not match.
+     */
+    void setMask(Mask const & other) { _mask->assign(other); }
+
+    /**
+     *  Set the variance plane's pixel values to those of another Image.
+     *
+     *  This copies pixel values, not pointers.
+     *
+     *  @throws pex::exceptions::LengthError if dimensions do not match.
+     */
+    void setVariance(Variance const & other) { _variance->assign(other); }
 
     /// Return a (shared_ptr to) the MaskedImage's variance
     VariancePtr getVariance() const { return _variance; }

--- a/include/lsst/afw/image/MaskedImage.h
+++ b/include/lsst/afw/image/MaskedImage.h
@@ -955,29 +955,16 @@ public:
     }
 
     // Getters
-    /// Return a (Ptr to) the MaskedImage's %image
-    ImagePtr getImage(bool const noThrow = false) const {
-        if (!_image && !noThrow) {
-            throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError, "MaskedImage's Image is NULL");
-        }
-        return _image;
-    }
-    /// Return a (Ptr to) the MaskedImage's %mask
-    MaskPtr getMask(bool const noThrow = false) const {
-        if (!_mask && !noThrow) {
-            throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError, "MaskedImage's Mask is NULL");
-        }
 
-        return _mask;
-    }
-    /// Return a (Ptr to) the MaskedImage's variance
-    VariancePtr getVariance(bool const noThrow = false) const {
-        if (!_variance && !noThrow) {
-            throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError, "MaskedImage's Variance is NULL");
-        }
+    /// Return a (shared_ptr to) the MaskedImage's %image
+    ImagePtr getImage() const { return _image; }
 
-        return _variance;
-    }
+    /// Return a (shared_ptr to) the MaskedImage's %mask
+    MaskPtr getMask() const { return _mask; }
+
+    /// Return a (shared_ptr to) the MaskedImage's variance
+    VariancePtr getVariance() const { return _variance; }
+
     /// Return the number of columns in the %image
     int getWidth() const { return _image->getWidth(); }
     /// Return the number of rows in the %image

--- a/python/lsst/afw/display/interface.py
+++ b/python/lsst/afw/display/interface.py
@@ -432,7 +432,7 @@ class Display(object):
             self._impl._mtv(afwImage.ImageU(data.getArray()), data, wcs, title)
         # it's a MaskedImage; display Image and overlay Mask
         elif isinstance(data, afwImage.MaskedImage):
-            self._impl._mtv(data.getImage(), data.getMask(True), wcs, title)
+            self._impl._mtv(data.getImage(), data.getMask(), wcs, title)
         else:
             raise RuntimeError("Unsupported type %s" % repr(data))
     #

--- a/python/lsst/afw/image/exposure/exposure.cc
+++ b/python/lsst/afw/image/exposure/exposure.cc
@@ -85,6 +85,11 @@ PyExposure<PixelT> declareExposure(py::module &mod, const std::string &suffix) {
     /* Members */
     cls.def("getMaskedImage", (MaskedImageT (ExposureT::*)()) & ExposureT::getMaskedImage);
     cls.def("setMaskedImage", &ExposureT::setMaskedImage, "maskedImage"_a);
+    cls.def_property(
+        "maskedImage",
+        (MaskedImageT (ExposureT::*)()) & ExposureT::getMaskedImage,
+        &ExposureT::setMaskedImage
+    );
     cls.def("getMetadata", &ExposureT::getMetadata);
     cls.def("setMetadata", &ExposureT::setMetadata, "metadata"_a);
     cls.def("getWidth", &ExposureT::getWidth);

--- a/python/lsst/afw/image/exposure/exposureContinued.py
+++ b/python/lsst/afw/image/exposure/exposureContinued.py
@@ -60,6 +60,30 @@ class Exposure(with_metaclass(TemplateMeta, object)):
     def __setitem__(self, imageSlice, rhs):
         self.getMaskedImage[imageSlice] = rhs.getMaskedImage()
 
+    def getImage(self):
+        return self.maskedImage.image
+
+    def setImage(self, image):
+        self.maskedImage.image = image
+
+    image = property(getImage, setImage)
+
+    def getMask(self):
+        return self.maskedImage.mask
+
+    def setMask(self, mask):
+        self.maskedImage.mask = mask
+
+    mask = property(getMask, setMask)
+
+    def getVariance(self):
+        return self.maskedImage.variance
+
+    def setVariance(self, variance):
+        self.maskedImage.variance = variance
+
+    variance = property(getVariance, setVariance)
+
 
 Exposure.register(np.int32, ExposureI)
 Exposure.register(np.float32, ExposureF)

--- a/python/lsst/afw/image/image/image.cc
+++ b/python/lsst/afw/image/image/image.cc
@@ -90,8 +90,11 @@ static void declareImageBase(py::module &mod, std::string const &suffix) {
     cls.def_property(
         "array",
         (Array (ImageBase<PixelT>::*)()) & ImageBase<PixelT>::getArray,
-        [](py::object const & self, py::object const & array) {
-            self.attr("array")[py::slice(py::none())] = array;
+        [](ImageBase<PixelT> & self, ndarray::Array<PixelT const,2,0> const & array) {
+            // Avoid self-assignment, which is invoked when a Python in-place operator is used.
+            if (array.shallow() != self.getArray().shallow()) {
+                self.getArray().deep() = array;
+            }
         }
     );
     cls.def("setXY0", (void (ImageBase<PixelT>::*)(geom::Point2I const)) & ImageBase<PixelT>::setXY0,

--- a/python/lsst/afw/image/image/image.cc
+++ b/python/lsst/afw/image/image/image.cc
@@ -87,6 +87,13 @@ static void declareImageBase(py::module &mod, std::string const &suffix) {
     cls.def("indexToPosition", &ImageBase<PixelT>::indexToPosition, "index"_a, "xOrY"_a);
     cls.def("getDimensions", &ImageBase<PixelT>::getDimensions);
     cls.def("getArray", (Array (ImageBase<PixelT>::*)()) & ImageBase<PixelT>::getArray);
+    cls.def_property(
+        "array",
+        (Array (ImageBase<PixelT>::*)()) & ImageBase<PixelT>::getArray,
+        [](py::object const & self, py::object const & array) {
+            self.attr("array")[py::slice(py::none())] = array;
+        }
+    );
     cls.def("setXY0", (void (ImageBase<PixelT>::*)(geom::Point2I const)) & ImageBase<PixelT>::setXY0,
             "xy0"_a);
     cls.def("setXY0", (void (ImageBase<PixelT>::*)(int const, int const)) & ImageBase<PixelT>::setXY0, "x0"_a,

--- a/python/lsst/afw/image/maskedImage/maskedImage.cc
+++ b/python/lsst/afw/image/maskedImage/maskedImage.cc
@@ -148,10 +148,13 @@ PyMaskedImage<ImagePixelT> declareMaskedImage(py::module &mod, const std::string
     cls.def_static("readFits", (MI(*)(fits::MemFileManager &))MI::readFits, "manager"_a);
     cls.def("getImage", &MI::getImage);
     cls.def("setImage", &MI::setImage);
+    cls.def_property("image", &MI::getImage, &MI::setImage);
     cls.def("getMask", &MI::getMask);
     cls.def("setMask", &MI::setMask);
+    cls.def_property("mask", &MI::getMask, &MI::setMask);
     cls.def("getVariance", &MI::getVariance);
     cls.def("setVariance", &MI::setVariance);
+    cls.def_property("variance", &MI::getVariance, &MI::setVariance);
     cls.def("getWidth", &MI::getWidth);
     cls.def("getHeight", &MI::getHeight);
     cls.def("getDimensions", &MI::getDimensions);

--- a/python/lsst/afw/image/maskedImage/maskedImage.cc
+++ b/python/lsst/afw/image/maskedImage/maskedImage.cc
@@ -146,9 +146,9 @@ PyMaskedImage<ImagePixelT> declareMaskedImage(py::module &mod, const std::string
 
     cls.def_static("readFits", (MI(*)(std::string const &))MI::readFits, "filename"_a);
     cls.def_static("readFits", (MI(*)(fits::MemFileManager &))MI::readFits, "manager"_a);
-    cls.def("getImage", &MI::getImage, "noThrow"_a = false);
-    cls.def("getMask", &MI::getMask, "noThrow"_a = false);
-    cls.def("getVariance", &MI::getVariance, "noThrow"_a = false);
+    cls.def("getImage", &MI::getImage);
+    cls.def("getMask", &MI::getMask);
+    cls.def("getVariance", &MI::getVariance);
     cls.def("getWidth", &MI::getWidth);
     cls.def("getHeight", &MI::getHeight);
     cls.def("getDimensions", &MI::getDimensions);

--- a/python/lsst/afw/image/maskedImage/maskedImage.cc
+++ b/python/lsst/afw/image/maskedImage/maskedImage.cc
@@ -147,8 +147,11 @@ PyMaskedImage<ImagePixelT> declareMaskedImage(py::module &mod, const std::string
     cls.def_static("readFits", (MI(*)(std::string const &))MI::readFits, "filename"_a);
     cls.def_static("readFits", (MI(*)(fits::MemFileManager &))MI::readFits, "manager"_a);
     cls.def("getImage", &MI::getImage);
+    cls.def("setImage", &MI::setImage);
     cls.def("getMask", &MI::getMask);
+    cls.def("setMask", &MI::setMask);
     cls.def("getVariance", &MI::getVariance);
+    cls.def("setVariance", &MI::setVariance);
     cls.def("getWidth", &MI::getWidth);
     cls.def("getHeight", &MI::getHeight);
     cls.def("getDimensions", &MI::getDimensions);

--- a/tests/testExposure.py
+++ b/tests/testExposure.py
@@ -154,6 +154,17 @@ class ExposureTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(crOnlyWidth, self.exposureCrOnly.getWidth())
         self.assertEqual(crOnlyHeight, self.exposureCrOnly.getHeight())
 
+
+    def testProperties(self):
+        self.assertMaskedImagesEqual(self.exposureMiOnly.maskedImage,
+                                     self.exposureMiOnly.getMaskedImage())
+        mi2 = afwImage.MaskedImageF(self.exposureMiOnly.getDimensions())
+        mi2.image.array = 5.0
+        mi2.variance.array = 3.0
+        mi2.mask.array = 0x1
+        self.exposureMiOnly.maskedImage = mi2
+        self.assertMaskedImagesEqual(self.exposureMiOnly.maskedImage, mi2)
+
     def testGetWcs(self):
         """
         Test if a WCS can be obtained from each Exposure created with

--- a/tests/testExposure.py
+++ b/tests/testExposure.py
@@ -158,26 +158,26 @@ class ExposureTestCase(lsst.utils.tests.TestCase):
         self.assertMaskedImagesEqual(self.exposureMiOnly.maskedImage,
                                      self.exposureMiOnly.getMaskedImage())
         mi2 = afwImage.MaskedImageF(self.exposureMiOnly.getDimensions())
-        mi2.image.array = 5.0
-        mi2.variance.array = 3.0
-        mi2.mask.array = 0x1
+        mi2.image.array[:] = 5.0
+        mi2.variance.array[:] = 3.0
+        mi2.mask.array[:] = 0x1
         self.exposureMiOnly.maskedImage = mi2
         self.assertMaskedImagesEqual(self.exposureMiOnly.maskedImage, mi2)
         self.assertImagesEqual(self.exposureMiOnly.image,
                                self.exposureMiOnly.maskedImage.image)
 
         image3 = afwImage.ImageF(self.exposureMiOnly.getDimensions())
-        image3.array = 3.0
+        image3.array[:] = 3.0
         self.exposureMiOnly.image = image3
         self.assertImagesEqual(self.exposureMiOnly.image, image3)
 
         mask3 = afwImage.MaskU(self.exposureMiOnly.getDimensions())
-        mask3.array = 0x2
+        mask3.array[:] = 0x2
         self.exposureMiOnly.mask = mask3
         self.assertMasksEqual(self.exposureMiOnly.mask, mask3)
 
         var3 = afwImage.ImageF(self.exposureMiOnly.getDimensions())
-        var3.array = 2.0
+        var3.array[:] = 2.0
         self.exposureMiOnly.variance = var3
         self.assertImagesEqual(self.exposureMiOnly.variance, var3)
 

--- a/tests/testExposure.py
+++ b/tests/testExposure.py
@@ -154,7 +154,6 @@ class ExposureTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(crOnlyWidth, self.exposureCrOnly.getWidth())
         self.assertEqual(crOnlyHeight, self.exposureCrOnly.getHeight())
 
-
     def testProperties(self):
         self.assertMaskedImagesEqual(self.exposureMiOnly.maskedImage,
                                      self.exposureMiOnly.getMaskedImage())
@@ -164,6 +163,23 @@ class ExposureTestCase(lsst.utils.tests.TestCase):
         mi2.mask.array = 0x1
         self.exposureMiOnly.maskedImage = mi2
         self.assertMaskedImagesEqual(self.exposureMiOnly.maskedImage, mi2)
+        self.assertImagesEqual(self.exposureMiOnly.image,
+                               self.exposureMiOnly.maskedImage.image)
+
+        image3 = afwImage.ImageF(self.exposureMiOnly.getDimensions())
+        image3.array = 3.0
+        self.exposureMiOnly.image = image3
+        self.assertImagesEqual(self.exposureMiOnly.image, image3)
+
+        mask3 = afwImage.MaskU(self.exposureMiOnly.getDimensions())
+        mask3.array = 0x2
+        self.exposureMiOnly.mask = mask3
+        self.assertMasksEqual(self.exposureMiOnly.mask, mask3)
+
+        var3 = afwImage.ImageF(self.exposureMiOnly.getDimensions())
+        var3.array = 2.0
+        self.exposureMiOnly.variance = var3
+        self.assertImagesEqual(self.exposureMiOnly.variance, var3)
 
     def testGetWcs(self):
         """

--- a/tests/testImage.py
+++ b/tests/testImage.py
@@ -106,11 +106,23 @@ class ImageTestCase(lsst.utils.tests.TestCase):
             self.assertEqual(array1.shape[0], image2.getHeight())
             self.assertEqual(array1.shape[1], image2.getWidth())
             self.assertEqual(type(image3), cls)
+            array2 = image1.array
+            np.testing.assert_array_equal(array1, array2)
             array1[:, :] = np.random.uniform(low=0, high=10, size=array1.shape)
             for j in range(image1.getHeight()):
                 for i in range(image1.getWidth()):
                     self.assertEqual(image1.get(i, j), array1[j, i])
                     self.assertEqual(image2.get(i, j), array1[j, i])
+            array3 = np.random.uniform(low=0, high=10,
+                                       size=array1.shape).astype(array1.dtype)
+            image1.array = array3
+            np.testing.assert_array_equal(array1, array3)
+            image1.array[2:4, 3:] = 10
+            np.testing.assert_array_equal(array1[2:4, 3:], 10)
+            array4 = image1.array.copy()
+            array4 += 5
+            image1.array += 5
+            np.testing.assert_array_equal(image1.array, array4)
 
     def testInitializeImages(self):
         val = 666

--- a/tests/testImage.py
+++ b/tests/testImage.py
@@ -115,7 +115,7 @@ class ImageTestCase(lsst.utils.tests.TestCase):
                     self.assertEqual(image2.get(i, j), array1[j, i])
             array3 = np.random.uniform(low=0, high=10,
                                        size=array1.shape).astype(array1.dtype)
-            image1.array = array3
+            image1.array[:] = array3
             np.testing.assert_array_equal(array1, array3)
             image1.array[2:4, 3:] = 10
             np.testing.assert_array_equal(array1[2:4, 3:], 10)

--- a/tests/testMask.py
+++ b/tests/testMask.py
@@ -132,6 +132,12 @@ class MaskTestCase(utilsTests.TestCase):
         self.assertEqual(type(image3), afwImage.MaskU)
         array1[:, :] = np.random.uniform(low=0, high=10, size=array1.shape)
         self.assertMasksEqual(image1, array1)
+        array2 = image1.array
+        np.testing.assert_array_equal(image1.array, array2)
+        array3 = np.random.uniform(low=0, high=10,
+                                   size=array1.shape).astype(array1.dtype)
+        image1.array = array3
+        np.testing.assert_array_equal(array1, array3)
 
     def testInitializeMasks(self):
         val = 0x1234

--- a/tests/testMaskedImage.py
+++ b/tests/testMaskedImage.py
@@ -127,6 +127,23 @@ class MaskedImageTestCase(lsst.utils.tests.TestCase):
         mimage2 = afwImage.makeMaskedImageFromArrays(image, mask, variance)
         self.assertEqual(type(mimage2), type(self.mimage))
 
+    def testProperties(self):
+        self.assertImagesEqual(self.mimage.image, self.mimage.getImage())
+        self.assertMasksEqual(self.mimage.mask, self.mimage.getMask())
+        self.assertImagesEqual(self.mimage.variance, self.mimage.getVariance())
+        image2 = self.mimage.image.Factory(self.mimage.getDimensions())
+        image2.array = 5.0
+        self.mimage.image = image2
+        self.assertImagesEqual(self.mimage.image, image2)
+        mask2 = self.mimage.mask.Factory(self.mimage.getDimensions())
+        mask2.array = 0x4
+        self.mimage.mask = mask2
+        self.assertMasksEqual(self.mimage.mask, mask2)
+        var2 = self.mimage.image.Factory(self.mimage.getDimensions())
+        var2.array = 3.0
+        self.mimage.variance = var2
+        self.assertImagesEqual(self.mimage.variance, var2)
+
     def testSetGetValues(self):
         self.assertEqual(self.mimage.get(0, 0),
                          (self.imgVal1, self.EDGE, self.varVal1))

--- a/tests/testMaskedImage.py
+++ b/tests/testMaskedImage.py
@@ -132,15 +132,15 @@ class MaskedImageTestCase(lsst.utils.tests.TestCase):
         self.assertMasksEqual(self.mimage.mask, self.mimage.getMask())
         self.assertImagesEqual(self.mimage.variance, self.mimage.getVariance())
         image2 = self.mimage.image.Factory(self.mimage.getDimensions())
-        image2.array = 5.0
+        image2.array[:] = 5.0
         self.mimage.image = image2
         self.assertImagesEqual(self.mimage.image, image2)
         mask2 = self.mimage.mask.Factory(self.mimage.getDimensions())
-        mask2.array = 0x4
+        mask2.array[:] = 0x4
         self.mimage.mask = mask2
         self.assertMasksEqual(self.mimage.mask, mask2)
         var2 = self.mimage.image.Factory(self.mimage.getDimensions())
-        var2.array = 3.0
+        var2.array[:] = 3.0
         self.mimage.variance = var2
         self.assertImagesEqual(self.mimage.variance, var2)
 


### PR DESCRIPTION
This adds:
 - `array` properties to `ImageBase` (and hence both `Image` and `Mask`).  The setters for these properties delegate to NumPy, so they can accept any value `NumPy` accepts when assigning to an array (including arrays with different types and scalars).
 - `image`, `mask`, and `variance` properties for `MaskedImage`.  The setters for these require `Image` and `Mask` objects of the appropriate (so you have to say `.image.array = value` to coerce types or assign scalars).
 - `setImage`, `setMask`, and `setVariance` to `MaskedImage`, for consistency with `Exposure.setMaskedImage` and the properties.
 - a `maskedImage` property for `Exposure`.  The setter requires a `MaskedImage` of the appropriate type.
 - Getters and setters for the image, mask, and variance of `Exposure` that just delegate to the getters and setters for `MaskedImage`.
 - `image`, `mask`, and `variance` properties for `Exposure`, using the just-added getters and setters.

I've also removed a useless and almost unused argument in the `MaskedImage` getters; it was intended to change the error-handling behavior when null pointers are encountered, but the `MaskedImage` constructors guarantee (and indeed, most of our code assumes) that those pointers can never be null.