### PR TITLE
Implement PhotoCalib ops that output to catalogs.

### DIFF
--- a/src/image/PhotoCalib.cc
+++ b/src/image/PhotoCalib.cc
@@ -102,8 +102,16 @@ ndarray::Array<double, 2, 2> PhotoCalib::instFluxToMaggies(afw::table::SourceCat
 
 void PhotoCalib::instFluxToMaggies(afw::table::SourceCatalog &sourceCatalog, std::string const &instFluxField,
                                    std::string const &outField) const {
-    throw LSST_EXCEPT(pex::exceptions::LogicError,
-                      "Will not be implemented until RFC-322 is implemented. See DM-10155");
+    auto instFluxKey = sourceCatalog.getSchema().find<double>(instFluxField + "_flux").key;
+    auto instFluxErrKey = sourceCatalog.getSchema().find<double>(instFluxField + "_fluxSigma").key;
+    auto maggiesKey = sourceCatalog.getSchema().find<double>(outField + "_calFlux").key;
+    auto maggiesErrKey = sourceCatalog.getSchema().find<double>(outField + "_calFluxErr").key;
+    for (auto & record : sourceCatalog) {
+        auto result = instFluxToMaggies(record.get(instFluxKey), record.get(instFluxErrKey),
+                                        record.getCentroid());
+        record.set(maggiesKey, result.value);
+        record.set(maggiesErrKey, result.err);
+    }
 }
 
 // ------------------- Conversions to Magnitudes -------------------
@@ -153,8 +161,16 @@ ndarray::Array<double, 2, 2> PhotoCalib::instFluxToMagnitude(afw::table::SourceC
 
 void PhotoCalib::instFluxToMagnitude(afw::table::SourceCatalog &sourceCatalog,
                                      std::string const &instFluxField, std::string const &outField) const {
-    throw LSST_EXCEPT(pex::exceptions::LogicError,
-                      "Will not be implemented until RFC-322 is implemented. See DM-10155.");
+    auto instFluxKey = sourceCatalog.getSchema().find<double>(instFluxField + "_flux").key;
+    auto instFluxErrKey = sourceCatalog.getSchema().find<double>(instFluxField + "_fluxSigma").key;
+    auto magKey = sourceCatalog.getSchema().find<double>(outField + "_mag").key;
+    auto magErrKey = sourceCatalog.getSchema().find<double>(outField + "_magErr").key;
+    for (auto & record : sourceCatalog) {
+        auto result = instFluxToMagnitude(record.get(instFluxKey), record.get(instFluxErrKey),
+                                          record.getCentroid());
+        record.set(magKey, result.value);
+        record.set(magErrKey, result.err);
+    }
 }
 
 // ------------------- other utility methods -------------------

--- a/tests/test_photoCalib.py
+++ b/tests/test_photoCalib.py
@@ -184,15 +184,13 @@ class PhotoCalibTestCase(lsst.utils.tests.TestCase):
         result = photoCalib.instFluxToMagnitude(catalog, self.instFluxKeyName)
         self.assertFloatsAlmostEqual(expectMag, result)
 
-        # test calculations on a sourceCatalog, setting values in the catalog
-        # TODO: see RFC-322 and DM-10155
-        RFC322_implemented = False
-        if RFC322_implemented:
-            photoCalib.instFluxToMaggiesAndMagnitude(self.catalog, self.instFluxKeyName, self.instFluxKeyName)
-            self.assertFloatsAlmostEqual(self.catalog[self.instFluxKeyName+'flux'], expectMaggies[:, 0])
-            self.assertFloatsAlmostEqual(self.catalog[self.instFluxKeyName+'fluxErr'], expectMaggies[:, 1])
-            self.assertFloatsAlmostEqual(self.catalog[self.instFluxKeyName+'magnitude'], expectMag[:, 0])
-            self.assertFloatsAlmostEqual(self.catalog[self.instFluxKeyName+'magnitudeErr'], expectMag[:, 1])
+        photoCalib.instFluxToMagnitude(catalog, self.instFluxKeyName, self.instFluxKeyName)
+        self.assertFloatsAlmostEqual(catalog[self.instFluxKeyName+'_mag'], expectMag[:, 0])
+        self.assertFloatsAlmostEqual(catalog[self.instFluxKeyName+'_magErr'], expectMag[:, 1])
+
+        photoCalib.instFluxToMaggies(catalog, self.instFluxKeyName, self.instFluxKeyName)
+        self.assertFloatsAlmostEqual(catalog[self.instFluxKeyName+'_calFlux'], expectMaggies[:, 0])
+        self.assertFloatsAlmostEqual(catalog[self.instFluxKeyName+'_calFluxErr'], expectMaggies[:, 1])
 
     def testNonVarying(self):
         """Tests a non-spatially-varying zeropoint."""


### PR DESCRIPTION
Names used here will have to be updated when RFC-322 is adopted.

This PR is a new one (against master) that supercedes #262.