### PR TITLE
Fix uninitialized variable problem.

### DIFF
--- a/tests/test_tableArchives.cc
+++ b/tests/test_tableArchives.cc
@@ -345,8 +345,8 @@ BOOST_AUTO_TEST_CASE(CompatibleSchemas) {
     std::shared_ptr<Comparable> a1(new ExampleA(3, 2.5, av1));
 
     ndarray::Array<float, 1, 1> av2 = ndarray::allocate(2);
-    av1[0] = 2.1;
-    av1[1] = 2.2;
+    av2[0] = 2.1;
+    av2[1] = 2.2;
     std::shared_ptr<Comparable> a2(new ExampleA(4, 3.5, av2));
 
     roundtripAndCompare(ndarray::makeVector(a1, a2), ndarray::makeVector<ndarray::Size>(2));


### PR DESCRIPTION
The wrong variable was being set, leaving the correct one uninitialized.  If the uninitialized memory happened to contain a NaN, it would not compare properly even after round-tripping correctly.