### PR TITLE
DM-12103: Investigate centering for vignetted pupils

### DIFF
--- a/python/lsst/afw/cameraGeom/camera.py
+++ b/python/lsst/afw/cameraGeom/camera.py
@@ -52,7 +52,7 @@ class Camera(DetectorCollection):
         """
         return self._name
 
-    def getPupilFactory(self, visitInfo, pupilSize, npix):
+    def getPupilFactory(self, visitInfo, pupilSize, npix, **kwargs):
         """!Construct a PupilFactory.
 
         @param[in] visitInfo  VisitInfo object for a particular exposure.
@@ -62,7 +62,7 @@ class Camera(DetectorCollection):
                               accommodate zero-padding.
         @param[in] npix       Constructed Pupils will be npix x npix.
         """
-        return self._pupilFactoryClass(visitInfo, pupilSize, npix)
+        return self._pupilFactoryClass(visitInfo, pupilSize, npix, **kwargs)
 
     @property
     def telescopeDiameter(self):

--- a/python/lsst/afw/cameraGeom/pupil.py
+++ b/python/lsst/afw/cameraGeom/pupil.py
@@ -138,3 +138,22 @@ class PupilFactory(object):
         pupil.illuminated[(d < 0.5*thickness) &
                           ((self.u - p0[0])*np.cos(angleRad) +
                            (self.v - p0[1])*np.sin(angleRad) >= 0)] = False
+
+    def _centerPupil(self, pupil):
+        """Center the illuminated portion of the pupil in array.
+
+        @param[in,out] pupil  Pupil to modify in place
+        """
+        def center(arr, axis):
+            smash = np.sum(arr, axis=axis)
+            w = np.where(smash)[0]
+            return int(0.5*(np.min(w)+np.max(w)))
+        ycenter = center(pupil.illuminated, 0)
+        xcenter = center(pupil.illuminated, 1)
+        ytarget = pupil.illuminated.shape[0]//2
+        xtarget = pupil.illuminated.shape[1]//2
+        pupil.illuminated = np.roll(np.roll(pupil.illuminated,
+                                            xtarget-xcenter,
+                                            axis=0),
+                                    ytarget-ycenter,
+                                    axis=1)


### PR DESCRIPTION
Adds _centerPupil function and **kwargs to getPupilFactory to
optionally recenter the illuminated portion of a pupil within
a pupil array, similar to what is done in Zemax.