### PR TITLE
DM-12040: Errors in test_transformFactory.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ core.*
 .sconsign.dblite
 config.log
 memleak.fits
+pytest_session.txt
 bin/filter-gcc
 doc/*.tag
 doc/html

--- a/tests/test_transformFactory.py
+++ b/tests/test_transformFactory.py
@@ -38,7 +38,7 @@ import lsst.pex.exceptions as pexExcept
 import lsst.utils.tests
 
 
-class transformFactoryTestSuite(TransformTestBaseClass):
+class TransformFactoryTestSuite(TransformTestBaseClass):
 
     def setUp(self):
         TransformTestBaseClass.setUp(self)


### PR DESCRIPTION
This PR fixes a bug in `testLinearize` and increases its test coverage, as well as taking care of a few cleanup issues.