### PR TITLE
DM-12905: fits: fix doxygen warnings

### DIFF
--- a/doc/doxygen.conf.in
+++ b/doc/doxygen.conf.in
@@ -12,4 +12,5 @@ EXCLUDE += src/geom/ellipses
 EXCLUDE += src/detection/Psf.cc
 EXCLUDE += src/detection/DoubleGaussianPsf.cc
 EXCLUDE += src/fits.cc
+EXCLUDE += src/fitsCompression.cc
 EXCLUDE_SYMBOLS += _swig_property

--- a/include/lsst/afw/fitsCompression.h
+++ b/include/lsst/afw/fitsCompression.h
@@ -377,7 +377,8 @@ class ImageScalingOptions {
     std::vector<std::string> maskPlanes;  ///< Mask planes to ignore when doing statistics
     float quantizeLevel;  ///< Divisor of the standard deviation for STDEV_* scaling
     float quantizePad;  ///< Number of stdev to allow on the low/high side (for STDEV_POSITIVE/NEGATIVE)
-    double bscale, bzero;  ///< Manually specified BSCALE and BZERO (for MANUAL scaling)
+    double bscale;  ///< Manually specified BSCALE (for MANUAL scaling)
+    double bzero;  ///< Manually specified BZERO (for MANUAL scaling)
 
     /// Default Ctor
     ///
@@ -417,7 +418,7 @@ class ImageScalingOptions {
     ImageScalingOptions(int bitpix_, double bscale_=1.0, double bzero_=0.0)
       : ImageScalingOptions(MANUAL, bitpix_, {}, 1, 4.0, 5.0, false, bscale_, bzero_) {}
 
-    //{
+    //@{
     /// Determine the scaling for a particular image
     ///
     /// @param[in] image  Image for which to determine scaling
@@ -436,7 +437,7 @@ class ImageScalingOptions {
         ndarray::Array<T const, N, N> const& image,
         ndarray::Array<bool, N, N> const& mask
     ) const;
-    //}
+    //@}
 
   private:
     /// Convert image,mask to arrays


### PR DESCRIPTION
fitsCompression.cc is causing doxygen warnings:

    documented symbol `ImageScale lsst::afw::fits::ImageScalingOptions::determine' was not declared or defined.

This appears to be due to a bug in doxygen (perhaps having to do with
underscores at the end of variable names?). To deal with this, corrected
the grouping markup for ImageScalingOptions::determine and put
fitsCompression.cc on the doxygen exclusion list. This doesn't produce
correct docs (e.g., ImageScalingOptions::determine isn't listed as a
member function) but it's no worse than it was before, more correct and
doesn't produce a warning.