### PR TITLE
DM-12061: Eliminate test warnings in test_methods.py

### DIFF
--- a/tests/test_maskedImageIO.py
+++ b/tests/test_maskedImageIO.py
@@ -39,7 +39,7 @@ import tempfile
 
 from builtins import object
 import numpy as np
-import pyfits
+import astropy.io
 
 import lsst.utils
 import lsst.utils.tests
@@ -204,9 +204,9 @@ class MaskedImageTestCase(unittest.TestCase):
 def tmpFits(*hdus):
     # Given a list of numpy arrays, create a temporary FITS file that
     # contains them as consecutive HDUs. Yield it, then remove it.
-    hdus = [pyfits.PrimaryHDU(hdus[0])] + [pyfits.ImageHDU(hdu)
-                                           for hdu in hdus[1:]]
-    hdulist = pyfits.HDUList(hdus)
+    hdus = [astropy.io.fits.PrimaryHDU(hdus[0])] + \
+        [astropy.io.fits.ImageHDU(hdu) for hdu in hdus[1:]]
+    hdulist = astropy.io.fits.HDUList(hdus)
     tempdir = tempfile.mkdtemp()
     try:
         filename = os.path.join(tempdir, 'test.fits')

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -20,6 +20,7 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 #
 from __future__ import absolute_import, division, print_function
+import contextlib
 import math
 import unittest
 import re
@@ -39,6 +40,20 @@ from lsst.afw.image.basicUtils import _compareWcsOverBBox
 class TestTestUtils(lsst.utils.tests.TestCase):
     """Test test methods added to lsst.utils.tests.TestCase
     """
+    def setUp(self):
+        # unittest did not get `assertWarns` until Python 3.2
+        self._addedAssertWarns = False
+        if not hasattr(self, "assertWarns"):
+            self._addedAssertWarns = True
+
+            @contextlib.contextmanager
+            def nullContextManger(dummy):
+                yield
+            self.assertWarns = nullContextManger
+
+    def tearDown(self):
+        if self._addedAssertWarns:
+            del self.assertWarns
 
     def testAssertAnglesAlmostEqual(self):
         """Test assertAnglesAlmostEqual"""
@@ -50,11 +65,12 @@ class TestTestUtils(lsst.utils.tests.TestCase):
                 maxDiff=0.010001*afwGeom.arcseconds,
             )
             # sanity-check deprecated version
-            self.assertAnglesNearlyEqual(
-                ang0,
-                ang0 + 0.01*afwGeom.arcseconds,
-                maxDiff=0.010001*afwGeom.arcseconds,
-            )
+            with self.assertWarns(DeprecationWarning):
+                self.assertAnglesNearlyEqual(
+                    ang0,
+                    ang0 + 0.01*afwGeom.arcseconds,
+                    maxDiff=0.010001*afwGeom.arcseconds,
+                )
             with self.assertRaises(AssertionError):
                 self.assertAnglesAlmostEqual(
                     ang0,
@@ -128,8 +144,9 @@ class TestTestUtils(lsst.utils.tests.TestCase):
                     self.assertBoxesAlmostEqual(
                         box0, box1, maxDiff=radDiff*1.00001)
                     # sanity-check deprecated version
-                    self.assertBoxesNearlyEqual(
-                        box0, box1, maxDiff=radDiff*1.00001)
+                    with self.assertWarns(DeprecationWarning):
+                        self.assertBoxesNearlyEqual(
+                            box0, box1, maxDiff=radDiff*1.00001)
                     with self.assertRaises(AssertionError):
                         self.assertBoxesAlmostEqual(
                             box0, box1, maxDiff=radDiff*0.99999)
@@ -158,8 +175,9 @@ class TestTestUtils(lsst.utils.tests.TestCase):
             self.assertCoordsAlmostEqual(
                 coord0, coord0, maxDiff=1e-7*afwGeom.arcseconds)
             # sanity-check deprecated version
-            self.assertCoordsNearlyEqual(
-                coord0, coord0, maxDiff=1e-7*afwGeom.arcseconds)
+            with self.assertWarns(DeprecationWarning):
+                self.assertCoordsNearlyEqual(
+                    coord0, coord0, maxDiff=1e-7*afwGeom.arcseconds)
 
             for offAng in (0, 45, 90):
                 offAng = offAng*afwGeom.degrees
@@ -246,7 +264,8 @@ class TestTestUtils(lsst.utils.tests.TestCase):
         for pair0 in ((-5, 4), (-5, 0.001), (0, 0), (49, 0.1)):
             self.assertPairsAlmostEqual(pair0, pair0, maxDiff=1e-7)
             # sanity-check deprecated version
-            self.assertPairsNearlyEqual(pair0, pair0, maxDiff=1e-7)
+            with self.assertWarns(DeprecationWarning):
+                self.assertPairsNearlyEqual(pair0, pair0, maxDiff=1e-7)
             self.assertPairsAlmostEqual(afwGeom.Point2D(*pair0),
                                         afwGeom.Extent2D(*pair0), maxDiff=1e-7)
             for diff in ((0.001, 0), (-0.01, 0.03)):
@@ -285,8 +304,9 @@ class TestTestUtils(lsst.utils.tests.TestCase):
         self.assertWcsAlmostEqualOverBBox(wcs0, wcs0, bbox,
                                           maxDiffSky=1e-7*afwGeom.arcseconds, maxDiffPix=1e-7)
         # sanity-check deprecated version
-        self.assertWcsNearlyEqualOverBBox(wcs0, wcs0, bbox,
-                                          maxDiffSky=1e-7*afwGeom.arcseconds, maxDiffPix=1e-7)
+        with self.assertWarns(DeprecationWarning):
+            self.assertWcsNearlyEqualOverBBox(wcs0, wcs0, bbox,
+                                              maxDiffSky=1e-7*afwGeom.arcseconds, maxDiffPix=1e-7)
         self.assertTrue(afwImage.wcsAlmostEqualOverBBox(wcs0, wcs0, bbox,
                                                         maxDiffSky=1e-7*afwGeom.arcseconds, maxDiffPix=1e-7))
 
@@ -335,7 +355,8 @@ class TestTestUtils(lsst.utils.tests.TestCase):
         self.assertMaskedImagesAlmostEqual(mi0, mi1, atol=0, rtol=0)
         self.assertMaskedImagesAlmostEqual(mi0, mi1, atol=0, rtol=0)
         # sanity-check deprecated version
-        self.assertMaskedImagesNearlyEqual(mi1, mi0, atol=0, rtol=0)
+        with self.assertWarns(DeprecationWarning):
+            self.assertMaskedImagesNearlyEqual(mi1, mi0, atol=0, rtol=0)
         self.assertMaskedImagesAlmostEqual(
             mi0.getArrays(), mi1, atol=0, rtol=0)
         self.assertMaskedImagesAlmostEqual(
@@ -349,7 +370,8 @@ class TestTestUtils(lsst.utils.tests.TestCase):
             self.assertImagesEqual(plane1, plane0)
             self.assertImagesAlmostEqual(plane0, plane1, atol=0, rtol=0)
             # sanity-check deprecated version
-            self.assertImagesNearlyEqual(plane0, plane1, atol=0, rtol=0)
+            with self.assertWarns(DeprecationWarning):
+                self.assertImagesNearlyEqual(plane0, plane1, atol=0, rtol=0)
             self.assertImagesAlmostEqual(plane1, plane0, atol=0, rtol=0)
             self.assertImagesAlmostEqual(
                 plane0.getArray(), plane1, atol=0, rtol=0)

--- a/tests/test_simpleTable.py
+++ b/tests/test_simpleTable.py
@@ -37,12 +37,6 @@ from builtins import zip
 from builtins import range
 import numpy as np
 
-try:
-    import pyfits
-except ImportError:
-    pyfits = None
-    print("WARNING: pyfits not available; some tests will not be run")
-
 import lsst.utils.tests
 import lsst.pex.exceptions
 import lsst.daf.base

--- a/tests/test_skyWcs.py
+++ b/tests/test_skyWcs.py
@@ -3,7 +3,7 @@ import itertools
 import sys
 import unittest
 
-import lsst.afw.coord   # needed for assertCoordsNearlyEqual
+import lsst.afw.coord   # needed for assertCoordsAlmostEqual
 import lsst.utils.tests
 from lsst.afw.coord import IcrsCoord
 from lsst.afw.geom import SkyWcs, Extent2D, Point2D, degrees, \
@@ -185,10 +185,10 @@ class WcsPairTransformTestCase(TransformTestBaseClass):
                 transform = makeWcsPairTransform(wcs1, wcs2)
                 for point1 in self.points():
                     point2 = transform.applyForward(point1)
-                    self.assertPairsNearlyEqual(
+                    self.assertPairsAlmostEqual(
                         transform.applyInverse(point2),
                         point1)
-                    self.assertCoordsNearlyEqual(
+                    self.assertCoordsAlmostEqual(
                         wcs1.pixelToSky(point1),
                         wcs2.pixelToSky(point2))
 
@@ -200,8 +200,8 @@ class WcsPairTransformTestCase(TransformTestBaseClass):
             for point in self.points():
                 outPoint1 = transform.applyForward(point)
                 outPoint2 = transform.applyInverse(outPoint1)
-                self.assertPairsNearlyEqual(point, outPoint1)
-                self.assertPairsNearlyEqual(outPoint1, outPoint2)
+                self.assertPairsAlmostEqual(point, outPoint1)
+                self.assertPairsAlmostEqual(outPoint1, outPoint2)
 
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_skyWcs.py
+++ b/tests/test_skyWcs.py
@@ -3,7 +3,6 @@ import itertools
 import sys
 import unittest
 
-import lsst.afw.coord   # needed for assertCoordsAlmostEqual
 import lsst.utils.tests
 from lsst.afw.coord import IcrsCoord
 from lsst.afw.geom import SkyWcs, Extent2D, Point2D, degrees, \

--- a/tests/test_skyWcs.py
+++ b/tests/test_skyWcs.py
@@ -150,7 +150,7 @@ class WcsPairTransformTestCase(TransformTestBaseClass):
             IcrsCoord(0.00001 * degrees, 45 * degrees),
             IcrsCoord(359.99999 * degrees, 45 * degrees),
             IcrsCoord(30 * degrees, 89.99999 * degrees),
-            ]
+        ]
         orientationList = [
             0 * degrees,
             0.00001 * degrees,

--- a/tests/test_wcsFitsTable.py
+++ b/tests/test_wcsFitsTable.py
@@ -23,7 +23,7 @@
 from __future__ import absolute_import, division, print_function
 import unittest
 
-import pyfits
+import astropy.io
 
 import lsst.afw.image
 import lsst.afw.geom
@@ -167,7 +167,7 @@ class WcsFitsTableTestCase(unittest.TestCase):
             # Manually mess up the headers, so we'd know if we were loading the Wcs from that;
             # when there is a WCS in the header and a WCS in the FITS table, we should use the
             # latter, because the former might just be an approximation.
-            fits = pyfits.open(fileName)
+            fits = astropy.io.fits.open(fileName)
             fits[1].header.remove("CTYPE1")
             fits[1].header.remove("CTYPE2")
             fits.writeto(fileName, clobber=True)

--- a/ups/afw.table
+++ b/ups/afw.table
@@ -16,7 +16,7 @@ setupRequired(python_future)
 setupRequired(log)
 setupRequired(pybind11)
 setupRequired(astshim)
-setupOptional(pyfits)
+setupOptional(astropy)
 setupOptional(matplotlib)
 
 setupOptional(afwdata)


### PR DESCRIPTION
Use `unittest.assertWarns` if available to check that deprecated
asserts raise `DeprecationWarning`. If the version of Python
is too old for unittest to have `assertWarngs` then use a
null context manager instead (and pytest will issue warnings).