### PR TITLE
DM-11429 Skip variable-length array fields in asAstropy

### DIFF
--- a/python/lsst/afw/table/base/baseContinued.py
+++ b/python/lsst/afw/table/base/baseContinued.py
@@ -269,6 +269,12 @@ class Catalog(with_metaclass(TemplateMeta, object)):
                 unit = "radian"
                 if copy:
                     data = data.copy()
+            elif "Array" in key.getTypeString() and key.isVariableLength():
+                # Can't get columns for variable-length array fields.
+                if unviewable == "raise":
+                    raise ValueError("Cannot extract variable-length array fields unless unviewable='skip'.")
+                elif unviewable == "skip" or unviewable == "copy":
+                    continue
             else:
                 data = self.columns.get(key)
                 if copy:


### PR DESCRIPTION
We can't use `columns.get()` on variable-length array fields, so the `unvieewable=copy` mode doesn't work, so we just skip them, unless we should raise. It's hacky, but until they're `get()`able, there's probably not a way around it.