### PR TITLE
DM-11326: add image::bboxFromMetadata

### DIFF
--- a/include/lsst/afw/image/Image.h
+++ b/include/lsst/afw/image/Image.h
@@ -864,6 +864,13 @@ private:
 
 template <typename PixelT>
 void swap(DecoratedImage<PixelT>& a, DecoratedImage<PixelT>& b);
+
+/// Determine the image bounding box from its metadata (FITS header)
+///
+/// Note that this modifies the metadata, stripping the WCS headers that
+/// provide the xy0.
+geom::Box2I bboxFromMetadata(daf::base::PropertySet & metadata);
+
 }
 }
 }  // lsst::afw::image

--- a/python/lsst/afw/image/image/image.cc
+++ b/python/lsst/afw/image/image/image.cc
@@ -324,6 +324,8 @@ PYBIND11_PLUGIN(image) {
     declareCastConstructor<std::uint64_t, float>(clsImageF);
     declareCastConstructor<std::uint64_t, double>(clsImageD);
 
+    mod.def("bboxFromMetadata", &bboxFromMetadata);
+
     return mod.ptr();
 }
 }

--- a/src/image/Image.cc
+++ b/src/image/Image.cc
@@ -658,6 +658,13 @@ Image<LhsPixelT>& operator/=(Image<LhsPixelT>& lhs, Image<RhsPixelT> const& rhs)
     return lhs;
 }
 
+geom::Box2I bboxFromMetadata(daf::base::PropertySet & metadata)
+{
+    geom::Extent2I dims{metadata.getAsInt("NAXIS1"), metadata.getAsInt("NAXIS2")};
+    geom::Point2I xy0 = detail::getImageXY0FromMetadata(detail::wcsNameForXY0, &metadata);
+    return geom::Box2I(xy0, dims);
+}
+
 //
 // Explicit instantiations
 //

--- a/tests/test_imageIo1.py
+++ b/tests/test_imageIo1.py
@@ -170,6 +170,22 @@ class ReadFitsTestCase(lsst.utils.tests.TestCase):
             expNew = afwImage.ExposureF(tmpFile)
             self.assertEqual(expNew.getMetadata().get(keyWord), longString)
 
+    def checkBBoxFromMetadata(self, filename, expected, hdu=0):
+        metadata = afwImage.readMetadata(filename, hdu)
+        bbox = afwImage.bboxFromMetadata(metadata)
+        self.assertEqual(bbox, expected)
+
+    def testBBoxFromMetadata(self):
+        self.checkBBoxFromMetadata(os.path.join(dataDir, "871034p_1_img.fits"),
+                                   afwGeom.Box2I(afwGeom.Point2I(0, 0), afwGeom.Extent2I(2112, 4644)))
+        for hdu in range(1, 4):
+            self.checkBBoxFromMetadata(os.path.join(dataDir, "871034p_1_MI.fits"),
+                                       afwGeom.Box2I(afwGeom.Point2I(0, 0), afwGeom.Extent2I(2112, 4644)),
+                                       hdu=hdu)
+            self.checkBBoxFromMetadata(os.path.join(dataDir, "medsub.fits"),
+                                       afwGeom.Box2I(afwGeom.Point2I(40, 150), afwGeom.Extent2I(145, 200)),
+                                       hdu=hdu)
+
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):
     pass


### PR DESCRIPTION
This function provides a bounding box, given the FITS header.