### PR TITLE
DM-10764: Rename Transform::of and Mapping::of to ::then

### DIFF
--- a/examples/timeWarpExposureUsingTransform.py
+++ b/examples/timeWarpExposureUsingTransform.py
@@ -136,7 +136,7 @@ def run():
                         cdMatrix = afwGeom.makeCdMatrix(scale = destScale,
                                                         orientation = rotAngDeg * afwGeom.degrees,
                                                         flipX = False))
-                    destToSrc = srcWcs.getInverse().of(destWcs)
+                    destToSrc = destWcs.then(srcWcs.getInverse())
                     dTime, nIter, goodPix = timeWarp(
                         destMaskedImage, srcMaskedImage, destToSrc, warpingControl)
                     print("%4d  %5d  %8.1f  %6.1f, %6.1f  %7.1f %10s %8d %6.2f" % (

--- a/include/lsst/afw/geom/Transform.h
+++ b/include/lsst/afw/geom/Transform.h
@@ -200,25 +200,25 @@ public:
     /**
      * Concatenate two Transforms.
      *
-     * @tparam FirstFromEndpoint the starting Endpoint of `first`
-     * @param first the Transform to apply before this one
-     * @returns a Transform that first applies `first` to its input, and then
-     *          this Transform to the result. Its inverse shall first apply the
-     *          inverse of this Transform, then the inverse of `first`.
+     * @tparam NextToEndpoint the "to" Endpoint of `next`
+     * @tparam FromEndpoint the 
+     * @param next the Transform to apply after this one
+     * @returns a Transform that first applies this transform to its input, and then
+     *          `next` to the result. Its inverse shall first apply the
+     *          inverse of `next`, and then the inverse of this transform.
      *
      * @throws pex::exceptions::InvalidParameterError Thrown if
-     *         `first.getToEndpoint()` and `this->getFromEndpoint()` do not
+     *         `getToEndpoint()` and `next.getFromEndpoint()` do not
      *         have the same number of axes.
      * @exceptsafe Provides basic exception safety.
      *
      * More than two Transforms can be combined in series. For example:
      *
-     *     auto skyFromPixels = skyFromPupil.of(pupilFromFp)
-     *                                      .of(fpFromPixels);
+     *     auto pixelsToSky = pixelsToFP.then(fpToPupil.then(pupilToSky));
      */
-    template <class FirstFromEndpoint>
-    Transform<FirstFromEndpoint, ToEndpoint> of(
-            Transform<FirstFromEndpoint, FromEndpoint> const &first) const;
+    template <class NextToEndpoint>
+    Transform<FromEndpoint, NextToEndpoint> then(
+            Transform<ToEndpoint, NextToEndpoint> const &next) const;
 
 protected:
     /**

--- a/include/lsst/afw/math/warpExposure.h
+++ b/include/lsst/afw/math/warpExposure.h
@@ -467,7 +467,7 @@ int warpImage(DestImageT &destImage,                            ///< remapped %i
  * @param[in,out] destImage  Destination image; all pixels are set
  * @param[in] srcImage  Source image
  * @param[in] destToSrc  Transformation from destination to source pixels in parent coordinates.
- *    This can be computed as srcWcs.getInverse().of(destWcs)
+ *    This can be computed as destWcs.then(srcWcs.getInverse())
  *    because WCS computes pixels to sky in the forward direction
  * @param[in] control  Warning control parameters
  * @param[in] padValue  Value used for pixels in the destination image that are outside

--- a/python/lsst/afw/geom/python/transform.py
+++ b/python/lsst/afw/geom/python/transform.py
@@ -53,17 +53,17 @@ def getJacobian(self, x):
     return matrix
 
 
-def of(self, first):
+def then(self, next):
     """Concatenate two transforms
 
-    The result of B.of(A) is C(x) = B(A(x))
+    The result of A.then(B) is is C(x) = B(A(x))
     """
-    if first.toEndpoint == self.fromEndpoint:
-        return self._of(first)
+    if self.toEndpoint == next.fromEndpoint:
+        return self._then(next)
     else:
         raise lsst.pex.exceptions.InvalidParameterError(
             "Cannot concatenate %r and %r: endpoints do not match."
-            % (first, self))
+            % (self, next))
 
 
 def saveToFile(self, path):
@@ -95,5 +95,5 @@ def addTransformMethods(cls):
                            (className, transformRegistry[className], cls))
     transformRegistry[cls.__name__] = cls
     cls.getJacobian = getJacobian
-    cls.of = of
+    cls.then = then
     cls.saveToFile = saveToFile

--- a/python/lsst/afw/geom/testUtils.py
+++ b/python/lsst/afw/geom/testUtils.py
@@ -886,8 +886,8 @@ class TransformTestBaseClass(lsst.utils.tests.TestCase):
             assert_allclose(jacobian, self.makeJacobian(nIn, nOut, rawInPoint),
                             err_msg=msg)
 
-    def checkOf(self, fromName, midName, toName):
-        """Test Transform<midName>To<toName>.of(Transform<fromName>To<midName>)
+    def checkThen(self, fromName, midName, toName):
+        """Test Transform<fromName>To<midName>.then(Transform<midName>To<toName>)
 
         Parameters
         ----------
@@ -905,18 +905,18 @@ class TransformTestBaseClass(lsst.utils.tests.TestCase):
                                   "Transform{}To{}".format(fromName, midName))
         TransformClass2 = getattr(afwGeom,
                                   "Transform{}To{}".format(midName, toName))
-        baseMsg = "{}.of({})".format(TransformClass2.__name__,
-                                     TransformClass1.__name__)
+        baseMsg = "{}.then({})".format(TransformClass1.__name__,
+                                       TransformClass2.__name__)
         for nIn, nMid, nOut in itertools.product(self.goodNAxes[fromName],
                                                  self.goodNAxes[midName],
                                                  self.goodNAxes[toName]):
             msg = "{}, nIn={}, nMid={}, nOut={}".format(
                 baseMsg, nIn, nMid, nOut)
-            polyMap = makeTwoWayPolyMap(nIn, nMid)
-            transform1 = TransformClass1(polyMap)
-            polyMap = makeTwoWayPolyMap(nMid, nOut)
-            transform2 = TransformClass2(polyMap)
-            transform = transform2.of(transform1)
+            polyMap1 = makeTwoWayPolyMap(nIn, nMid)
+            transform1 = TransformClass1(polyMap1)
+            polyMap2 = makeTwoWayPolyMap(nMid, nOut)
+            transform2 = TransformClass2(polyMap2)
+            transform = transform1.then(transform2)
 
             fromEndpoint = transform1.fromEndpoint
             toEndpoint = transform2.toEndpoint
@@ -947,7 +947,7 @@ class TransformTestBaseClass(lsst.utils.tests.TestCase):
             polyMap = makeTwoWayPolyMap(2, nOut)
             transform2 = TransformClass2(polyMap)
             with self.assertRaises(InvalidParameterError):
-                transform = transform2.of(transform1)
+                transform = transform1.then(transform2)
 
         # Mismatched types of endpoints should fail
         if fromName != midName:
@@ -964,7 +964,7 @@ class TransformTestBaseClass(lsst.utils.tests.TestCase):
                 polyMap = makeTwoWayPolyMap(nMid, nOut)
                 transform2 = TransformClass1(polyMap)
                 with self.assertRaises(InvalidParameterError):
-                    transform = transform2.of(transform1)
+                    transform = transform1.then(transform2)
 
     def checkPersistence(self, transform):
         """Check persistence of a transform

--- a/src/geom/SkyWcs.cc
+++ b/src/geom/SkyWcs.cc
@@ -160,7 +160,7 @@ SkyWcs SkyWcs::copyAtShiftedPixelOrigin(Extent2D const& shift) const {
     // Compute new mapping from GRID to PIXEL0
     std::vector<double> shiftVec{shift[0], shift[1]};
     auto deltaShiftMap = ast::ShiftMap(shiftVec);
-    auto newGridToPixel0Map = deltaShiftMap.of(*oldGridToPixel0Map).simplify();
+    auto newGridToPixel0Map = oldGridToPixel0Map->then(deltaShiftMap).simplify();
 
     // Replace the mapping from GRID to PIXEL0.
     // We actually remove the old PIXEL0 and ACTUAL_PIXEL0 frames (if present)

--- a/src/geom/Transform.cc
+++ b/src/geom/Transform.cc
@@ -140,14 +140,14 @@ Eigen::MatrixXd Transform<FromEndpoint, ToEndpoint>::getJacobian(FromPoint const
 }
 
 template <class FromEndpoint, class ToEndpoint>
-template <class FirstFromEndpoint>
-Transform<FirstFromEndpoint, ToEndpoint> Transform<FromEndpoint, ToEndpoint>::of(
-        Transform<FirstFromEndpoint, FromEndpoint> const &first) const {
-    if (_fromEndpoint.getNAxes() == first.getToEndpoint().getNAxes()) {
-        return Transform<FirstFromEndpoint, ToEndpoint>(*ast::prepend(*_frameSet, *(first.getFrameSet())));
+template <class NextToEndpoint>
+Transform<FromEndpoint, NextToEndpoint> Transform<FromEndpoint, ToEndpoint>::then(
+        Transform<ToEndpoint, NextToEndpoint> const &next) const {
+    if (_toEndpoint.getNAxes() == next.getFromEndpoint().getNAxes()) {
+        return Transform<FromEndpoint, NextToEndpoint>(*ast::append(*_frameSet, *(next.getFrameSet())));
     } else {
-        auto message = "Cannot match " + std::to_string(first.getToEndpoint().getNAxes()) +
-                       "-D to-endpoint to " + std::to_string(_fromEndpoint.getNAxes()) + "-D from-endpoint.";
+        auto message = "Cannot match " + std::to_string(_toEndpoint.getNAxes()) +
+                       "-D to-endpoint to " + std::to_string(next.getFromEndpoint().getNAxes()) + "-D from-endpoint.";
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError, message);
     }
 }
@@ -159,9 +159,11 @@ std::ostream &operator<<(std::ostream &os, Transform<FromEndpoint, ToEndpoint> c
     return os;
 };
 
-#define INSTANTIATE_OVERLOADS(FromEndpoint, ToEndpoint, ExtraEndpoint)                                    \
-    template Transform<ExtraEndpoint, ToEndpoint> Transform<FromEndpoint, ToEndpoint>::of<ExtraEndpoint>( \
-            Transform<ExtraEndpoint, FromEndpoint> const &) const;
+#define INSTANTIATE_OVERLOADS(FromEndpoint, ToEndpoint, NextToEndpoint) \
+    template Transform<FromEndpoint, NextToEndpoint>                    \
+    Transform<FromEndpoint, ToEndpoint>::then<NextToEndpoint>(          \
+            Transform<ToEndpoint, NextToEndpoint> const &next) const;
+
 #define INSTANTIATE_TRANSFORM(FromEndpoint, ToEndpoint)                  \
     template class Transform<FromEndpoint, ToEndpoint>;                  \
     INSTANTIATE_OVERLOADS(FromEndpoint, ToEndpoint, GenericEndpoint)     \

--- a/src/math/warpExposure.cc
+++ b/src/math/warpExposure.cc
@@ -535,7 +535,8 @@ int warpImage(DestImageT &destImage, SrcImageT const &srcImage,
     std::vector<double> const srcParentToLocalVec = {static_cast<double>(-srcImage.getX0()),
                                                      static_cast<double>(-srcImage.getY0())};
     auto const srcParentToLocalMap = ast::ShiftMap(srcParentToLocalVec);
-    auto const localDestToSrcMap = srcParentToLocalMap.of(destToSrc.getFrameSet()->of(destLocalToParentMap));
+    auto const localDestToSrcMap =
+            destLocalToParentMap.then(*(destToSrc.getFrameSet())).then(srcParentToLocalMap);
     auto localDestToSrc = geom::Transform<geom::Point2Endpoint, geom::Point2Endpoint>(localDestToSrcMap);
 
     // Get the source MaskedImage and a pixel accessor to it.

--- a/tests/testWarpExposure.py
+++ b/tests/testWarpExposure.py
@@ -457,9 +457,9 @@ class WarpExposureTestCase(lsst.utils.tests.TestCase):
             swarpedMetadata = swarpedDecoratedImage.getMetadata()
             warpedSkyWcs = afwGeom.SkyWcs(swarpedMetadata)
 
-            # original image is source, warped image is destination
+            # warped image is destination, original image is source
             # and WCS computes pixels to sky in the forward direction, so...
-            destToSrc = originalSkyWcs.getInverse().of(warpedSkyWcs)
+            destToSrc = warpedSkyWcs.then(originalSkyWcs.getInverse())
 
             afwWarpedMaskedImage = afwImage.MaskedImageF(swarpedImage.getDimensions())
             originalMaskedImage = originalExposure.getMaskedImage()

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -40,7 +40,7 @@ class TransformTestCase(TransformTestBaseClass):
                 self.checkGetInverse(fromName, toName)
                 self.checkGetJacobian(fromName, toName)
                 for midName in self.endpointPrefixes:
-                    self.checkOf(fromName, midName, toName)
+                    self.checkThen(fromName, midName, toName)
 
     def testFrameSetIndependence(self):
         """Test that the FrameSet returned by getFrameSet is independent of the contained FrameSet
@@ -55,10 +55,11 @@ class TransformTestCase(TransformTestBaseClass):
         extractedFrameSet.ident = "Extracted Ident"
         self.assertEqual(initialIdent, transform.getFrameSet().ident)
 
-    def testOfChaining(self):
-        """Test that the order of chaining Transform.of does not matter
+    def testThenChaining(self):
+        """Test that the order of chaining Transform.then does not matter
 
-        Test that C.of(B.of(A)) gives the same transformation as (C.of(B)).of(A)
+        Test that A.then(B.then(C)) gives the same transformation as
+        (A.then(B)).then(C)
         Internal details may differ (e.g. frame indices if the frames in the
         contained FrameSet), but the mathematical result of the two transforms
         should be the same.
@@ -70,8 +71,8 @@ class TransformTestCase(TransformTestBaseClass):
         transform3 = afwGeom.TransformGenericToGeneric(
             makeForwardPolyMap(4, 1))
 
-        merged1 = transform3.of(transform2).of(transform1)
-        merged2 = transform3.of(transform2.of(transform1))
+        merged1 = transform1.then(transform2.then(transform3))
+        merged2 = transform1.then(transform2).then(transform3)
 
         fromEndpoint = transform1.fromEndpoint
         toEndpoint = transform3.toEndpoint


### PR DESCRIPTION
Change `Transform::of(first)` to `Transform::then(next)` to improve readability.