### PR TITLE
DM-10552 Upgrade display_firefly to work with more servers

### DIFF
--- a/python/lsst/afw/display/interface.py
+++ b/python/lsst/afw/display/interface.py
@@ -193,8 +193,20 @@ class Display(object):
     def __del__(self):
         self.close()
 
-    def __getattr__(self, name, *args, **kwargs):
-        """Try to call self._impl.name(*args, *kwargs)"""
+    def __getattr__(self, name):
+        """Return the attribute of self._impl, or ._impl if it is requested
+        Parameters:
+        -----------
+            name : string
+                name of the attribute requested
+        Returns:
+        --------
+            attribute : object
+                the attribute of self._impl for the requested name
+        """
+
+        if name == '_impl':
+            return object.__getattr__(self, name)
 
         if not (hasattr(self, "_impl") and self._impl):
             raise AttributeError("Device has no _impl attached")

--- a/tests/testDisplay.py
+++ b/tests/testDisplay.py
@@ -65,17 +65,6 @@ class DisplayTestCase(unittest.TestCase):
             dirName, "data", "HSC-0908120-056-small.fits")
         self.display0 = afwDisplay.getDisplay(frame=0, verbose=True)
 
-    def tearDown(self):
-        for d in self.display0._displays.values():
-            d.verbose = False           # ensure that display9.close() call is quiet
-
-        del self.display0
-        afwDisplay.delAllDisplays()
-
-    def testClose(self):
-        """Test that we can close devices."""
-        self.display0.close()
-
     def testMtv(self):
         """Test basic image display"""
         exp = afwImage.ExposureF(self.fileName)
@@ -170,6 +159,18 @@ class DisplayTestCase(unittest.TestCase):
         If running the tests using ds9 you will be expected to do this manually.
         """
         self.display0.interact()
+
+    def testClose(self):
+        """Test that we can close devices."""
+        self.display0.close()
+
+    def tearDown(self):
+        for d in self.display0._displays.values():
+            d.verbose = False           # ensure that display9.close() call is quiet
+
+        del self.display0
+        afwDisplay.delAllDisplays()
+
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
Updates to afw.display found in testing display_firefly.

- Fix the __getattr__ method to avoid an infinite recursion in Python 3.
- Reorder tests in testDisplay.py so that displays are not closed prematurely.