### PR TITLE
DM-13096: Add refraction calculation

### DIFF
--- a/python/lsst/afw/coord/refraction.py
+++ b/python/lsst/afw/coord/refraction.py
@@ -21,56 +21,59 @@ from __future__ import absolute_import, division, print_function
 # see <http://www.lsstcorp.org/LegalNotices/>.
 #
 
-from astropy import units as u
+from astropy import units
 from astropy.units import cds
 import numpy as np
 
 from lsst.afw.geom import Angle
-from lsst.afw.coord import Observatory, Weather
-from lsst.afw.geom import degrees
+from lsst.afw.coord import Weather
 
 __all__ = ["refraction", "differentialRefraction"]
 
-lsstLat = -30.244639*degrees
-lsstLon = -70.749417*degrees
-lsstAlt = 2663.
-lsstTemperature = 20.*u.Celsius  # in degrees Celcius
-lsstHumidity = 10.  # in percent
-lsstPressure = 101325.*u.pascal  # 1 atmosphere.
-
-lsstWeather = Weather(lsstTemperature.value, lsstPressure.value, lsstHumidity)
-lsstObservatory = Observatory(lsstLon, lsstLat, lsstAlt)
+# The differential refractive index is the difference of the refractive index from 1.,
+#    multiplied by 1E8 to simplify the notation and equations.
+deltaRefractScale = 1.0E8
 
 
-def refraction(wavelength, elevation, weather=lsstWeather, observatory=lsstObservatory):
+def refraction(wavelength, elevation, weather, observatory):
     """Calculate overall refraction under atmospheric and observing conditions.
 
+    The calculation is taken from Stone 1996
+    "An Accurate Method for Computing Atmospheric Refraction"
     Parameters
     ----------
-    wavelength : float
+    wavelength : `float`
         wavelength is in nm (valid for 230.2 < wavelength < 2058.6)
-    elevation : lsst.afw.geom Angle
+    elevation : `lsst.afw.geom.Angle`
         Elevation of the observation, as an Angle.
-    weather : lsst.afw.coord Weather, optional
+    weather : `lsst.afw.coord.Weather`
         Class containing the measured temperature, pressure, and humidity
         at the observatory during an observation
-    observatory : lsst.afw.coord Observatory, optional
-        Class containing the longitude, latitude, and altitude of the observatory.
+    observatory : `lsst.afw.coord.Observatory`
+        Class containing the longitude, latitude,
+        and altitude of the observatory.
 
     Returns
     -------
-    lsst.afw.geom Angle
-        The angular refraction for light of the given wavelength, under the given observing conditions.
+    `lsst.afw.geom.Angle`
+        The angular refraction for light of the given wavelength,
+        under the given observing conditions.
     """
+    if wavelength < 230.2:
+        raise ValueError("Refraction calculation is valid for wavelengths between 230.2 and 2058.6 nm.")
+    if wavelength > 2058.6:
+        raise ValueError("Refraction calculation is valid for wavelengths between 230.2 and 2058.6 nm.")
     latitude = observatory.getLatitude()
     altitude = observatory.getElevation()
+    weatherNanSafe = defaultWeather(weather, altitude=altitude*units.meter)
 
-    reducedN = deltaN(wavelength, weather)*1E-8
+    reducedN = deltaN(wavelength, weatherNanSafe)/deltaRefractScale
 
-    temperature = _extractTemperature(weather, useKelvin=True)
-    atmosScaleheightRatio = float(4.5908E-6*temperature/u.Kelvin)
+    temperature = extractTemperature(weatherNanSafe, useKelvin=True)
+    atmosScaleheightRatio = float(4.5908E-6*temperature/units.Kelvin)
 
     # Account for oblate Earth
+    # This replicates equation 10 of Stone 1996
     relativeGravity = (1. + 0.005302*np.sin(latitude.asRadians())**2. -
                        0.00000583*np.sin(2.*latitude.asRadians())**2. - 0.000000315*altitude)
 
@@ -83,55 +86,56 @@ def refraction(wavelength, elevation, weather=lsstWeather, observatory=lsstObser
     return result
 
 
-def differentialRefraction(wavelength, wavelengthRef, elevation,
-                           weather=lsstWeather, observatory=lsstObservatory):
+def differentialRefraction(wavelength, wavelengthRef, elevation, weather, observatory):
     """Calculate the differential refraction between two wavelengths.
 
     Parameters
     ----------
-    wavelength : float
+    wavelength : `float`
         wavelength is in nm (valid for 230.2 < wavelength < 2058.6)
-    wavelengthRef : float
+    wavelengthRef : `float`
         Reference wavelength, typically the effective wavelength of a filter.
-    elevation : lsst.afw.geom Angle
+    elevation : `lsst.afw.geom.Angle`
         Elevation of the observation, as an Angle.
-    weather : lsst.afw.coord Weather, optional
+    weather : `lsst.afw.coord.Weather`
         Class containing the measured temperature, pressure, and humidity
         at the observatory during an observation
-    observatory : lsst.afw.coord Observatory, optional
-        Class containing the longitude, latitude, and altitude of the observatory.
+    observatory : `lsst.afw.coord.Observatory`
+        Class containing the longitude, latitude,
+        and altitude of the observatory.
 
     Returns
     -------
-    lsst.afw.geom Angle
+    `lsst.afw.geom.Angle`
         The refraction at `wavelength` - the refraction at `wavelengthRef`.
     """
-    refractionStart = refraction(wavelength, elevation, weather=weather, observatory=observatory)
-    refractionEnd = refraction(wavelengthRef, elevation, weather=weather, observatory=observatory)
+    refractionStart = refraction(wavelength, elevation, weather, observatory)
+    refractionEnd = refraction(wavelengthRef, elevation, weather, observatory)
     return refractionStart - refractionEnd
 
 
 def deltaN(wavelength, weather):
     """Calculate the differential refractive index of air.
 
-    The differential refractive index is the difference of the refractive index from 1.,
-    multiplied by 1E8 to simplify the notation and equations.
-    Calculated as (n_air - 1)*10^8
+    The differential refractive index is the difference of
+    the refractive index from 1., multiplied by 1E8 to simplify
+    the notation and equations. Calculated as (n_air - 1)*10^8
 
-    This replicates equation 14 of Stone 1996 "An Accurate Method for Computing Atmospheric Refraction"
+    This replicates equation 14 of Stone 1996
 
     Parameters
     ----------
-    wavelength : float
+    wavelength : `float`
         wavelength is in nanometers
-    weather : lsst.afw.coord Weather
+    weather : `lsst.afw.coord.Weather`
         Class containing the measured temperature, pressure, and humidity
         at the observatory during an observation
 
     Returns
     -------
-    float
-        The difference of the refractive index of air from 1., calculated as (n_air - 1)*10^8
+    `float`
+        The difference of the refractive index of air from 1.,
+        calculated as (n_air - 1)*10^8
     """
     waveNum = 1E3/wavelength  # want wave number in units 1/micron
 
@@ -146,28 +150,29 @@ def deltaN(wavelength, weather):
 def densityFactorDry(weather):
     """Calculate dry air pressure term to refractive index calculation.
 
-    This replicates equation 15 of Stone 1996 "An Accurate Method for Computing Atmospheric Refraction"
+    This replicates equation 15 of Stone 1996
 
     Parameters
     ----------
-    weather : lsst.afw.coord Weather
+    weather : `lsst.afw.coord.Weather`
         Class containing the measured temperature, pressure, and humidity
         at the observatory during an observation
 
     Returns
     -------
-    float
-        Returns the relative density of dry air at the given pressure and temperature.
+    `float`
+        Returns the relative density of dry air
+        at the given pressure and temperature.
     """
-    temperature = _extractTemperature(weather, useKelvin=True)
+    temperature = extractTemperature(weather, useKelvin=True)
     waterVaporPressure = humidityToPressure(weather)
-    airPressure = _extractPressure(weather)
+    airPressure = weather.getAirPressure()*units.pascal
     dryPressure = airPressure - waterVaporPressure
 
-    eqn = (dryPressure/cds.mbar)*(57.90E-8 - 9.3250E-4*u.Kelvin/temperature +
-                                  0.25844*u.Kelvin**2/temperature**2.)
+    eqn = (dryPressure/cds.mbar)*(57.90E-8 - 9.3250E-4*units.Kelvin/temperature +
+                                  0.25844*units.Kelvin**2/temperature**2.)
 
-    densityFactor = float((1. + eqn)*(dryPressure/cds.mbar)/(temperature/u.Kelvin))
+    densityFactor = float((1. + eqn)*(dryPressure/cds.mbar)/(temperature/units.Kelvin))
 
     return densityFactor
 
@@ -175,110 +180,125 @@ def densityFactorDry(weather):
 def densityFactorWater(weather):
     """Calculate water vapor pressure term to refractive index calculation.
 
-    This replicates equation 16 of Stone 1996 "An Accurate Method for Computing Atmospheric Refraction"
+    This replicates equation 16 of Stone 1996
 
     Parameters
     ----------
-    weather : lsst.afw.coord Weather
+    weather : `lsst.afw.coord.Weather`
         Class containing the measured temperature, pressure, and humidity
         at the observatory during an observation
 
     Returns
     -------
-    float
-        Returns the relative density of water vapor at the given pressure and temperature.
+    `float`
+        Returns the relative density of water vapor
+        at the given pressure and temperature.
     """
-    temperature = _extractTemperature(weather, useKelvin=True)
+    temperature = extractTemperature(weather, useKelvin=True)
     waterVaporPressure = humidityToPressure(weather)
 
-    densityEqn1 = float(-2.37321E-3 + 2.23366*u.Kelvin/temperature -
-                        710.792*u.Kelvin**2/temperature**2. +
-                        7.75141E-4*u.Kelvin**3/temperature**3.)
+    densityEqn1 = float(-2.37321E-3 + 2.23366*units.Kelvin/temperature -
+                        710.792*units.Kelvin**2/temperature**2. +
+                        7.75141E-4*units.Kelvin**3/temperature**3.)
 
     densityEqn2 = float(waterVaporPressure/cds.mbar)*(1. + 3.7E-4*waterVaporPressure/cds.mbar)
 
-    relativeDensity = float(waterVaporPressure*u.Kelvin/(temperature*cds.mbar))
+    relativeDensity = float(waterVaporPressure*units.Kelvin/(temperature*cds.mbar))
     densityFactor = (1 + densityEqn2*densityEqn1)*relativeDensity
 
     return densityFactor
 
 
 def humidityToPressure(weather):
-    """Simple function that converts humidity and temperature to water vapor pressure.
+    """Convert humidity and temperature to water vapor pressure.
 
-    This replicates equations 18 & 20 of Stone 1996 "An Accurate Method for Computing Atmospheric Refraction"
+    This replicates equations 18 & 20 of Stone 1996
 
     Parameters
     ----------
-    weather : lsst.afw.coord Weather
+    weather : `lsst.afw.coord.Weather`
         Class containing the measured temperature, pressure, and humidity
         at the observatory during an observation
 
     Returns
     -------
-    float
-        The water vapor pressure in millibar, calculated from the given humidity and temperature.
+    `float`
+        The water vapor pressure in millibar
+        calculated from the given humidity and temperature.
     """
-    if np.isnan(weather.getHumidity()):
-        humidity = lsstWeather.getHumidity()
-    else:
-        humidity = weather.getHumidity()
+    humidity = weather.getHumidity()
     x = np.log(humidity/100.0)
-    temperature = _extractTemperature(weather)
-    temperatureEqn1 = (temperature + 238.3*u.Celsius)*x + 17.2694*temperature
-    temperatureEqn2 = (temperature + 238.3*u.Celsius)*(17.2694 - x) - 17.2694*temperature
+    temperature = extractTemperature(weather)
+    temperatureEqn1 = (temperature + 238.3*units.Celsius)*x + 17.2694*temperature
+    temperatureEqn2 = (temperature + 238.3*units.Celsius)*(17.2694 - x) - 17.2694*temperature
     dewPoint = 238.3*float(temperatureEqn1/temperatureEqn2)
 
     waterVaporPressure = (4.50874 + 0.341724*dewPoint + 0.0106778*dewPoint**2 + 0.184889E-3*dewPoint**3 +
-                          0.238294E-5*dewPoint**4 + 0.203447E-7*dewPoint**5)*133.32239*u.pascal
+                          0.238294E-5*dewPoint**4 + 0.203447E-7*dewPoint**5)*133.32239*units.pascal
 
     return waterVaporPressure
 
 
-def _extractTemperature(weather, useKelvin=False):
-    """Thin wrapper to return the measured temperature from an observation with astropy units attached.
+def extractTemperature(weather, useKelvin=False):
+    """Thin wrapper to return the measured temperature from an observation.
 
     Parameters
     ----------
-    weather : lsst.afw.coord Weather
+    weather : `lsst.afw.coord.Weather`
         Class containing the measured temperature, pressure, and humidity
         at the observatory during an observation
     useKelvin : bool, optional
         Set to True to return the temperature in Kelvin instead of Celsius
-        This is needed because Astropy can't easily convert between Kelvin and Celsius.
+        This is needed because Astropy can't easily convert
+        between Kelvin and Celsius.
 
     Returns
     -------
-    astropy.units
+    `astropy.units.quantity.Quantity`
         The temperature in Celsius, unless `useKelvin` is set.
     """
-    temperature = weather.getAirTemperature()
-    if np.isnan(temperature):
-        temperature = lsstWeather.getAirTemperature()*u.Celsius
-    else:
-        temperature *= u.Celsius
+    temperature = weather.getAirTemperature()*units.Celsius
     if useKelvin:
-        temperature = temperature.to(u.Kelvin, equivalencies=u.temperature())
+        temperature = temperature.to(units.Kelvin, equivalencies=units.temperature())
     return temperature
 
 
-def _extractPressure(weather):
-    """Thin wrapper to return the measured pressure from an observation with astropy units attached.
+def defaultWeather(weather, altitude):
+    """Set default local weather conditions if they are missing.
 
     Parameters
     ----------
-    weather : lsst.afw.coord Weather
+    weather : `lsst.afw.coord.Weather`
         Class containing the measured temperature, pressure, and humidity
         at the observatory during an observation
+    altitude : `astropy.units.quantity.Quantity`
+        The altitude of the observatory, in meters.
 
     Returns
     -------
-    astropy.units
-        The air pressure in pascals.
+    `lsst.afw.coord.Weather`
+        Updated Weather class with any `nan` values replaced by defaults.
     """
+    p0 = 101325.*units.pascal  # sea level air pressure
+    g = 9.80665*units.meter/units.second**2  # typical gravitational acceleration at sea level
+    R0 = 8.31447*units.Joule/(units.mol*units.Kelvin)  # gas constant
+    T0 = 19.*units.Celsius  # Typical sea-level temperature
+    lapseRate = -6.5*units.Celsius/units.km  # Typical rate of change of temperature with altitude
+    M = 0.0289644*units.kg/units.mol  # molar mass of dry air
+
+    temperature = weather.getAirTemperature()
+    if np.isnan(temperature):
+        temperature = T0 + lapseRate*altitude
+    else:
+        temperature = temperature*units.Celsius
     pressure = weather.getAirPressure()
     if np.isnan(pressure):
-        pressure = lsstWeather.getAirPressure()*u.pascal
+        temperatureK = temperature.to(units.Kelvin, equivalencies=units.temperature())
+        pressure = p0*np.exp(-(g*M*altitude)/(R0*temperatureK))
     else:
-        pressure *= u.pascal
-    return pressure
+        pressure = pressure*units.pascal
+    humidity = weather.getHumidity()
+    if np.isnan(humidity):
+        humidity = 40.  # Typical humidity at many observatory sites.
+    weatherNanSafe = Weather((temperature/units.Celsius).value, (pressure/units.pascal).value, humidity)
+    return weatherNanSafe

--- a/python/lsst/afw/coord/refraction.py
+++ b/python/lsst/afw/coord/refraction.py
@@ -1,0 +1,284 @@
+from __future__ import absolute_import, division, print_function
+#
+# LSST Data Management System
+# Copyright 2008-2018 LSST/AURA.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
+from astropy import units as u
+from astropy.units import cds
+import numpy as np
+
+from lsst.afw.geom import Angle
+from lsst.afw.coord import Observatory, Weather
+from lsst.afw.geom import degrees
+
+__all__ = ["refraction", "differentialRefraction"]
+
+lsstLat = -30.244639*degrees
+lsstLon = -70.749417*degrees
+lsstAlt = 2663.
+lsstTemperature = 20.*u.Celsius  # in degrees Celcius
+lsstHumidity = 10.  # in percent
+lsstPressure = 101325.*u.pascal  # 1 atmosphere.
+
+lsstWeather = Weather(lsstTemperature.value, lsstPressure.value, lsstHumidity)
+lsstObservatory = Observatory(lsstLon, lsstLat, lsstAlt)
+
+
+def refraction(wavelength, elevation, weather=lsstWeather, observatory=lsstObservatory):
+    """Calculate overall refraction under atmospheric and observing conditions.
+
+    Parameters
+    ----------
+    wavelength : float
+        wavelength is in nm (valid for 230.2 < wavelength < 2058.6)
+    elevation : lsst.afw.geom Angle
+        Elevation of the observation, as an Angle.
+    weather : lsst.afw.coord Weather, optional
+        Class containing the measured temperature, pressure, and humidity
+        at the observatory during an observation
+    observatory : lsst.afw.coord Observatory, optional
+        Class containing the longitude, latitude, and altitude of the observatory.
+
+    Returns
+    -------
+    lsst.afw.geom Angle
+        The angular refraction for light of the given wavelength, under the given observing conditions.
+    """
+    latitude = observatory.getLatitude()
+    altitude = observatory.getElevation()
+
+    reducedN = deltaN(wavelength, weather)*1E-8
+
+    temperature = _extractTemperature(weather, useKelvin=True)
+    atmosScaleheightRatio = float(4.5908E-6*temperature/u.Kelvin)
+
+    # Account for oblate Earth
+    relativeGravity = (1. + 0.005302*np.sin(latitude.asRadians())**2. -
+                       0.00000583*np.sin(2.*latitude.asRadians())**2. - 0.000000315*altitude)
+
+    # Calculate the tangent of the zenith angle.
+    tanZ = np.tan(np.pi/2. - elevation.asRadians())
+
+    atmosTerm1 = reducedN*relativeGravity*(1. - atmosScaleheightRatio)
+    atmosTerm2 = reducedN*relativeGravity*(atmosScaleheightRatio - reducedN/2.)
+    result = Angle(float(atmosTerm1*tanZ + atmosTerm2*tanZ**3.))
+    return result
+
+
+def differentialRefraction(wavelength, wavelengthRef, elevation,
+                           weather=lsstWeather, observatory=lsstObservatory):
+    """Calculate the differential refraction between two wavelengths.
+
+    Parameters
+    ----------
+    wavelength : float
+        wavelength is in nm (valid for 230.2 < wavelength < 2058.6)
+    wavelengthRef : float
+        Reference wavelength, typically the effective wavelength of a filter.
+    elevation : lsst.afw.geom Angle
+        Elevation of the observation, as an Angle.
+    weather : lsst.afw.coord Weather, optional
+        Class containing the measured temperature, pressure, and humidity
+        at the observatory during an observation
+    observatory : lsst.afw.coord Observatory, optional
+        Class containing the longitude, latitude, and altitude of the observatory.
+
+    Returns
+    -------
+    lsst.afw.geom Angle
+        The refraction at `wavelength` - the refraction at `wavelengthRef`.
+    """
+    refractionStart = refraction(wavelength, elevation, weather=weather, observatory=observatory)
+    refractionEnd = refraction(wavelengthRef, elevation, weather=weather, observatory=observatory)
+    return refractionStart - refractionEnd
+
+
+def deltaN(wavelength, weather):
+    """Calculate the differential refractive index of air.
+
+    The differential refractive index is the difference of the refractive index from 1.,
+    multiplied by 1E8 to simplify the notation and equations.
+    Calculated as (n_air - 1)*10^8
+
+    This replicates equation 14 of Stone 1996 "An Accurate Method for Computing Atmospheric Refraction"
+
+    Parameters
+    ----------
+    wavelength : float
+        wavelength is in nanometers
+    weather : lsst.afw.coord Weather
+        Class containing the measured temperature, pressure, and humidity
+        at the observatory during an observation
+
+    Returns
+    -------
+    float
+        The difference of the refractive index of air from 1., calculated as (n_air - 1)*10^8
+    """
+    waveNum = 1E3/wavelength  # want wave number in units 1/micron
+
+    dryAirTerm = 2371.34 + (683939.7/(130. - waveNum**2.)) + (4547.3/(38.9 - waveNum**2.))
+
+    wetAirTerm = 6487.31 + 58.058*waveNum**2. - 0.71150*waveNum**4. + 0.08851*waveNum**6.
+
+    return (dryAirTerm*densityFactorDry(weather) +
+            wetAirTerm*densityFactorWater(weather))
+
+
+def densityFactorDry(weather):
+    """Calculate dry air pressure term to refractive index calculation.
+
+    This replicates equation 15 of Stone 1996 "An Accurate Method for Computing Atmospheric Refraction"
+
+    Parameters
+    ----------
+    weather : lsst.afw.coord Weather
+        Class containing the measured temperature, pressure, and humidity
+        at the observatory during an observation
+
+    Returns
+    -------
+    float
+        Returns the relative density of dry air at the given pressure and temperature.
+    """
+    temperature = _extractTemperature(weather, useKelvin=True)
+    waterVaporPressure = humidityToPressure(weather)
+    airPressure = _extractPressure(weather)
+    dryPressure = airPressure - waterVaporPressure
+
+    eqn = (dryPressure/cds.mbar)*(57.90E-8 - 9.3250E-4*u.Kelvin/temperature +
+                                  0.25844*u.Kelvin**2/temperature**2.)
+
+    densityFactor = float((1. + eqn)*(dryPressure/cds.mbar)/(temperature/u.Kelvin))
+
+    return densityFactor
+
+
+def densityFactorWater(weather):
+    """Calculate water vapor pressure term to refractive index calculation.
+
+    This replicates equation 16 of Stone 1996 "An Accurate Method for Computing Atmospheric Refraction"
+
+    Parameters
+    ----------
+    weather : lsst.afw.coord Weather
+        Class containing the measured temperature, pressure, and humidity
+        at the observatory during an observation
+
+    Returns
+    -------
+    float
+        Returns the relative density of water vapor at the given pressure and temperature.
+    """
+    temperature = _extractTemperature(weather, useKelvin=True)
+    waterVaporPressure = humidityToPressure(weather)
+
+    densityEqn1 = float(-2.37321E-3 + 2.23366*u.Kelvin/temperature -
+                        710.792*u.Kelvin**2/temperature**2. +
+                        7.75141E-4*u.Kelvin**3/temperature**3.)
+
+    densityEqn2 = float(waterVaporPressure/cds.mbar)*(1. + 3.7E-4*waterVaporPressure/cds.mbar)
+
+    relativeDensity = float(waterVaporPressure*u.Kelvin/(temperature*cds.mbar))
+    densityFactor = (1 + densityEqn2*densityEqn1)*relativeDensity
+
+    return densityFactor
+
+
+def humidityToPressure(weather):
+    """Simple function that converts humidity and temperature to water vapor pressure.
+
+    This replicates equations 18 & 20 of Stone 1996 "An Accurate Method for Computing Atmospheric Refraction"
+
+    Parameters
+    ----------
+    weather : lsst.afw.coord Weather
+        Class containing the measured temperature, pressure, and humidity
+        at the observatory during an observation
+
+    Returns
+    -------
+    float
+        The water vapor pressure in millibar, calculated from the given humidity and temperature.
+    """
+    if np.isnan(weather.getHumidity()):
+        humidity = lsstWeather.getHumidity()
+    else:
+        humidity = weather.getHumidity()
+    x = np.log(humidity/100.0)
+    temperature = _extractTemperature(weather)
+    temperatureEqn1 = (temperature + 238.3*u.Celsius)*x + 17.2694*temperature
+    temperatureEqn2 = (temperature + 238.3*u.Celsius)*(17.2694 - x) - 17.2694*temperature
+    dewPoint = 238.3*float(temperatureEqn1/temperatureEqn2)
+
+    waterVaporPressure = (4.50874 + 0.341724*dewPoint + 0.0106778*dewPoint**2 + 0.184889E-3*dewPoint**3 +
+                          0.238294E-5*dewPoint**4 + 0.203447E-7*dewPoint**5)*133.32239*u.pascal
+
+    return waterVaporPressure
+
+
+def _extractTemperature(weather, useKelvin=False):
+    """Thin wrapper to return the measured temperature from an observation with astropy units attached.
+
+    Parameters
+    ----------
+    weather : lsst.afw.coord Weather
+        Class containing the measured temperature, pressure, and humidity
+        at the observatory during an observation
+    useKelvin : bool, optional
+        Set to True to return the temperature in Kelvin instead of Celsius
+        This is needed because Astropy can't easily convert between Kelvin and Celsius.
+
+    Returns
+    -------
+    astropy.units
+        The temperature in Celsius, unless `useKelvin` is set.
+    """
+    temperature = weather.getAirTemperature()
+    if np.isnan(temperature):
+        temperature = lsstWeather.getAirTemperature()*u.Celsius
+    else:
+        temperature *= u.Celsius
+    if useKelvin:
+        temperature = temperature.to(u.Kelvin, equivalencies=u.temperature())
+    return temperature
+
+
+def _extractPressure(weather):
+    """Thin wrapper to return the measured pressure from an observation with astropy units attached.
+
+    Parameters
+    ----------
+    weather : lsst.afw.coord Weather
+        Class containing the measured temperature, pressure, and humidity
+        at the observatory during an observation
+
+    Returns
+    -------
+    astropy.units
+        The air pressure in pascals.
+    """
+    pressure = weather.getAirPressure()
+    if np.isnan(pressure):
+        pressure = lsstWeather.getAirPressure()*u.pascal
+    else:
+        pressure *= u.pascal
+    return pressure

--- a/python/lsst/afw/coord/refraction.py
+++ b/python/lsst/afw/coord/refraction.py
@@ -35,7 +35,7 @@ __all__ = ["refraction", "differentialRefraction"]
 deltaRefractScale = 1.0E8
 
 
-def refraction(wavelength, elevation, weather, observatory):
+def refraction(wavelength, elevation, observatory, weather=None):
     """Calculate overall refraction under atmospheric and observing conditions.
 
     The calculation is taken from Stone 1996
@@ -46,12 +46,13 @@ def refraction(wavelength, elevation, weather, observatory):
         wavelength is in nm (valid for 230.2 < wavelength < 2058.6)
     elevation : `lsst.afw.geom.Angle`
         Elevation of the observation, as an Angle.
-    weather : `lsst.afw.coord.Weather`
-        Class containing the measured temperature, pressure, and humidity
-        at the observatory during an observation
     observatory : `lsst.afw.coord.Observatory`
         Class containing the longitude, latitude,
         and altitude of the observatory.
+    weather : `lsst.afw.coord.Weather`, optional
+        Class containing the measured temperature, pressure, and humidity
+        at the observatory during an observation
+        If omitted, typical conditions for the observatory's elevation will be calculated.
 
     Returns
     -------
@@ -84,7 +85,7 @@ def refraction(wavelength, elevation, weather, observatory):
     return result
 
 
-def differentialRefraction(wavelength, wavelengthRef, elevation, weather, observatory):
+def differentialRefraction(wavelength, wavelengthRef, elevation, observatory, weather=None):
     """Calculate the differential refraction between two wavelengths.
 
     Parameters
@@ -95,20 +96,21 @@ def differentialRefraction(wavelength, wavelengthRef, elevation, weather, observ
         Reference wavelength, typically the effective wavelength of a filter.
     elevation : `lsst.afw.geom.Angle`
         Elevation of the observation, as an Angle.
-    weather : `lsst.afw.coord.Weather`
-        Class containing the measured temperature, pressure, and humidity
-        at the observatory during an observation
     observatory : `lsst.afw.coord.Observatory`
         Class containing the longitude, latitude,
         and altitude of the observatory.
+    weather : `lsst.afw.coord.Weather`, optional
+        Class containing the measured temperature, pressure, and humidity
+        at the observatory during an observation
+        If omitted, typical conditions for the observatory's elevation will be calculated.
 
     Returns
     -------
     `lsst.afw.geom.Angle`
         The refraction at `wavelength` - the refraction at `wavelengthRef`.
     """
-    refractionStart = refraction(wavelength, elevation, weather, observatory)
-    refractionEnd = refraction(wavelengthRef, elevation, weather, observatory)
+    refractionStart = refraction(wavelength, elevation, observatory, weather=weather)
+    refractionEnd = refraction(wavelengthRef, elevation, observatory, weather=weather)
     return refractionStart - refractionEnd
 
 

--- a/tests/test_refraction.py
+++ b/tests/test_refraction.py
@@ -1,0 +1,94 @@
+#
+# LSST Data Management System
+# See COPYRIGHT file at the top of the source tree.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
+from __future__ import absolute_import, division, print_function
+
+from astropy import units as u
+import numpy as np
+import unittest
+
+from lsst.afw.geom import Angle
+from lsst.afw.coord import Observatory, Weather
+from lsst.afw.coord.refraction import refraction, differentialRefraction
+from lsst.afw.geom import degrees
+import lsst.utils.tests
+
+
+class RefractionTestSuite(lsst.utils.tests.TestCase):
+    """Test the refraction calculations."""
+
+    def setUp(self):
+        """Define parameters used by every test."""
+        lsstLat = -30.244639*degrees
+        lsstLon = -70.749417*degrees
+        lsstAlt = 2663.
+        lsstTemperature = 20.*u.Celsius  # in degrees Celcius
+        lsstHumidity = 10.  # in percent
+        lsstPressure = 101325.*u.pascal  # 1 atmosphere.
+        self.randGen = np.random
+        self.randGen.seed = 5
+
+        self.weather = Weather(lsstTemperature.value, lsstPressure.value, lsstHumidity)
+        self.observatory = Observatory(lsstLon, lsstLat, lsstAlt)
+
+    def testZenithZero(self):
+        """There should be no refraction exactly at zenith."""
+        elevation = Angle(np.pi/2.)
+        wl = 505.  # in nm
+        refractZen = refraction(wl, elevation)
+        self.assertAlmostEqual(refractZen.asDegrees(), 0.)
+
+    def testNoDifferential(self):
+        """There should be no differential refraction if the wavelength is the same as the reference."""
+        wl = 470.  # in nm
+        wl_ref = wl
+        elevation = Angle(self.randGen.random()*np.pi/2.)
+        diffRefraction = differentialRefraction(wl, wl_ref, elevation)
+        self.assertFloatsAlmostEqual(diffRefraction.asDegrees(), 0.)
+
+    def testRefractHighAirmass(self):
+        """Compare the refraction calculation to precomputed values."""
+        elevation = Angle(np.pi/6.)  # Airmass 2.0
+        wls = [370., 480., 620., 860., 960., 1025.]  # in nm
+        refVals = [100.18009112043688,
+                   98.39816181171116,
+                   97.39979727127752,
+                   96.70222559729264,
+                   96.5552003626887,
+                   96.482091761146,
+                   ]
+        for wl, refVal in zip(wls, refVals):
+            refract = refraction(wl, elevation)
+            self.assertFloatsAlmostEqual(refract.asArcseconds(), refVal, rtol=1e-3)
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_refraction.py
+++ b/tests/test_refraction.py
@@ -44,33 +44,32 @@ class RefractionTestSuite(lsst.utils.tests.TestCase):
         lsstTemperature = 20.*units.Celsius  # in degrees Celsius
         lsstHumidity = 10.  # in percent
         lsstPressure = 73892.*units.pascal  # 1 atmosphere.
-        self.randGen = np.random
-        self.randGen.seed = 5
+        np.random.seed(5)
 
         self.weather = Weather(lsstTemperature/units.Celsius, lsstPressure/units.pascal, lsstHumidity)
         self.observatory = Observatory(lsstLon, lsstLat, lsstAlt)
 
     def testWavelengthRangeError(self):
         """Refraction should raise an error if the wavelength is out of range."""
-        elevation = Angle(self.randGen.random()*np.pi/2.)
+        elevation = Angle(np.random.random()*np.pi/2.)
         wl_low = 230.
         wl_high = 2059.
-        self.assertRaises(ValueError, refraction, wl_low, elevation, self.weather, self.observatory)
-        self.assertRaises(ValueError, refraction, wl_high, elevation, self.weather, self.observatory)
+        self.assertRaises(ValueError, refraction, wl_low, elevation, self.observatory, weather=self.weather)
+        self.assertRaises(ValueError, refraction, wl_high, elevation, self.observatory, weather=self.weather)
 
     def testZenithZero(self):
         """There should be no refraction exactly at zenith."""
         elevation = Angle(np.pi/2.)
         wl = 505.  # in nm
-        refractZen = refraction(wl, elevation, self.weather, self.observatory)
+        refractZen = refraction(wl, elevation, self.observatory, weather=self.weather)
         self.assertAlmostEqual(refractZen.asDegrees(), 0.)
 
     def testNoDifferential(self):
         """There should be no differential refraction if the wavelength is the same as the reference."""
         wl = 470.  # in nm
         wl_ref = wl
-        elevation = Angle(self.randGen.random()*np.pi/2.)
-        diffRefraction = differentialRefraction(wl, wl_ref, elevation, self.weather, self.observatory)
+        elevation = Angle(np.random.random()*np.pi/2.)
+        diffRefraction = differentialRefraction(wl, wl_ref, elevation, self.observatory, weather=self.weather)
         self.assertFloatsAlmostEqual(diffRefraction.asDegrees(), 0.)
 
     def testRefractHighAirmass(self):
@@ -85,13 +84,12 @@ class RefractionTestSuite(lsst.utils.tests.TestCase):
                    70.35113687114644,
                    ]
         for wl, refVal in zip(wls, refVals):
-            refract = refraction(wl, elevation, self.weather, self.observatory)
+            refract = refraction(wl, elevation, self.observatory, weather=self.weather)
             self.assertFloatsAlmostEqual(refract.asArcseconds(), refVal, rtol=1e-3)
 
     def testRefractWeatherNan(self):
-        """Test the values of refraction when the supplied weather is nan."""
-        weather = Weather(np.nan, np.nan, np.nan)
-        elevation = Angle(self.randGen.random()*np.pi/2.)
+        """Test the values of refraction when no weather is supplied."""
+        elevation = Angle(np.random.random()*np.pi/2.)
         elevation = Angle(np.pi/6.)  # Airmass 2.0
         wls = [370., 480., 620., 860., 960., 1025.]  # in nm
         refVals = [76.7339313496466,
@@ -102,7 +100,7 @@ class RefractionTestSuite(lsst.utils.tests.TestCase):
                    73.9006681751504,
                    ]
         for wl, refVal in zip(wls, refVals):
-            refract = refraction(wl, elevation, weather, self.observatory)
+            refract = refraction(wl, elevation, self.observatory)
             self.assertFloatsAlmostEqual(refract.asArcseconds(), refVal, rtol=1e-3)
 
 


### PR DESCRIPTION
Adds a detailed calculation of refraction to `afw.coord` that can account for local atmospheric conditions in `Weather`.
Needed for generating Differential Chromatic Refraction-corrected template images.