### PR TITLE
DM-12473: Add getParallacticAngle() to visitInfo

### DIFF
--- a/include/lsst/afw/image/VisitInfo.h
+++ b/include/lsst/afw/image/VisitInfo.h
@@ -174,6 +174,17 @@ public:
     // get hour angle at the boresight
     geom::Angle getBoresightHourAngle() const;
 
+    /**
+     * Get parallactic angle at the boresight
+     *
+     * Equal to the angle between the North celestial pole and Zenith at the boresight.
+     * Or, the angular separation between two great circle arcs that meet at the object:
+     *   One passing through the North celestial pole, and the other through zenith.
+     * For an object on the meridian the angle is zero if it is South of zenith and pi if it is North of zenith
+     * The angle is positive for objects East of the meridian, and negative for objects to the West.
+     */
+    geom::Angle getBoresightParAngle() const;
+
 protected:
     virtual std::string getPersistenceName() const;
 

--- a/python/lsst/afw/image/visitInfo.cc
+++ b/python/lsst/afw/image/visitInfo.cc
@@ -95,6 +95,7 @@ PYBIND11_PLUGIN(visitInfo) {
     cls.def("getBoresightRaDec", &VisitInfo::getBoresightRaDec);
     cls.def("getBoresightAzAlt", &VisitInfo::getBoresightAzAlt);
     cls.def("getBoresightAirmass", &VisitInfo::getBoresightAirmass);
+    cls.def("getBoresightParAngle", &VisitInfo::getBoresightParAngle);
     cls.def("getBoresightRotAngle", &VisitInfo::getBoresightRotAngle);
     cls.def("getRotType", &VisitInfo::getRotType);
     cls.def("getObservatory", &VisitInfo::getObservatory);

--- a/src/image/VisitInfo.cc
+++ b/src/image/VisitInfo.cc
@@ -414,6 +414,19 @@ geom::Angle VisitInfo::getLocalEra() const { return getEra() + getObservatory().
 
 geom::Angle VisitInfo::getBoresightHourAngle() const { return getLocalEra() - getBoresightRaDec()[0]; }
 
+geom::Angle VisitInfo::getBoresightParAngle() const {
+  /**
+   * Compute the parallactic angle.
+   * Defined as the angle between the North celestial pole and Zenith at the boresight.
+   */
+  double _parallactic_y, _parallactic_x, result;
+  _parallactic_y = sin(getBoresightHourAngle().asRadians());
+  _parallactic_x = cos((getBoresightRaDec()[1]).asRadians())*tan(getObservatory().getLatitude().asRadians()) -
+    sin((getBoresightRaDec()[1]).asRadians())*cos(getBoresightHourAngle().asRadians());
+  result = atan2(_parallactic_y, _parallactic_x);
+  return result * geom::radians;
+}
+
 std::ostream& operator<<(std::ostream& os, VisitInfo const& visitInfo) {
     os << "VisitInfo(";
     os << "exposureId=" << visitInfo.getExposureId() << ", ";


### PR DESCRIPTION
Adds a simple function to VisitInfo, that calculates the parallactic angle at the boresight of the exposure. 