### PR TITLE
DM-10257: Fix compiler warnings in afw

### DIFF
--- a/examples/wcsTest.cc
+++ b/examples/wcsTest.cc
@@ -68,7 +68,6 @@ int main(int argc, char **argv) {
     }
     std::cout << "Opening exposure " << inImagePath << std::endl;
 
-    auto miMetadata(new PropertySet);
     afwImage::Exposure<Pixel> exposure(inImagePath);
     if (!exposure.hasWcs()) {
         std::cerr << "Exposure does not have a WCS." << std::endl;

--- a/python/lsst/afw/display/scaling.cc
+++ b/python/lsst/afw/display/scaling.cc
@@ -31,8 +31,8 @@ static void getSample(image::Image<T> const& image, std::size_t const nSamples, 
     for (int stride = initialStride; stride >= 1; --stride) {
         vSample.clear();
 
-        for (std::size_t y = 0; y < height; y += stride) {
-            for (std::size_t x = 0; x < width; x += stride) {
+        for (int y = 0; y < height; y += stride) {
+            for (int x = 0; x < width; x += stride) {
                 T const elem = image(x, y);
                 if (std::isfinite(elem)) {
                     vSample.push_back(elem);
@@ -85,8 +85,8 @@ static std::pair<double, double> fitLine(
     // Mask that is used in k-sigma clipping
     std::vector<int> vBadPix(vSample.size(), 0);
 
-    std::size_t nGoodPix = vSample.size();
-    std::size_t nGoodPixOld = nGoodPix + 1;
+    int nGoodPix = vSample.size();
+    int nGoodPixOld = nGoodPix + 1;
 
     // values to be obtained
     double intercept = 0;

--- a/src/coord/Coord.cc
+++ b/src/coord/Coord.cc
@@ -188,28 +188,7 @@ geom::Angle meanSiderealTimeGreenwich(double const jd  ///< Julian Day
            geom::degrees;
 }
 
-/*
- * A pair of utility functions to go from cartesian to spherical
- */
 double const atPoleEpsilon = 0.0;  // std::numeric_limits<double>::epsilon();
-geom::Angle pointToLongitude(geom::Point3D const &p3d, double const defaultLongitude = 0.0) {
-    geom::Angle lon;
-    if (fabs(p3d.getX()) <= atPoleEpsilon && fabs(p3d.getY()) <= atPoleEpsilon) {
-        lon = geom::Angle(0.0);
-    } else {
-        lon = (std::atan2(p3d.getY(), p3d.getX()) * geom::radians).wrap();
-    }
-    return lon;
-}
-geom::Angle pointToLatitude(geom::Point3D const &p3d) {
-    geom::Angle lat;
-    if (fabs(p3d.getX()) <= atPoleEpsilon && fabs(p3d.getY()) <= atPoleEpsilon) {
-        lat = (p3d.getZ() >= 0) ? geom::Angle(geom::HALFPI) : geom::Angle(-geom::HALFPI);
-    } else {
-        lat = std::asin(p3d.getZ()) * geom::radians;
-    }
-    return lat;
-}
 std::pair<geom::Angle, geom::Angle> pointToLonLat(geom::Point3D const &p3d,
                                                   double const defaultLongitude = 0.0,
                                                   bool normalize = true) {

--- a/src/detection/PsfFormatter.cc
+++ b/src/detection/PsfFormatter.cc
@@ -49,15 +49,17 @@ void PsfFormatter::write(dafBase::Persistable const* persistable,
     if (ps == 0) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError, "Persisting non-Psf");
     }
-    if (typeid(*storage) == typeid(dafPersist::BoostStorage)) {
+    // TODO: Replace this with something better in DM-10776
+    auto boost = std::dynamic_pointer_cast<dafPersist::BoostStorage>(storage);
+    if (boost) {
         LOGL_DEBUG(_log, "PsfFormatter write BoostStorage");
-        dafPersist::BoostStorage* boost = dynamic_cast<dafPersist::BoostStorage*>(storage.get());
         boost->getOArchive() & ps;
         LOGL_DEBUG(_log, "PsfFormatter write end");
         return;
-    } else if (typeid(*storage) == typeid(dafPersist::XmlStorage)) {
+    }
+    auto xml = std::dynamic_pointer_cast<dafPersist::XmlStorage>(storage);
+    if (xml) {
         LOGL_DEBUG(_log, "PsfFormatter write XmlStorage");
-        dafPersist::XmlStorage* xml = dynamic_cast<dafPersist::XmlStorage*>(storage.get());
         xml->getOArchive() & make_nvp("psf", ps);
         LOGL_DEBUG(_log, "PsfFormatter write end");
         return;
@@ -69,15 +71,18 @@ dafBase::Persistable* PsfFormatter::read(std::shared_ptr<dafPersist::FormatterSt
                                          std::shared_ptr<dafBase::PropertySet>) {
     LOGL_DEBUG(_log, "PsfFormatter read start");
     Psf* ps;
-    if (typeid(*storage) == typeid(dafPersist::BoostStorage)) {
+
+    // TODO: Replace this with something better in DM-10776
+    auto boost = std::dynamic_pointer_cast<dafPersist::BoostStorage>(storage);
+    if (boost) {
         LOGL_DEBUG(_log, "PsfFormatter read BoostStorage");
-        dafPersist::BoostStorage* boost = dynamic_cast<dafPersist::BoostStorage*>(storage.get());
         boost->getIArchive() & ps;
         LOGL_DEBUG(_log, "PsfFormatter read end");
         return ps;
-    } else if (typeid(*storage) == typeid(dafPersist::XmlStorage)) {
+    }
+    auto xml = std::dynamic_pointer_cast<dafPersist::XmlStorage>(storage);
+    if (xml) {
         LOGL_DEBUG(_log, "PsfFormatter read XmlStorage");
-        dafPersist::XmlStorage* xml = dynamic_cast<dafPersist::XmlStorage*>(storage.get());
         xml->getIArchive() & make_nvp("psf", ps);
         LOGL_DEBUG(_log, "PsfFormatter read end");
         return ps;

--- a/src/formatters/DecoratedImageFormatter.cc
+++ b/src/formatters/DecoratedImageFormatter.cc
@@ -134,7 +134,6 @@ void DecoratedImageFormatter<ImagePixelT>::write(Persistable const* persistable,
     auto fits = std::dynamic_pointer_cast<FitsStorage>(storage);
     if (fits) {
         LOGL_DEBUG(_log, "DecoratedImageFormatter write FitsStorage");
-        typedef DecoratedImage<ImagePixelT> DecoratedImage;
 
         ip->writeFits(fits->getPath());
         // @todo Do something with these fields?
@@ -143,7 +142,8 @@ void DecoratedImageFormatter<ImagePixelT>::write(Persistable const* persistable,
         LOGL_DEBUG(_log, "DecoratedImageFormatter write end");
         return;
     }
-    throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError, "Unrecognized FormatterStorage for DecoratedImage");
+    throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
+                      "Unrecognized FormatterStorage for DecoratedImage");
 }
 
 template <typename ImagePixelT>
@@ -178,7 +178,8 @@ Persistable* DecoratedImageFormatter<ImagePixelT>::read(std::shared_ptr<Formatte
         LOGL_DEBUG(_log, "DecoratedImageFormatter read end");
         return ip;
     }
-    throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError, "Unrecognized FormatterStorage for DecoratedImage");
+    throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
+                      "Unrecognized FormatterStorage for DecoratedImage");
 }
 
 template <typename ImagePixelT>
@@ -225,6 +226,6 @@ InstantiateFormatter(double);
 InstantiateFormatter(std::uint64_t);
 
 #undef InstantiateFormatter
-}
-}
-}  // namespace lsst::afw::formatters
+}  // namespace formatters
+}  // namespace afw
+}  // namespace lsst

--- a/src/formatters/DecoratedImageFormatter.cc
+++ b/src/formatters/DecoratedImageFormatter.cc
@@ -115,21 +115,25 @@ void DecoratedImageFormatter<ImagePixelT>::write(Persistable const* persistable,
     if (ip == 0) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError, "Persisting non-DecoratedImage");
     }
-    if (typeid(*storage) == typeid(BoostStorage)) {
+
+    // TODO: Replace this with something better in DM-10776
+    auto boost = std::dynamic_pointer_cast<BoostStorage>(storage);
+    if (boost) {
         LOGL_DEBUG(_log, "DecoratedImageFormatter write BoostStorage");
-        BoostStorage* boost = dynamic_cast<BoostStorage*>(storage.get());
         boost->getOArchive() & *ip;
         LOGL_DEBUG(_log, "DecoratedImageFormatter write end");
         return;
-    } else if (typeid(*storage) == typeid(XmlStorage)) {
+    }
+    auto xml = std::dynamic_pointer_cast<XmlStorage>(storage);
+    if (xml) {
         LOGL_DEBUG(_log, "DecoratedImageFormatter write XmlStorage");
-        XmlStorage* boost = dynamic_cast<XmlStorage*>(storage.get());
-        boost->getOArchive() & make_nvp("img", *ip);
+        xml->getOArchive() & make_nvp("img", *ip);
         LOGL_DEBUG(_log, "DecoratedImageFormatter write end");
         return;
-    } else if (typeid(*storage) == typeid(FitsStorage)) {
+    }
+    auto fits = std::dynamic_pointer_cast<FitsStorage>(storage);
+    if (fits) {
         LOGL_DEBUG(_log, "DecoratedImageFormatter write FitsStorage");
-        FitsStorage* fits = dynamic_cast<FitsStorage*>(storage.get());
         typedef DecoratedImage<ImagePixelT> DecoratedImage;
 
         ip->writeFits(fits->getPath());
@@ -146,23 +150,26 @@ template <typename ImagePixelT>
 Persistable* DecoratedImageFormatter<ImagePixelT>::read(std::shared_ptr<FormatterStorage> storage,
                                                         std::shared_ptr<lsst::daf::base::PropertySet>) {
     LOGL_DEBUG(_log, "DecoratedImageFormatter read start");
-    if (typeid(*storage) == typeid(BoostStorage)) {
+    // TODO: Replace this with something better in DM-10776
+    auto boost = std::dynamic_pointer_cast<BoostStorage>(storage);
+    if (boost) {
         LOGL_DEBUG(_log, "DecoratedImageFormatter read BoostStorage");
-        BoostStorage* boost = dynamic_cast<BoostStorage*>(storage.get());
         DecoratedImage<ImagePixelT>* ip = new DecoratedImage<ImagePixelT>;
         boost->getIArchive() & *ip;
         LOGL_DEBUG(_log, "DecoratedImageFormatter read end");
         return ip;
-    } else if (typeid(*storage) == typeid(XmlStorage)) {
+    }
+    auto xml = std::dynamic_pointer_cast<XmlStorage>(storage);
+    if (xml) {
         LOGL_DEBUG(_log, "DecoratedImageFormatter read XmlStorage");
-        XmlStorage* boost = dynamic_cast<XmlStorage*>(storage.get());
         DecoratedImage<ImagePixelT>* ip = new DecoratedImage<ImagePixelT>;
         boost->getIArchive() & make_nvp("img", *ip);
         LOGL_DEBUG(_log, "DecoratedImageFormatter read end");
         return ip;
-    } else if (typeid(*storage) == typeid(FitsStorage)) {
+    }
+    auto fits = std::dynamic_pointer_cast<FitsStorage>(storage);
+    if (fits) {
         LOGL_DEBUG(_log, "DecoratedImageFormatter read FitsStorage");
-        FitsStorage* fits = dynamic_cast<FitsStorage*>(storage.get());
 
         DecoratedImage<ImagePixelT>* ip = new DecoratedImage<ImagePixelT>(fits->getPath(), fits->getHdu());
         // @todo Do something with these fields?

--- a/src/formatters/ImageFormatter.cc
+++ b/src/formatters/ImageFormatter.cc
@@ -114,10 +114,11 @@ ImageFormatter<ImagePixelT>::~ImageFormatter(void) {}
 namespace {
 namespace dafBase = lsst::daf::base;
 namespace afwImage = lsst::afw::image;
-}
+}  // namespace
 
 template <typename ImagePixelT>
-void ImageFormatter<ImagePixelT>::write(Persistable const* persistable, std::shared_ptr<FormatterStorage> storage,
+void ImageFormatter<ImagePixelT>::write(Persistable const* persistable,
+                                        std::shared_ptr<FormatterStorage> storage,
                                         std::shared_ptr<lsst::daf::base::PropertySet>) {
     LOGL_DEBUG(_log, "ImageFormatter write start");
     Image<ImagePixelT> const* ip = dynamic_cast<Image<ImagePixelT> const*>(persistable);
@@ -142,7 +143,6 @@ void ImageFormatter<ImagePixelT>::write(Persistable const* persistable, std::sha
     auto fits = std::dynamic_pointer_cast<FitsStorage>(storage);
     if (fits) {
         LOGL_DEBUG(_log, "ImageFormatter write FitsStorage");
-        typedef Image<ImagePixelT> Image;
 
         ip->writeFits(fits->getPath());
         // @todo Do something with these fields?
@@ -197,9 +197,8 @@ Persistable* ImageFormatter<ImagePixelT>::read(std::shared_ptr<FormatterStorage>
                 throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                                   (boost::format("Unknown ImageOrigin type  %s specified in additional"
                                                  "data for retrieving Image from fits") %
-                                   originStr
-
-                                   ).str());
+                                   originStr)
+                                          .str());
             }
         }
         std::shared_ptr<lsst::daf::base::PropertySet> metadata;
@@ -277,6 +276,6 @@ InstantiateFormatter(double);
 InstantiateFormatter(std::uint64_t);
 
 #undef InstantiateSerializer
-}
-}
-}  // namespace lsst::afw::formatters
+}  // namespace formatters
+}  // namespace afw
+}  // namespace lsst

--- a/src/formatters/KernelFormatter.cc
+++ b/src/formatters/KernelFormatter.cc
@@ -139,15 +139,17 @@ void KernelFormatter::write(dafBase::Persistable const* persistable,
     if (kp == 0) {
         throw LSST_EXCEPT(pex::exceptions::RuntimeError, "Persisting non-Kernel");
     }
-    if (typeid(*storage) == typeid(dafPersist::BoostStorage)) {
+    // TODO: Replace this with something better in DM-10776
+    auto boost = std::dynamic_pointer_cast<dafPersist::BoostStorage>(storage);
+    if (boost) {
         LOGL_DEBUG(_log, "KernelFormatter write BoostStorage");
-        dafPersist::BoostStorage* boost = dynamic_cast<dafPersist::BoostStorage*>(storage.get());
         boost->getOArchive() & kp;
         LOGL_DEBUG(_log, "KernelFormatter write end");
         return;
-    } else if (typeid(*storage) == typeid(dafPersist::XmlStorage)) {
+    }
+    auto xml = std::dynamic_pointer_cast<dafPersist::XmlStorage>(storage);
+    if (xml) {
         LOGL_DEBUG(_log, "KernelFormatter write XmlStorage");
-        dafPersist::XmlStorage* xml = dynamic_cast<dafPersist::XmlStorage*>(storage.get());
         xml->getOArchive() & make_nvp("ptr", kp);
         LOGL_DEBUG(_log, "KernelFormatter write end");
         return;
@@ -159,15 +161,17 @@ dafBase::Persistable* KernelFormatter::read(std::shared_ptr<dafPersist::Formatte
                                             std::shared_ptr<dafBase::PropertySet>) {
     LOGL_DEBUG(_log, "KernelFormatter read start");
     math::Kernel* kp;
-    if (typeid(*storage) == typeid(dafPersist::BoostStorage)) {
+    // TODO: Replace this with something better in DM-10776
+    auto boost = std::dynamic_pointer_cast<dafPersist::BoostStorage>(storage);
+    if (boost) {
         LOGL_DEBUG(_log, "KernelFormatter read BoostStorage");
-        dafPersist::BoostStorage* boost = dynamic_cast<dafPersist::BoostStorage*>(storage.get());
         boost->getIArchive() & kp;
         LOGL_DEBUG(_log, "KernelFormatter read end");
         return kp;
-    } else if (typeid(*storage) == typeid(dafPersist::XmlStorage)) {
+    }
+    auto xml = std::dynamic_pointer_cast<dafPersist::XmlStorage>(storage);
+    if (xml) {
         LOGL_DEBUG(_log, "KernelFormatter read XmlStorage");
-        dafPersist::XmlStorage* xml = dynamic_cast<dafPersist::XmlStorage*>(storage.get());
         xml->getIArchive() & make_nvp("ptr", kp);
         LOGL_DEBUG(_log, "KernelFormatter read end");
         return kp;

--- a/src/formatters/MaskFormatter.cc
+++ b/src/formatters/MaskFormatter.cc
@@ -93,15 +93,17 @@ void MaskFormatter<MaskPixelT>::write(Persistable const* persistable, std::share
     if (ip == 0) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError, "Persisting non-Mask");
     }
-    if (typeid(*storage) == typeid(BoostStorage)) {
+    // TODO: Replace this with something better in DM-10776
+    auto boost = std::dynamic_pointer_cast<BoostStorage>(storage);
+    if (boost) {
         LOGL_DEBUG(_log, "MaskFormatter write BoostStorage");
-        BoostStorage* boost = dynamic_cast<BoostStorage*>(storage.get());
         boost->getOArchive() & *ip;
         LOGL_DEBUG(_log, "MaskFormatter write end");
         return;
-    } else if (typeid(*storage) == typeid(FitsStorage)) {
+    }
+    auto fits = std::dynamic_pointer_cast<FitsStorage>(storage);
+    if (fits) {
         LOGL_DEBUG(_log, "MaskFormatter write FitsStorage");
-        FitsStorage* fits = dynamic_cast<FitsStorage*>(storage.get());
         // Need to cast away const because writeFits modifies the metadata.
         Mask<MaskPixelT>* vip = const_cast<Mask<MaskPixelT>*>(ip);
         vip->writeFits(fits->getPath());
@@ -115,16 +117,18 @@ template <typename MaskPixelT>
 Persistable* MaskFormatter<MaskPixelT>::read(std::shared_ptr<FormatterStorage> storage,
                                              std::shared_ptr<lsst::daf::base::PropertySet>) {
     LOGL_DEBUG(_log, "MaskFormatter read start");
-    if (typeid(*storage) == typeid(BoostStorage)) {
+    // TODO: Replace this with something better in DM-10776
+    auto boost = std::dynamic_pointer_cast<BoostStorage>(storage);
+    if (boost) {
         LOGL_DEBUG(_log, "MaskFormatter read BoostStorage");
-        BoostStorage* boost = dynamic_cast<BoostStorage*>(storage.get());
         Mask<MaskPixelT>* ip = new Mask<MaskPixelT>;
         boost->getIArchive() & *ip;
         LOGL_DEBUG(_log, "MaskFormatter read end");
         return ip;
-    } else if (typeid(*storage) == typeid(FitsStorage)) {
+    }
+    auto fits = std::dynamic_pointer_cast<FitsStorage>(storage);
+    if (fits) {
         LOGL_DEBUG(_log, "MaskFormatter read FitsStorage");
-        FitsStorage* fits = dynamic_cast<FitsStorage*>(storage.get());
         Mask<MaskPixelT>* ip = new Mask<MaskPixelT>(fits->getPath(), fits->getHdu());
         LOGL_DEBUG(_log, "MaskFormatter read end");
         return ip;

--- a/src/formatters/MaskedImageFormatter.cc
+++ b/src/formatters/MaskedImageFormatter.cc
@@ -121,15 +121,17 @@ void MaskedImageFormatter<ImagePixelT, MaskPixelT, VariancePixelT>::write(
     if (ip == 0) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError, "Persisting non-MaskedImage");
     }
-    if (typeid(*storage) == typeid(BoostStorage)) {
+    // TODO: Replace this with something better in DM-10776
+    auto boost = std::dynamic_pointer_cast<BoostStorage>(storage);
+    if (boost) {
         LOGL_DEBUG(_log, "MaskedImageFormatter write BoostStorage");
-        BoostStorage* boost = dynamic_cast<BoostStorage*>(storage.get());
         boost->getOArchive() & *ip;
         LOGL_DEBUG(_log, "MaskedImageFormatter write end");
         return;
-    } else if (typeid(*storage) == typeid(FitsStorage)) {
+    }
+    auto fits = std::dynamic_pointer_cast<FitsStorage>(storage);
+    if (fits) {
         LOGL_DEBUG(_log, "MaskedImageFormatter write FitsStorage");
-        FitsStorage* fits = dynamic_cast<FitsStorage*>(storage.get());
         ip->writeFits(fits->getPath());
         LOGL_DEBUG(_log, "MaskedImageFormatter write end");
         return;
@@ -141,16 +143,18 @@ template <typename ImagePixelT, typename MaskPixelT, typename VariancePixelT>
 Persistable* MaskedImageFormatter<ImagePixelT, MaskPixelT, VariancePixelT>::read(
         std::shared_ptr<FormatterStorage> storage, std::shared_ptr<lsst::daf::base::PropertySet>) {
     LOGL_DEBUG(_log, "MaskedImageFormatter read start");
-    if (typeid(*storage) == typeid(BoostStorage)) {
+    auto boost = std::dynamic_pointer_cast<BoostStorage>(storage);
+    // TODO: Replace this with something better in DM-10776
+    if (boost) {
         LOGL_DEBUG(_log, "MaskedImageFormatter read BoostStorage");
-        BoostStorage* boost = dynamic_cast<BoostStorage*>(storage.get());
         MaskedImage<ImagePixelT, MaskPixelT>* ip = new MaskedImage<ImagePixelT, MaskPixelT>;
         boost->getIArchive() & *ip;
         LOGL_DEBUG(_log, "MaskedImageFormatter read end");
         return ip;
-    } else if (typeid(*storage) == typeid(FitsStorage)) {
+    }
+    auto fits = std::dynamic_pointer_cast<FitsStorage>(storage);
+    if (fits) {
         LOGL_DEBUG(_log, "MaskedImageFormatter read FitsStorage");
-        FitsStorage* fits = dynamic_cast<FitsStorage*>(storage.get());
         MaskedImage<ImagePixelT, MaskPixelT>* ip = new MaskedImage<ImagePixelT, MaskPixelT>(fits->getPath());
         LOGL_DEBUG(_log, "MaskedImageFormatter read end");
         return ip;

--- a/src/formatters/PropertyListFormatter.cc
+++ b/src/formatters/PropertyListFormatter.cc
@@ -60,7 +60,9 @@ void PropertyListFormatter::write(lsst::daf::base::Persistable const* persistabl
     if (ip == 0) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError, "Persisting non-PropertyList");
     }
-    if (typeid(*storage) == typeid(lsst::daf::persistence::FitsStorage)) {
+    // TODO: Replace this with something better in DM-10776
+    auto & actualStorage = *storage;
+    if (typeid(actualStorage) == typeid(lsst::daf::persistence::FitsStorage)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "FitsStorage for PropertyList read-only (writing is not supported)");
     }
@@ -83,10 +85,11 @@ lsst::daf::base::Persistable* PropertyListFormatter::read(
         std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
         std::shared_ptr<lsst::daf::base::PropertySet>) {
     LOGL_DEBUG(_log, "PropertyListFormatter read start");
-    if (typeid(*storage) == typeid(lsst::daf::persistence::FitsStorage)) {
+    // TODO: Replace this with something better in DM-10776
+    auto fits = std::dynamic_pointer_cast<lsst::daf::persistence::FitsStorage>(storage);
+    if (fits) {
         LOGL_DEBUG(_log, "PropertyListFormatter read FitsStorage");
 
-        auto fits = dynamic_cast<lsst::daf::persistence::FitsStorage*>(storage.get());
         auto ip = readMetadataAsUniquePtr(fits->getPath(), fits->getHdu(), false);
 
         LOGL_DEBUG(_log, "PropertyListFormatter read end");

--- a/src/formatters/TanWcsFormatter.cc
+++ b/src/formatters/TanWcsFormatter.cc
@@ -80,9 +80,10 @@ void TanWcsFormatter::write(dafBase::Persistable const* persistable,
     if (ip == 0) {
         throw LSST_EXCEPT(pexExcept::RuntimeError, "Persisting non-TanWcs");
     }
-    if (typeid(*storage) == typeid(dafPersist::BoostStorage)) {
+    // TODO: Replace this with something better in DM-10776
+    auto boost = std::dynamic_pointer_cast<dafPersist::BoostStorage>(storage);
+    if (boost) {
         LOGL_DEBUG(_log, "TanWcsFormatter write BoostStorage");
-        dafPersist::BoostStorage* boost = dynamic_cast<dafPersist::BoostStorage*>(storage.get());
         boost->getOArchive() & *ip;
         LOGL_DEBUG(_log, "TanWcsFormatter write end");
         return;
@@ -93,16 +94,18 @@ void TanWcsFormatter::write(dafBase::Persistable const* persistable,
 dafBase::Persistable* TanWcsFormatter::read(std::shared_ptr<dafPersist::FormatterStorage> storage,
                                             std::shared_ptr<dafBase::PropertySet> additionalData) {
     LOGL_DEBUG(_log, "TanWcsFormatter read start");
-    if (typeid(*storage) == typeid(dafPersist::BoostStorage)) {
+    // TODO: Replace this with something better in DM-10776
+    auto boost = std::dynamic_pointer_cast<dafPersist::BoostStorage>(storage);
+    if (boost) {
         image::TanWcs* ip = new image::TanWcs;
         LOGL_DEBUG(_log, "TanWcsFormatter read BoostStorage");
-        dafPersist::BoostStorage* boost = dynamic_cast<dafPersist::BoostStorage*>(storage.get());
         boost->getIArchive() & *ip;
         LOGL_DEBUG(_log, "TanWcsFormatter read end");
         return ip;
-    } else if (typeid(*storage) == typeid(dafPersist::FitsStorage)) {
+    }
+    auto fits = std::dynamic_pointer_cast<dafPersist::FitsStorage>(storage);
+    if (fits) {
         LOGL_DEBUG(_log, "TanWcsFormatter read FitsStorage");
-        dafPersist::FitsStorage* fits = dynamic_cast<dafPersist::FitsStorage*>(storage.get());
         int hdu = additionalData->get<int>("hdu", INT_MIN);
         std::shared_ptr<dafBase::PropertySet> md = afw::fits::readMetadata(fits->getPath(), hdu);
         image::TanWcs* ip = new image::TanWcs(md);

--- a/src/image/ImagePca.cc
+++ b/src/image/ImagePca.cc
@@ -109,7 +109,7 @@ struct SortEvalueDecreasing
         return a.first > b.first;  // N.b. sort on greater
     }
 };
-}
+}  // namespace
 
 template <typename ImageT>
 void ImagePca<ImageT>::analyze() {
@@ -219,10 +219,10 @@ std::shared_ptr<typename MaskedImageT::Image> fitEigenImagesToImage(
     if (nEigen == 0) {
         throw LSST_EXCEPT(lsst::pex::exceptions::LengthError, "You must have at least one eigen image");
     } else if (nEigen > static_cast<int>(eigenImages.size())) {
-        throw LSST_EXCEPT(
-                lsst::pex::exceptions::LengthError,
-                (boost::format("You only have %d eigen images (you asked for %d)") % eigenImages.size() %
-                 nEigen).str());
+        throw LSST_EXCEPT(lsst::pex::exceptions::LengthError,
+                          (boost::format("You only have %d eigen images (you asked for %d)") %
+                           eigenImages.size() % nEigen)
+                                  .str());
     }
     /*
      * Solve the linear problem  image = sum x_i K_i + epsilon; we solve this for x_i by constructing the
@@ -343,10 +343,10 @@ double do_updateBadPixels(detail::MaskedImage_tag const&,
         }
     } else {
         if (ncomp > static_cast<int>(eigenImages.size())) {
-            throw LSST_EXCEPT(
-                    lsst::pex::exceptions::LengthError,
-                    (boost::format("You only have %d eigen images (you asked for %d)") % eigenImages.size() %
-                     ncomp).str());
+            throw LSST_EXCEPT(lsst::pex::exceptions::LengthError,
+                              (boost::format("You only have %d eigen images (you asked for %d)") %
+                               eigenImages.size() % ncomp)
+                                      .str());
         }
 
         for (int i = 0; i != nImage; ++i) {
@@ -359,7 +359,7 @@ double do_updateBadPixels(detail::MaskedImage_tag const&,
                                                               end = fitted->row_end(y);
                      fptr != end; ++fptr, ++iptr) {
                     if (iptr.mask() & mask) {
-                        double const delta = ::fabs(*fptr - iptr.image());
+                        double const delta = fabs(static_cast<double>(*fptr) - iptr.image());
                         if (delta > maxChange) {
                             maxChange = delta;
                         }
@@ -373,7 +373,7 @@ double do_updateBadPixels(detail::MaskedImage_tag const&,
 
     return maxChange;
 }
-}
+}  // namespace
 template <typename ImageT>
 double ImagePca<ImageT>::updateBadPixels(unsigned long mask, int const ncomp) {
     return do_updateBadPixels<ImageT>(typename ImageT::image_category(), _imageList, _fluxList, _eigenImages,
@@ -401,7 +401,7 @@ template <typename Image1T, typename Image2T>
 bool imagesAreIdentical(Image1T const& im1, Image2T const& im2) {
     return IsSame<Image1T, Image2T>(im1, im2)();
 }
-}
+}  // namespace
 template <typename Image1T, typename Image2T>
 double innerProduct(Image1T const& lhs, Image2T const& rhs, int border) {
     if (lhs.getWidth() <= 2 * border || lhs.getHeight() <= 2 * border) {
@@ -471,6 +471,6 @@ INSTANTIATE(double)
 
 INSTANTIATE2(float, double)  // the two types must be different
 /// @endcond
-}
-}
-}
+}  // namespace image
+}  // namespace afw
+}  // namespace lsst

--- a/src/image/VisitInfo.cc
+++ b/src/image/VisitInfo.cc
@@ -50,7 +50,6 @@ namespace image {
 namespace {
 
 auto const nan = std::numeric_limits<double>::quiet_NaN();
-auto const nanAngle = nan * geom::radians;
 
 /**
  * @internal Get a specified double from a PropertySet, or nan if not present
@@ -253,7 +252,7 @@ std::string getVisitInfoPersistenceName() { return "VisitInfo"; }
 
 VisitInfoFactory registration(getVisitInfoPersistenceName());
 
-}  // anonymous
+}  // namespace
 
 namespace detail {
 
@@ -305,7 +304,7 @@ void setVisitInfoMetadata(daf::base::PropertyList& metadata, VisitInfo const& vi
     setDouble(metadata, "HUMIDITY", weather.getHumidity(), "Relative humidity (%)");
 }
 
-}  // lsst::afw::image::detail
+}  // namespace detail
 
 VisitInfo::VisitInfo(daf::base::PropertySet const& metadata)
         : _exposureId(0),
@@ -414,6 +413,6 @@ void VisitInfo::write(OutputArchiveHandle& handle) const {
 geom::Angle VisitInfo::getLocalEra() const { return getEra() + getObservatory().getLongitude(); }
 
 geom::Angle VisitInfo::getBoresightHourAngle() const { return getLocalEra() - getBoresightRaDec()[0]; }
-}
-}
-}  // namespace
+}  // namespace image
+}  // namespace afw
+}  // namespace lsst

--- a/src/math/GaussianProcess.cc
+++ b/src/math/GaussianProcess.cc
@@ -144,12 +144,12 @@ void KdTree<T>::findNeighbors(ndarray::Array<int, 1, 1> neighdex, ndarray::Array
                           "Asked for zero or a negative number of neighbors\n");
     }
 
-    if (neighdex.getNumElements() != n_nn) {
+    if (neighdex.getNumElements() != static_cast<ndarray::Size>(n_nn)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "Size of neighdex does not equal n_nn in KdTree.findNeighbors\n");
     }
 
-    if (dd.getNumElements() != n_nn) {
+    if (dd.getNumElements() != static_cast<ndarray::Size>(n_nn)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "Size of dd does not equal n_nn in KdTree.findNeighbors\n");
     }
@@ -208,7 +208,7 @@ ndarray::Array<T, 1, 1> KdTree<T>::getData(int ipt) const {
 
 template <typename T>
 void KdTree<T>::addPoint(ndarray::Array<const T, 1, 1> const &v) {
-    if (v.getNumElements() != _dimensions) {
+    if (v.getNumElements() != static_cast<ndarray::Size>(_dimensions)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "You are trying to add a point of the incorrect dimensionality to KdTree\n");
     }
@@ -765,7 +765,7 @@ GaussianProcess<T>::GaussianProcess(ndarray::Array<T, 2, 2> const &dataIn, ndarr
     _nFunctions = 1;
     _function = allocate(ndarray::makeVector(_npts, 1));
 
-    if (ff.getNumElements() != _npts) {
+    if (ff.getNumElements() != static_cast<ndarray::Size>(_npts)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "You did not pass in the same number of data points as function values\n");
     }
@@ -796,12 +796,13 @@ GaussianProcess<T>::GaussianProcess(ndarray::Array<T, 2, 2> const &dataIn, ndarr
     _room = _npts;
     _roomStep = 5000;
 
-    if (ff.getNumElements() != _npts) {
+    if (ff.getNumElements() != static_cast<ndarray::Size>(_npts)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "You did not pass in the same number of data points as function values\n");
     }
 
-    if (mn.getNumElements() != _dimensions || mx.getNumElements() != _dimensions) {
+    if (mn.getNumElements() != static_cast<ndarray::Size>(_dimensions) ||
+        mx.getNumElements() != static_cast<ndarray::Size>(_dimensions)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "Your min/max values have different dimensionality than your data points\n");
     }
@@ -843,7 +844,7 @@ GaussianProcess<T>::GaussianProcess(ndarray::Array<T, 2, 2> const &dataIn, ndarr
     _room = _npts;
     _roomStep = 5000;
 
-    if (ff.template getSize<0>() != _npts) {
+    if (ff.template getSize<0>() != static_cast<ndarray::Size>(_npts)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "You did not pass in the same number of data points as function values\n");
     }
@@ -878,12 +879,13 @@ GaussianProcess<T>::GaussianProcess(ndarray::Array<T, 2, 2> const &dataIn, ndarr
     _room = _npts;
     _roomStep = 5000;
 
-    if (ff.template getSize<0>() != _npts) {
+    if (ff.template getSize<0>() != static_cast<ndarray::Size>(_npts)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "You did not pass in the same number of data points as function values\n");
     }
 
-    if (mn.getNumElements() != _dimensions || mx.getNumElements() != _dimensions) {
+    if (mn.getNumElements() != static_cast<ndarray::Size>(_dimensions) ||
+        mx.getNumElements() != static_cast<ndarray::Size>(_dimensions)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "Your min/max values have different dimensionality than your data points\n");
     }
@@ -932,7 +934,7 @@ void GaussianProcess<T>::getData(ndarray::Array<T, 2, 2> pts, ndarray::Array<T, 
                           "in your GaussianProcess.\n");
     }
 
-    if (pts.template getSize<1>() != _dimensions) {
+    if (pts.template getSize<1>() != static_cast<ndarray::Size>(_dimensions)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "Your pts array is constructed for points of the wrong dimensionality.\n");
     }
@@ -949,13 +951,12 @@ void GaussianProcess<T>::getData(ndarray::Array<T, 2, 2> pts, ndarray::Array<T, 
                           "for all of the points you requested in your indices array.\n");
     }
 
-    int i, j;
-    for (i = 0; i < indices.template getSize<0>(); i++) {
+    for (ndarray::Size i = 0; i < indices.template getSize<0>(); i++) {
         pts[i] = _kdTree.getData(indices[i]);  // do this first in case one of the indices is invalid.
                                                // _kdTree.getData() will raise an exception in that case
         fn[i] = _function[indices[i]][0];
         if (_useMaxMin == 1) {
-            for (j = 0; j < _dimensions; j++) {
+            for (int j = 0; j < _dimensions; j++) {
                 pts[i][j] *= (_max[j] - _min[j]);
                 pts[i][j] += _min[j];
             }
@@ -966,13 +967,13 @@ void GaussianProcess<T>::getData(ndarray::Array<T, 2, 2> pts, ndarray::Array<T, 
 template <typename T>
 void GaussianProcess<T>::getData(ndarray::Array<T, 2, 2> pts, ndarray::Array<T, 2, 2> fn,
                                  ndarray::Array<int, 1, 1> indices) const {
-    if (fn.template getSize<1>() != _nFunctions) {
+    if (fn.template getSize<1>() != static_cast<ndarray::Size>(_nFunctions)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "Your function value array does not have enough room for all of the functions "
                           "in your GaussianProcess.\n");
     }
 
-    if (pts.template getSize<1>() != _dimensions) {
+    if (pts.template getSize<1>() != static_cast<ndarray::Size>(_dimensions)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "Your pts array is constructed for points of the wrong dimensionality.\n");
     }
@@ -989,15 +990,14 @@ void GaussianProcess<T>::getData(ndarray::Array<T, 2, 2> pts, ndarray::Array<T, 
                           "for all of the points you requested in your indices array.\n");
     }
 
-    int i, j;
-    for (i = 0; i < indices.template getSize<0>(); i++) {
+    for (ndarray::Size i = 0; i < indices.template getSize<0>(); i++) {
         pts[i] = _kdTree.getData(indices[i]);  // do this first in case one of the indices is invalid.
                                                // _kdTree.getData() will raise an exception in that case
-        for (j = 0; j < _nFunctions; j++) {
+        for (int j = 0; j < _nFunctions; j++) {
             fn[i][j] = _function[indices[i]][j];
         }
         if (_useMaxMin == 1) {
-            for (j = 0; j < _dimensions; j++) {
+            for (int j = 0; j < _dimensions; j++) {
                 pts[i][j] *= (_max[j] - _min[j]);
                 pts[i][j] += _min[j];
             }
@@ -1025,13 +1025,13 @@ T GaussianProcess<T>::interpolate(ndarray::Array<T, 1, 1> variance, ndarray::Arr
                           "Asked for more neighbors than you have data points\n");
     }
 
-    if (variance.getNumElements() != _nFunctions) {
+    if (variance.getNumElements() != static_cast<ndarray::Size>(_nFunctions)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "Your variance array is the incorrect size for the number "
                           "of functions you are trying to interpolate\n");
     }
 
-    if (vin.getNumElements() != _dimensions) {
+    if (vin.getNumElements() != static_cast<ndarray::Size>(_dimensions)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "You are interpolating at a point with different dimensionality than you data\n");
     }
@@ -1140,12 +1140,13 @@ void GaussianProcess<T>::interpolate(ndarray::Array<T, 1, 1> mu, ndarray::Array<
                           "Asked for more neighbors than you have data points\n");
     }
 
-    if (vin.getNumElements() != _dimensions) {
+    if (vin.getNumElements() != static_cast<ndarray::Size>(_dimensions)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "You are interpolating at a point with different dimensionality than you data\n");
     }
 
-    if (mu.getNumElements() != _nFunctions || variance.getNumElements() != _nFunctions) {
+    if (mu.getNumElements() != static_cast<ndarray::Size>(_nFunctions) ||
+        variance.getNumElements() != static_cast<ndarray::Size>(_nFunctions)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "Your mu and/or var arrays are improperly sized for the number of functions "
                           "you are interpolating\n");
@@ -1249,7 +1250,7 @@ T GaussianProcess<T>::selfInterpolate(ndarray::Array<T, 1, 1> variance, int dex,
                           "You are interpolating more than one function.");
     }
 
-    if (variance.getNumElements() != _nFunctions) {
+    if (variance.getNumElements() != static_cast<ndarray::Size>(_nFunctions)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "Your variance array is the incorrect size for the number "
                           "of functions you are trying to interpolate\n");
@@ -1365,7 +1366,8 @@ T GaussianProcess<T>::selfInterpolate(ndarray::Array<T, 1, 1> variance, int dex,
 template <typename T>
 void GaussianProcess<T>::selfInterpolate(ndarray::Array<T, 1, 1> mu, ndarray::Array<T, 1, 1> variance,
                                          int dex, int numberOfNeighbors) const {
-    if (mu.getNumElements() != _nFunctions || variance.getNumElements() != _nFunctions) {
+    if (mu.getNumElements() != static_cast<ndarray::Size>(_nFunctions) ||
+        variance.getNumElements() != static_cast<ndarray::Size>(_nFunctions)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "Your mu and/or var arrays are improperly sized for the number of functions "
                           "you are interpolating\n");
@@ -1485,9 +1487,9 @@ void GaussianProcess<T>::selfInterpolate(ndarray::Array<T, 1, 1> mu, ndarray::Ar
 template <typename T>
 void GaussianProcess<T>::batchInterpolate(ndarray::Array<T, 1, 1> mu, ndarray::Array<T, 1, 1> variance,
                                           ndarray::Array<T, 2, 2> const &queries) const {
-    int i, j, ii, nQueries;
+    int i, j;
 
-    nQueries = queries.template getSize<0>();
+    ndarray::Size nQueries = queries.template getSize<0>();
 
     if (_nFunctions != 1) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
@@ -1501,7 +1503,7 @@ void GaussianProcess<T>::batchInterpolate(ndarray::Array<T, 1, 1> mu, ndarray::A
                           "at which you are trying to interpolate your function.\n");
     }
 
-    if (queries.template getSize<1>() != _dimensions) {
+    if (queries.template getSize<1>() != static_cast<ndarray::Size>(_dimensions)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "The points you passed to batchInterpolate are of the wrong "
                           "dimensionality for your Gaussian Process\n");
@@ -1545,7 +1547,7 @@ void GaussianProcess<T>::batchInterpolate(ndarray::Array<T, 1, 1> mu, ndarray::A
     batchxx = ldlt.solve(batchbb);
     _timer.addToEigen();
 
-    for (ii = 0; ii < nQueries; ii++) {
+    for (ndarray::Size ii = 0; ii < nQueries; ii++) {
         for (i = 0; i < _dimensions; i++) v1[i] = queries[ii][i];
         if (_useMaxMin == 1) {
             for (i = 0; i < _dimensions; i++) v1[i] = (v1[i] - _min[i]) / (_max[i] - _min[i]);
@@ -1557,7 +1559,7 @@ void GaussianProcess<T>::batchInterpolate(ndarray::Array<T, 1, 1> mu, ndarray::A
     }
     _timer.addToIteration();
 
-    for (ii = 0; ii < nQueries; ii++) {
+    for (ndarray::Size ii = 0; ii < nQueries; ii++) {
         for (i = 0; i < _dimensions; i++) v1[i] = queries[ii][i];
         if (_useMaxMin == 1) {
             for (i = 0; i < _dimensions; i++) v1[i] = (v1[i] - _min[i]) / (_max[i] - _min[i]);
@@ -1585,9 +1587,9 @@ void GaussianProcess<T>::batchInterpolate(ndarray::Array<T, 1, 1> mu, ndarray::A
 template <typename T>
 void GaussianProcess<T>::batchInterpolate(ndarray::Array<T, 2, 2> mu, ndarray::Array<T, 2, 2> variance,
                                           ndarray::Array<T, 2, 2> const &queries) const {
-    int i, j, ii, nQueries, ifn;
+    int i, j, ifn;
 
-    nQueries = queries.template getSize<0>();
+    ndarray::Size nQueries = queries.template getSize<0>();
 
     if (mu.template getSize<0>() != nQueries || variance.template getSize<0>() != nQueries) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
@@ -1595,13 +1597,14 @@ void GaussianProcess<T>::batchInterpolate(ndarray::Array<T, 2, 2> mu, ndarray::A
                           "you are interpolating your functions.\n");
     }
 
-    if (mu.template getSize<1>() != _nFunctions || variance.template getSize<1>() != _nFunctions) {
+    if (mu.template getSize<1>() != static_cast<ndarray::Size>(_nFunctions) ||
+        variance.template getSize<1>() != static_cast<ndarray::Size>(_nFunctions)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "Your output arrays do not have room for all of the functions you are "
                           "interpolating\n");
     }
 
-    if (queries.template getSize<1>() != _dimensions) {
+    if (queries.template getSize<1>() != static_cast<ndarray::Size>(_dimensions)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "The points at which you are interpolating your functions have the "
                           "wrong dimensionality.\n");
@@ -1650,7 +1653,7 @@ void GaussianProcess<T>::batchInterpolate(ndarray::Array<T, 2, 2> mu, ndarray::A
         batchxx = ldlt.solve(batchbb);
         _timer.addToEigen();
 
-        for (ii = 0; ii < nQueries; ii++) {
+        for (ndarray::Size ii = 0; ii < nQueries; ii++) {
             for (i = 0; i < _dimensions; i++) v1[i] = queries[ii][i];
             if (_useMaxMin == 1) {
                 for (i = 0; i < _dimensions; i++) v1[i] = (v1[i] - _min[i]) / (_max[i] - _min[i]);
@@ -1664,7 +1667,7 @@ void GaussianProcess<T>::batchInterpolate(ndarray::Array<T, 2, 2> mu, ndarray::A
     }  // ifn = 0 to _nFunctions
 
     _timer.addToIteration();
-    for (ii = 0; ii < nQueries; ii++) {
+    for (ndarray::Size ii = 0; ii < nQueries; ii++) {
         for (i = 0; i < _dimensions; i++) v1[i] = queries[ii][i];
         if (_useMaxMin == 1) {
             for (i = 0; i < _dimensions; i++) v1[i] = (v1[i] - _min[i]) / (_max[i] - _min[i]);
@@ -1692,9 +1695,9 @@ void GaussianProcess<T>::batchInterpolate(ndarray::Array<T, 2, 2> mu, ndarray::A
 template <typename T>
 void GaussianProcess<T>::batchInterpolate(ndarray::Array<T, 1, 1> mu,
                                           ndarray::Array<T, 2, 2> const &queries) const {
-    int i, j, ii, nQueries;
+    int i, j;
 
-    nQueries = queries.template getSize<0>();
+    ndarray::Size nQueries = queries.template getSize<0>();
 
     if (_nFunctions != 1) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
@@ -1702,7 +1705,7 @@ void GaussianProcess<T>::batchInterpolate(ndarray::Array<T, 1, 1> mu,
                           "you are trying to interpolate.\n");
     }
 
-    if (queries.template getSize<1>() != _dimensions) {
+    if (queries.template getSize<1>() != static_cast<ndarray::Size>(_dimensions)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "The points at which you are trying to interpolate your function are "
                           "of the wrong dimensionality.\n");
@@ -1753,7 +1756,7 @@ void GaussianProcess<T>::batchInterpolate(ndarray::Array<T, 1, 1> mu,
     batchxx = ldlt.solve(batchbb);
     _timer.addToEigen();
 
-    for (ii = 0; ii < nQueries; ii++) {
+    for (ndarray::Size ii = 0; ii < nQueries; ii++) {
         for (i = 0; i < _dimensions; i++) v1[i] = queries[ii][i];
         if (_useMaxMin == 1) {
             for (i = 0; i < _dimensions; i++) v1[i] = (v1[i] - _min[i]) / (_max[i] - _min[i]);
@@ -1771,9 +1774,9 @@ void GaussianProcess<T>::batchInterpolate(ndarray::Array<T, 1, 1> mu,
 template <typename T>
 void GaussianProcess<T>::batchInterpolate(ndarray::Array<T, 2, 2> mu,
                                           ndarray::Array<T, 2, 2> const &queries) const {
-    int i, j, ii, nQueries, ifn;
+    int i, j, ifn;
 
-    nQueries = queries.template getSize<0>();
+    ndarray::Size nQueries = queries.template getSize<0>();
 
     if (mu.template getSize<0>() != nQueries) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
@@ -1781,13 +1784,13 @@ void GaussianProcess<T>::batchInterpolate(ndarray::Array<T, 2, 2> mu,
                           "at which you want to interpolate your functions.\n");
     }
 
-    if (mu.template getSize<1>() != _nFunctions) {
+    if (mu.template getSize<1>() != static_cast<ndarray::Size>(_nFunctions)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "Your output array does not have enough room for all of the functions "
                           "you are trying to interpolate.\n");
     }
 
-    if (queries.template getSize<1>() != _dimensions) {
+    if (queries.template getSize<1>() != static_cast<ndarray::Size>(_dimensions)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "The points at which you are interpolating your functions do not "
                           "have the correct dimensionality.\n");
@@ -1838,7 +1841,7 @@ void GaussianProcess<T>::batchInterpolate(ndarray::Array<T, 2, 2> mu,
         batchxx = ldlt.solve(batchbb);
         _timer.addToEigen();
 
-        for (ii = 0; ii < nQueries; ii++) {
+        for (ndarray::Size ii = 0; ii < nQueries; ii++) {
             for (i = 0; i < _dimensions; i++) v1[i] = queries[ii][i];
             if (_useMaxMin == 1) {
                 for (i = 0; i < _dimensions; i++) v1[i] = (v1[i] - _min[i]) / (_max[i] - _min[i]);
@@ -1864,7 +1867,7 @@ void GaussianProcess<T>::addPoint(ndarray::Array<T, 1, 1> const &vin, T f) {
                           "You are calling the wrong addPoint; you need a vector of functions\n");
     }
 
-    if (vin.getNumElements() != _dimensions) {
+    if (vin.getNumElements() != static_cast<ndarray::Size>(_dimensions)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "You are trying to add a point of the wrong dimensionality to "
                           "your GaussianProcess.\n");
@@ -1902,13 +1905,13 @@ void GaussianProcess<T>::addPoint(ndarray::Array<T, 1, 1> const &vin, T f) {
 
 template <typename T>
 void GaussianProcess<T>::addPoint(ndarray::Array<T, 1, 1> const &vin, ndarray::Array<T, 1, 1> const &f) {
-    if (vin.getNumElements() != _dimensions) {
+    if (vin.getNumElements() != static_cast<ndarray::Size>(_dimensions)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "You are trying to add a point of the wrong dimensionality to "
                           "your GaussianProcess.\n");
     }
 
-    if (f.template getSize<0>() != _nFunctions) {
+    if (f.template getSize<0>() != static_cast<ndarray::Size>(_nFunctions)) {
         throw LSST_EXCEPT(lsst::pex::exceptions::RuntimeError,
                           "You are not adding the correct number of function values to "
                           "your GaussianProcess.\n");
@@ -2006,10 +2009,8 @@ void SquaredExpCovariogram<T>::setEllSquared(double ellSquared) {
 template <typename T>
 T SquaredExpCovariogram<T>::operator()(ndarray::Array<const T, 1, 1> const &p1,
                                        ndarray::Array<const T, 1, 1> const &p2) const {
-    int i;
-    T d;
-    d = 0.0;
-    for (i = 0; i < p1.template getSize<0>(); i++) {
+    T d = 0.0;
+    for (ndarray::Size i = 0; i < p1.template getSize<0>(); i++) {
         d += (p1[i] - p2[i]) * (p1[i] - p2[i]);
     }
 

--- a/src/math/Interpolate.cc
+++ b/src/math/Interpolate.cc
@@ -301,7 +301,7 @@ std::vector<double> Interpolate::interpolate(std::vector<double> const &x) const
 ndarray::Array<double, 1> Interpolate::interpolate(ndarray::Array<double const, 1> const &x) const {
     int const num = x.getShape()[0];
     ndarray::Array<double, 1> out = ndarray::allocate(ndarray::makeVector(num));
-    for (size_t i = 0; i < num; ++i) {
+    for (int i = 0; i < num; ++i) {
         std::cout << "Interpolating " << x[i] << std::endl;
         out[i] = interpolate(x[i]);
     }

--- a/src/math/Interpolate.cc
+++ b/src/math/Interpolate.cc
@@ -161,6 +161,9 @@ namespace {
             throw LSST_EXCEPT(pex::exceptions::LogicError,
                               str(boost::format("You can't get here: style == %") % style));
     }
+    // don't use default statement to let compiler check switch coverage
+    throw LSST_EXCEPT(pex::exceptions::LogicError,
+                      str(boost::format("You can't get here: style == %") % style));
 }
 }
 

--- a/src/math/LinearCombinationKernel.cc
+++ b/src/math/LinearCombinationKernel.cc
@@ -163,8 +163,11 @@ std::shared_ptr<Kernel> LinearCombinationKernel::refactor() const {
             this->_spatialFunctionList.begin();
     KernelList::const_iterator kIter = _kernelList.begin();
     KernelList::const_iterator const kEnd = _kernelList.end();
+    auto & firstSpFunc = *firstSpFuncPtr;
+    auto & firstType = typeid(firstSpFunc);     // noncopyable object of static storage duration
     for (; kIter != kEnd; ++kIter, ++spFuncPtrIter) {
-        if (typeid(**spFuncPtrIter) != typeid(*firstSpFuncPtr)) {
+        auto & spFunc = **spFuncPtrIter;
+        if (typeid(spFunc) != firstType) {
             return std::shared_ptr<Kernel>();
         }
 

--- a/src/table/io/FitsSchemaInputMapper.cc
+++ b/src/table/io/FitsSchemaInputMapper.cc
@@ -38,7 +38,7 @@ private:
     std::string const &_v;
 };
 
-}  // anonymous
+}  // namespace
 
 class FitsSchemaInputMapper::Impl {
 public:
@@ -136,13 +136,10 @@ FitsSchemaInputMapper::FitsSchemaInputMapper(daf::base::PropertyList &metadata, 
         // Read slots saved using an old mechanism in as aliases, since the new slot mechanism delegates
         // slot definition to the AliasMap.
         static std::array<std::pair<std::string, std::string>, 7> oldSlotKeys = {
-                std::make_pair("PSF_FLUX", "slot_PsfFlux"),
-                std::make_pair("AP_FLUX", "slot_ApFlux"),
-                std::make_pair("INST_FLUX", "slot_InstFlux"),
-                std::make_pair("MODEL_FLUX", "slot_ModelFlux"),
-                std::make_pair("CALIB_FLUX", "slot_CalibFlux"),
-                std::make_pair("CENTROID", "slot_Centroid"),
-                std::make_pair("SHAPE", "slot_Shape")};
+                {std::make_pair("PSF_FLUX", "slot_PsfFlux"), std::make_pair("AP_FLUX", "slot_ApFlux"),
+                 std::make_pair("INST_FLUX", "slot_InstFlux"), std::make_pair("MODEL_FLUX", "slot_ModelFlux"),
+                 std::make_pair("CALIB_FLUX", "slot_CalibFlux"), std::make_pair("CENTROID", "slot_Centroid"),
+                 std::make_pair("SHAPE", "slot_Shape")}};
         for (std::size_t i = 0; i < oldSlotKeys.size(); ++i) {
             std::string target = metadata.get(oldSlotKeys[i].first + "_SLOT", std::string(""));
             if (!target.empty()) {
@@ -693,7 +690,7 @@ std::string replaceSuffix(std::string const &s, std::size_t n, std::string const
     return s.substr(0, s.size() - n) + suffix;
 }
 
-}  // anonymous
+}  // namespace
 
 Schema FitsSchemaInputMapper::finalize() {
     if (_impl->version == 0) {
@@ -780,7 +777,7 @@ void FitsSchemaInputMapper::readRecord(BaseRecord &record, afw::fits::Fits &fits
         (**iter).readCell(record, row, fits, _impl->archive);
     }
 }
-}
-}
-}
-}  // namespace lsst::afw::table::io
+}  // namespace io
+}  // namespace table
+}  // namespace afw
+}  // namespace lsst


### PR DESCRIPTION
This PR eliminates all but one compiler warning (unused `fits::{}::getFormatCode(int8_t)`) when building `afw` with Ubuntu+GCC and MacOS+Clang. Justifications for individual changes are included in the commit messages.

During the MacOS port a few unrelated clang-format changes were made because of the mismatch in clang-format versions between Ubuntu and MacOS. @parejkoj and I allowed them to get committed on the grounds that we will probably standardize on clang-format 5 anyway.