### PR TITLE
DM-12521: Update boost to 1.66

### DIFF
--- a/doc/imageAlgorithm.dox
+++ b/doc/imageAlgorithm.dox
@@ -15,7 +15,7 @@ spirit of the STL was more important.  There are variants of @c for_each_pixel c
 pixel to a function, setting it to a function of an Image, and setting it to a
 function of its value and a second Image's pixel value.  The selection of which of these operations is desired
 is done by requiring the functor to inherit from a class such as @c pixelOp0 or @c pixelOp1XY, each of which
-is a @c tr1::function with a virtual @c operator() added.
+is a @c std::function with a virtual @c operator() added.
 
 <DL>
 <DT> <TT>for_each_pixel(Image<LhsT> &lhs, pixelOp0<LhsT> const& func)</TT>

--- a/include/lsst/afw/image/ImageAlgorithm.h
+++ b/include/lsst/afw/image/ImageAlgorithm.h
@@ -34,7 +34,6 @@
 #include <utility>
 #include <functional>
 
-#include "boost/tr1/functional.hpp"
 #include "boost/mpl/bool.hpp"
 #include <memory>
 
@@ -48,46 +47,46 @@ namespace lsst {
 namespace afw {
 namespace image {
 /**
- * A functor class equivalent to tr1::function<ValT ()>, but with a virtual operator()
+ * A functor class equivalent to std::function<ValT ()>, but with a virtual operator()
  */
 template <typename ValT>
-struct pixelOp0 : public std::tr1::function<ValT()> {
+struct pixelOp0 : public std::function<ValT()> {
     virtual ~pixelOp0() {}
     virtual ValT operator()() const = 0;
 };
 
 /**
- * A functor class equivalent to tr1::function<ValT (ValT)>, but with a virtual operator()
+ * A functor class equivalent to std::function<ValT (ValT)>, but with a virtual operator()
  */
 template <typename ValT>
-struct pixelOp1 : public std::tr1::function<ValT(ValT)> {
+struct pixelOp1 : public std::function<ValT(ValT)> {
     virtual ~pixelOp1() {}
     virtual ValT operator()(ValT lhs) const = 0;
 };
 
 /**
- * A functor class equivalent to tr1::function<ValT (int, int, ValT)>, but with a virtual operator()
+ * A functor class equivalent to std::function<ValT (int, int, ValT)>, but with a virtual operator()
  */
 template <typename ValT>
-struct pixelOp1XY : public std::tr1::function<ValT(int, int, ValT)> {
+struct pixelOp1XY : public std::function<ValT(int, int, ValT)> {
     virtual ~pixelOp1XY() {}
     virtual ValT operator()(int x, int y, ValT lhs) const = 0;
 };
 
 /**
- * A functor class equivalent to tr1::function<LhsT (LhsT, RhsT)>, but with a virtual operator()
+ * A functor class equivalent to std::function<LhsT (LhsT, RhsT)>, but with a virtual operator()
  */
 template <typename LhsT, typename RhsT>
-struct pixelOp2 : public std::tr1::function<LhsT(LhsT, RhsT)> {
+struct pixelOp2 : public std::function<LhsT(LhsT, RhsT)> {
     virtual ~pixelOp2() {}
     virtual LhsT operator()(LhsT lhs, RhsT rhs) const = 0;
 };
 
 /**
- * A functor class equivalent to tr1::function<LhsT (int, int, LhsT, RhsT)>, but with a virtual operator()
+ * A functor class equivalent to std::function<LhsT (int, int, LhsT, RhsT)>, but with a virtual operator()
  */
 template <typename LhsT, typename RhsT>
-struct pixelOp2XY : public std::tr1::function<LhsT(int, int, LhsT, RhsT)> {
+struct pixelOp2XY : public std::function<LhsT(int, int, LhsT, RhsT)> {
     virtual ~pixelOp2XY() {}
     virtual LhsT operator()(int x, int y, LhsT lhs, RhsT rhs) const = 0;
 };

--- a/include/lsst/afw/math/Function.h
+++ b/include/lsst/afw/math/Function.h
@@ -27,6 +27,7 @@
 /*
  * Define the basic Function classes.
  */
+#include <cmath>
 #include <stdexcept>
 #include <sstream>
 #include <vector>

--- a/src/math/Spline.cc
+++ b/src/math/Spline.cc
@@ -1253,7 +1253,7 @@ std::vector<double> Spline::roots(double const value, double a, double const b) 
         //
         // Could use
         //    std::transform(newRoots.begin(), newRoots.end(), newRoots.begin(),
-        //                   std::tr1::bind(std::plus<double>(), _1, _knots[i0]));
+        //                   std::bind(std::plus<double>(), _1, _knots[i0]));
         // but let's not
         //
         for (unsigned int j = 0; j != newRoots.size(); ++j) {


### PR DESCRIPTION
Minor changes required for AFW:

* Boost 1.65.1 no longer provides `std::tr1::function`; cut over to `std::function`
* Explicit `#include <cmath>` required to get `std::sqrt` for Function.h on OSX

Passed Jenkins CI here: https://ci.lsst.codes/blue/organizations/jenkins/stack-os-matrix/detail/stack-os-matrix/27178/pipeline