### PR TITLE
Make it possible to specify an origin (e.g. PARENT) with e.g. im[bbox]

### DIFF
--- a/python/lsst/afw/image/slicing.py
+++ b/python/lsst/afw/image/slicing.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
 import lsst.afw.geom as afwGeom
-from .image import LOCAL
+from .image import LOCAL, PARENT, ImageOrigin
 
 __all__ = ["supportSlicing"]
 
 
 def _getBBoxFromSliceTuple(img, imageSlice):
-    """Given a slice specification return the proper Box2I
+    """Given a slice specification return the proper Box2I and origin
     This is the worker routine behind __getitem__ and __setitem__
 
     The imageSlice may be:
@@ -31,9 +31,30 @@ def _getBBoxFromSliceTuple(img, imageSlice):
      im[-2, -2]
      im[1:4, 6:10]
      im[:]
+
+    You may also add an extra argument, afwImage.PARENT or afwImage.LOCAL.  The default is LOCAL
+    as before, but if you specify PARENT the bounding box is interpreted in PARENT coordinates
+    (this includes slices; e.g.
+     im[-3:, -2:, afwImage.PARENT]
+    still means the last few rows and columns, and 
+     im[1001:1004, 2006:2010, afwImage.PARENT]
+    with xy0 = (1000, 2000) refers to the same pixels as
+     im[1:4, 6:10, afwImage.LOCAL]
+    )
     """
+    origin = LOCAL                      # this sets the default value
+
+    try:
+        _origin = imageSlice[-1]
+    except TypeError:
+        _origin = None
+
+    if isinstance(_origin, ImageOrigin):
+        origin = _origin
+        imageSlice = imageSlice[0] if len(imageSlice) <= 2 else imageSlice[:-1]
+        
     if isinstance(imageSlice, afwGeom.Box2I):
-        return imageSlice
+        return imageSlice, origin
 
     if isinstance(imageSlice, slice) and imageSlice.start is None and imageSlice.stop is None:
         imageSlice = (Ellipsis, Ellipsis,)
@@ -43,31 +64,44 @@ def _getBBoxFromSliceTuple(img, imageSlice):
         raise IndexError(
             "Images may only be indexed as a 2-D slice not %s" % imageSlice)
 
+    # Because we're going to use slice.indices(...) to construct our ranges, and
+    # python doesn't understand PARENT coordinate systems,  we need
+    # to convert slices specified in PARENT coords to LOCAL
+
     imageSlice, _imageSlice = [], imageSlice
-    for s, wh in zip(_imageSlice, img.getDimensions()):
+    for s, wh, z0 in zip(_imageSlice, img.getDimensions(), img.getXY0()):
+        if origin == LOCAL:
+            z0 = 0                      # ignore image's xy0
+
         if isinstance(s, slice):
-            pass
+            if z0 != 0:
+                start = s.start if s.start is None or s.start < 0 else s.start - z0
+                stop  = s.stop  if s.stop  is None or s.stop  < 0 else s.stop -  z0
+                s = slice(start, stop, s.step)
         elif isinstance(s, int):
             if s < 0:
-                s += wh
-            s = slice(s, s + 1)
+                s += z0 + wh
+            s = slice(s - z0, s - z0 + 1)
         else:
             s = slice(0, wh)
 
         imageSlice.append(s)
 
     x, y = [_.indices(wh) for _, wh in zip(imageSlice, img.getDimensions())]
-    return afwGeom.Box2I(afwGeom.Point2I(x[0], y[0]), afwGeom.Point2I(x[1] - 1, y[1] - 1))
-
+    return afwGeom.Box2I(afwGeom.Point2I(x[0], y[0]), afwGeom.Point2I(x[1] - 1, y[1] - 1)), LOCAL
 
 def supportSlicing(cls):
     """Support image slicing
     """
 
-    def Factory(self, *args):
+    def _checkOrigin(origin):
+        if origin not in (LOCAL, PARENT):
+            raise RuntimeError("keyword origin must be afwImage.ORIGIN or afwImage.PARENT, not %s" % origin)
+
+    def Factory(self, *args, **kwargs):
         """Return an object of this type
         """
-        return cls(*args)
+        return cls(*args, **kwargs)
     cls.Factory = Factory
 
     def clone(self):
@@ -76,14 +110,18 @@ def supportSlicing(cls):
     cls.clone = clone
 
     def __getitem__(self, imageSlice):
-        return self.Factory(self, _getBBoxFromSliceTuple(self, imageSlice), LOCAL)
+        bbox, origin = _getBBoxFromSliceTuple(self, imageSlice)
+
+        _checkOrigin(origin)
+        return self.Factory(self, bbox, origin)
     cls.__getitem__ = __getitem__
 
     def __setitem__(self, imageSlice, rhs):
-        bbox = _getBBoxFromSliceTuple(self, imageSlice)
+        bbox, origin = _getBBoxFromSliceTuple(self, imageSlice)
 
-        if self.assign(rhs, bbox, LOCAL) is NotImplemented:
-            lhs = self.Factory(self, bbox, LOCAL)
+        _checkOrigin(origin)
+        if self.assign(rhs, bbox, origin) is NotImplemented:
+            lhs = self.Factory(self, bbox, origin=origin)
             lhs.set(rhs)
     cls.__setitem__ = __setitem__
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -521,11 +521,55 @@ class ImageTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(im.get(2, 2), 10)
         self.assertEqual(im.get(0, 0), -1)
 
+    def testImageSlicesOrigin(self):
+        """Test image slicing, which generate sub-images using Box2I under the covers"""
+        im = afwImage.ImageF(10, 20)
+        im.setXY0(50, 100)
+        im[-1, :, afwImage.PARENT] = -5
+        im[..., 118, afwImage.PARENT] = -5              # equivalent to im[:, 118]
+        im[54, 110, afwImage.PARENT] = 10
+        im[-3:, -2:, afwImage.PARENT] = 100
+        im[-2, -2, afwImage.PARENT] = -10
+        sim = im[51:54, 106:110, afwImage.PARENT]
+        sim[:] = -1
+        im[50:54, 100:104, afwImage.PARENT] = im[2:6, 8:12, afwImage.LOCAL]
+
+        if display:
+            ds9.mtv(im)
+
+        self.assertEqual(im.get(0, 6), 0)
+        self.assertEqual(im.get(9, 15), -5)
+        self.assertEqual(im.get(5, 18), -5)
+        self.assertEqual(im.get(6, 17), 0)
+        self.assertEqual(im.get(7, 18), 100)
+        self.assertEqual(im.get(9, 19), 100)
+        self.assertEqual(im.get(8, 18), -10)
+        self.assertEqual(im.get(1, 6), -1)
+        self.assertEqual(im.get(3, 9), -1)
+        self.assertEqual(im.get(4, 10), 10)
+        self.assertEqual(im.get(4, 9), 0)
+        self.assertEqual(im.get(2, 2), 10)
+        self.assertEqual(im.get(0, 0), -1)
+
     def testImageSliceFromBox(self):
         """Test using a Box2I to index an Image"""
         im = afwImage.ImageF(10, 20)
         bbox = afwGeom.BoxI(afwGeom.PointI(1, 3), afwGeom.PointI(6, 9))
         im[bbox] = -1
+
+        if display:
+            ds9.mtv(im)
+
+        self.assertEqual(im.get(0, 6), 0)
+        self.assertEqual(im.get(1, 6), -1)
+        self.assertEqual(im.get(3, 9), -1)
+
+    def testImageSliceFromBoxOrigin(self):
+        """Test using a Box2I to index an Image"""
+        im = afwImage.ImageF(10, 20)
+        im.setXY0(50, 100)
+        bbox = afwGeom.BoxI(afwGeom.PointI(51, 103), afwGeom.ExtentI(6, 7))
+        im[bbox, afwImage.PARENT] = -1
 
         if display:
             ds9.mtv(im)


### PR DESCRIPTION
That is, when using the syntactic sugar which makes using bboxes easier,
allow an extra argument such as
    im[bbox, afwImage.PARENT]
or
	 im[1000:1010, -1:, afwImage.PARENT]

In the second case we'll use PARENT coordinates when interpreting the
slices (i.e. the "1000" includes x0)