### PR TITLE
DM-10834: pybind: clear error if we're not going to use it

### DIFF
--- a/python/lsst/afw/table/schema/schema.cc
+++ b/python/lsst/afw/table/schema/schema.cc
@@ -346,6 +346,7 @@ void declareSchema(py::module &mod) {
         try {
             self.attr("find")(key);
         } catch (py::error_already_set &err) {
+            err.clear();
             return false;
         }
         return true;


### PR DESCRIPTION
To fail to do so results in a deadlock when using python multiprocessing.