### PR TITLE
DM-13110: export magic value to select default HDU

### DIFF
--- a/include/lsst/afw/fits.h
+++ b/include/lsst/afw/fits.h
@@ -23,6 +23,7 @@
 #include "lsst/daf/base.h"
 #include "ndarray.h"
 #include "lsst/afw/fitsCompression.h"
+#include "lsst/afw/fitsDefaults.h"
 
 namespace lsst {
 namespace afw {
@@ -300,7 +301,7 @@ public:
      *  Set the current HDU.
      *
      *  @param[in] hdu                 The HDU to move to (0-indexed; 0 is the Primary HDU).
-     *                                 The special value of INT_MIN moves to the first extension
+     *                                 The special value of DEFAULT_HDU moves to the first extension
      *                                 if the Primary HDU is empty (has NAXIS==0) and the
      *                                 the Primary HDU is the current one.
      *  @param[in] relative            If true, move relative to the current HDU.
@@ -640,7 +641,7 @@ public:
  * @param strip if `true`, common FITS keys that usually have non-metadata intepretations
  *              (e.g. NAXIS, BITPIX) will be ignored.
  */
-std::shared_ptr<daf::base::PropertyList> readMetadata(std::string const& fileName, int hdu = INT_MIN,
+std::shared_ptr<daf::base::PropertyList> readMetadata(std::string const& fileName, int hdu = DEFAULT_HDU,
                                                       bool strip = false);
 /** Read FITS header
  *
@@ -652,7 +653,7 @@ std::shared_ptr<daf::base::PropertyList> readMetadata(std::string const& fileNam
  * @param strip if `true`, common FITS keys that usually have non-metadata intepretations
  *              (e.g. NAXIS, BITPIX) will be ignored.
  */
-std::shared_ptr<daf::base::PropertyList> readMetadata(fits::MemFileManager& manager, int hdu = INT_MIN,
+std::shared_ptr<daf::base::PropertyList> readMetadata(fits::MemFileManager& manager, int hdu = DEFAULT_HDU,
                                                       bool strip = false);
 /** Read FITS header
  *

--- a/include/lsst/afw/fitsDefaults.h
+++ b/include/lsst/afw/fitsDefaults.h
@@ -1,0 +1,22 @@
+// -*- lsst-c++ -*-
+#ifndef LSST_AFW_fitsDefaults_h_INCLUDED
+#define LSST_AFW_fitsDefaults_h_INCLUDED
+
+#include <climits>
+
+namespace lsst {
+namespace afw {
+namespace fits {
+
+/**
+ *  Specify that the default HDU should be read.
+ *
+ *  This special HDU number indicates that the first extension
+ *  should be used if the primary HDU is empty (i.e., has NAXIS=0)
+ *  and the Primary HDU is the current.
+ */
+const int DEFAULT_HDU = INT_MIN;
+
+}}} // namespace lsst::afw::fits
+
+#endif

--- a/include/lsst/afw/image/Image.h
+++ b/include/lsst/afw/image/Image.h
@@ -46,6 +46,7 @@
 #include "lsst/afw/image/ImageUtils.h"
 #include "lsst/afw/image/Mask.h"
 #include "lsst/afw/math/Function.h"
+#include "lsst/afw/fitsDefaults.h"
 #include "lsst/daf/base.h"
 #include "lsst/daf/base/Citizen.h"
 #include "lsst/pex/exceptions.h"
@@ -141,14 +142,14 @@ public:
      *
      *  @param[in]      fileName    File to read.
      *  @param[in]      hdu         HDU to read, 0-indexed (i.e. 0=Primary HDU).  The special value
-     *                              of INT_MIN reads the Primary HDU unless it is empty, in which case it
-     *                              reads the first extension HDU.
+     *                              of afw::fits::DEFAULT_HDU reads the Primary HDU unless it is empty,
+     *                              in which case it reads the first extension HDU.
      *  @param[in,out]  metadata    Metadata read from the header (may be null).
      *  @param[in]      bbox        If non-empty, read only the pixels within the bounding box.
      *  @param[in]      origin      Coordinate system of the bounding box; if PARENT, the bounding box
      *                              should take into account the xy0 saved with the image.
      */
-    explicit Image(std::string const& fileName, int hdu = INT_MIN,
+    explicit Image(std::string const& fileName, int hdu = fits::DEFAULT_HDU,
                    std::shared_ptr<lsst::daf::base::PropertySet> metadata =
                            std::shared_ptr<lsst::daf::base::PropertySet>(),
                    geom::Box2I const& bbox = geom::Box2I(), ImageOrigin origin = PARENT);
@@ -158,14 +159,14 @@ public:
      *
      *  @param[in]      manager     An object that manages the memory buffer to read.
      *  @param[in]      hdu         HDU to read, 0-indexed (i.e. 0=Primary HDU).  The special value
-     *                              of INT_MIN reads the Primary HDU unless it is empty, in which case it
-     *                              reads the first extension HDU.
+     *                              of afw::fits::DEFAULT_HDU reads the Primary HDU unless it is empty,
+     *                              in which case it reads the first extension HDU.
      *  @param[in,out]  metadata    Metadata read from the header (may be null).
      *  @param[in]      bbox        If non-empty, read only the pixels within the bounding box.
      *  @param[in]      origin      Coordinate system of the bounding box; if PARENT, the bounding box
      *                              should take into account the xy0 saved with the image.
      */
-    explicit Image(fits::MemFileManager& manager, int hdu = INT_MIN,
+    explicit Image(fits::MemFileManager& manager, int hdu = fits::DEFAULT_HDU,
                    std::shared_ptr<lsst::daf::base::PropertySet> metadata =
                            std::shared_ptr<lsst::daf::base::PropertySet>(),
                    geom::Box2I const& bbox = geom::Box2I(), ImageOrigin origin = PARENT);
@@ -294,10 +295,10 @@ public:
      *
      *  @param[in] filename    Name of the file to read.
      *  @param[in] hdu         Number of the "header-data unit" to read (where 0 is the Primary HDU).
-     *                         The default value of INT_MIN is interpreted as "the first HDU with
-     *                         NAXIS != 0".
+     *                         The default value of afw::fits::DEFAULT_HDU is interpreted as
+     *                         "the first HDU with NAXIS != 0".
      */
-    static Image readFits(std::string const& filename, int hdu = INT_MIN) {
+    static Image readFits(std::string const& filename, int hdu = fits::DEFAULT_HDU) {
         return Image<PixelT>(filename, hdu);
     }
 
@@ -306,10 +307,10 @@ public:
      *
      *  @param[in] manager     Object that manages the memory to be read.
      *  @param[in] hdu         Number of the "header-data unit" to read (where 0 is the Primary HDU).
-     *                         The default value of INT_MIN is interpreted as "the first HDU with
-     *                         NAXIS != 0".
+     *                         The default value of afw::fits::DEFAULT_HDU is interpreted as
+     *                         "the first HDU with NAXIS != 0".
      */
-    static Image readFits(fits::MemFileManager& manager, int hdu = INT_MIN) {
+    static Image readFits(fits::MemFileManager& manager, int hdu = fits::DEFAULT_HDU) {
         return Image<PixelT>(manager, hdu);
     }
 
@@ -430,7 +431,7 @@ public:
      * @param bbox Only read these pixels
      * @param origin Coordinate system of the bbox
      */
-    explicit DecoratedImage(std::string const& fileName, const int hdu = INT_MIN,
+    explicit DecoratedImage(std::string const& fileName, const int hdu = fits::DEFAULT_HDU,
                             geom::Box2I const& bbox = geom::Box2I(), ImageOrigin const origin = PARENT);
 
     /**

--- a/include/lsst/afw/image/Mask.h
+++ b/include/lsst/afw/image/Mask.h
@@ -43,6 +43,7 @@
 #include "lsst/afw/formatters/ImageFormatter.h"
 #include "lsst/afw/image/ImageBase.h"
 #include "lsst/afw/image/LsstImageTypes.h"
+#include "lsst/afw/fitsDefaults.h"
 
 namespace lsst {
 namespace afw {
@@ -151,8 +152,8 @@ public:
      *
      *  @param[in]      fileName      File to read.
      *  @param[in]      hdu           HDU to read, 0-indexed (i.e. 0=Primary HDU).  The special value
-     *                                of INT_MIN reads the Primary HDU unless it is empty, in which case it
-     *                                reads the first extension HDU.
+     *                                of afw::fits::DEFAULT_HDU reads the Primary HDU unless it is empty,
+     *                                in which case it reads the first extension HDU.
      *  @param[in,out]  metadata      Metadata read from the header (may be null).
      *  @param[in]      bbox          If non-empty, read only the pixels within the bounding box.
      *  @param[in]      origin        Coordinate system of the bounding box; if PARENT, the bounding box
@@ -164,7 +165,7 @@ public:
      *  bitvalues will be left alone, but Mask's dictionary will be modified to match the
      *  on-disk version.
      */
-    explicit Mask(std::string const& fileName, int hdu = INT_MIN,
+    explicit Mask(std::string const& fileName, int hdu = fits::DEFAULT_HDU,
                   std::shared_ptr<lsst::daf::base::PropertySet> metadata =
                           std::shared_ptr<lsst::daf::base::PropertySet>(),
                   geom::Box2I const& bbox = geom::Box2I(), ImageOrigin origin = PARENT,
@@ -175,8 +176,8 @@ public:
      *
      *  @param[in]      manager       An object that manages the memory buffer to read.
      *  @param[in]      hdu           HDU to read, 0-indexed (i.e. 0=Primary HDU).  The special value
-     *                                of INT_MIN reads the Primary HDU unless it is empty, in which case it
-     *                                reads the first extension HDU.
+     *                                of afw::fits::DEFAULT_HDU reads the Primary HDU unless it is empty,
+     *                                in which case it reads the first extension HDU.
      *  @param[in,out]  metadata      Metadata read from the header (may be null).
      *  @param[in]      bbox          If non-empty, read only the pixels within the bounding box.
      *  @param[in]      origin        Coordinate system of the bounding box; if PARENT, the bounding box
@@ -188,7 +189,7 @@ public:
      *  bitvalues will be left alone, but Mask's dictionary will be modified to match the
      *  on-disk version.
      */
-    explicit Mask(fits::MemFileManager& manager, int hdu = INT_MIN,
+    explicit Mask(fits::MemFileManager& manager, int hdu = fits::DEFAULT_HDU,
                   std::shared_ptr<lsst::daf::base::PropertySet> metadata =
                           std::shared_ptr<lsst::daf::base::PropertySet>(),
                   geom::Box2I const& bbox = geom::Box2I(), ImageOrigin origin = PARENT,
@@ -397,9 +398,10 @@ public:
      *
      *  @param[in] filename    Name of the file to read.
      *  @param[in] hdu         Number of the "header-data unit" to read (where 0 is the Primary HDU).
-     *                         The default value of INT_MIN is interpreted as "the first HDU with NAXIS != 0".
+     *                         The default value of afw::fits::DEFAULT_HDU is interpreted as
+     *                         "the first HDU with NAXIS != 0".
      */
-    static Mask readFits(std::string const& filename, int hdu = INT_MIN) {
+    static Mask readFits(std::string const& filename, int hdu = fits::DEFAULT_HDU) {
         return Mask<MaskPixelT>(filename, hdu);
     }
 
@@ -408,9 +410,10 @@ public:
      *
      *  @param[in] manager     Object that manages the memory to be read.
      *  @param[in] hdu         Number of the "header-data unit" to read (where 0 is the Primary HDU).
-     *                         The default value of INT_MIN is interpreted as "the first HDU with NAXIS != 0".
+     *                         The default value of afw::fits::DEFAULT_HDU is interpreted as
+     *                          "the first HDU with NAXIS != 0".
      */
-    static Mask readFits(fits::MemFileManager& manager, int hdu = INT_MIN) {
+    static Mask readFits(fits::MemFileManager& manager, int hdu = fits::DEFAULT_HDU) {
         return Mask<MaskPixelT>(manager, hdu);
     }
 

--- a/include/lsst/afw/image/Utils.h
+++ b/include/lsst/afw/image/Utils.h
@@ -56,12 +56,13 @@ namespace image {
  *  @deprecated Use lsst::afw::fits::readMetadata instead.
  *
  *  @param[in]    fileName            File to read.
- *  @param[in]    hdu                 HDU to read, 0-indexed.  The special value of INT_MIN will read the
- *                                    first non-empty HDU.
+ *  @param[in]    hdu                 HDU to read, 0-indexed.  The special value of afw::fits::DEFAULT_HDU
+ *                                    will read the first non-empty HDU.
  *  @param[in]    strip               If true, ignore special header keys usually managed by cfitsio
  *                                    (e.g. NAXIS).
  */
-inline std::shared_ptr<daf::base::PropertyList> readMetadata(std::string const& fileName, int hdu = INT_MIN,
+inline std::shared_ptr<daf::base::PropertyList> readMetadata(std::string const& fileName,
+                                                             int hdu = fits::DEFAULT_HDU,
                                                              bool strip = false) {
     return afw::fits::readMetadata(fileName, hdu, strip);
 }

--- a/include/lsst/afw/table/Catalog.h
+++ b/include/lsst/afw/table/Catalog.h
@@ -10,6 +10,7 @@
 
 #include "lsst/base.h"
 #include "lsst/pex/exceptions.h"
+#include "lsst/afw/fitsDefaults.h"
 #include "lsst/afw/table/fwd.h"
 #include "lsst/afw/table/io/FitsWriter.h"
 #include "lsst/afw/table/io/FitsReader.h"
@@ -328,11 +329,12 @@ public:
      *
      *  @param[in] filename    Name of the file to read.
      *  @param[in] hdu         Number of the "header-data unit" to read (where 0 is the Primary HDU).
-     *                         The default value of INT_MIN is interpreted as "the first HDU with NAXIS != 0".
+     *                         The default value of afw::fits::DEFAULT_HDU is interpreted as
+     *                         "the first HDU with NAXIS != 0".
      *  @param[in] flags       Table-subclass-dependent bitflags that control the details of how to read
      *                         the catalog.  See e.g. SourceFitsFlags.
      */
-    static CatalogT readFits(std::string const& filename, int hdu = INT_MIN, int flags = 0) {
+    static CatalogT readFits(std::string const& filename, int hdu = fits::DEFAULT_HDU, int flags = 0) {
         return io::FitsReader::apply<CatalogT>(filename, hdu, flags);
     }
 
@@ -341,11 +343,12 @@ public:
      *
      *  @param[in] manager     Object that manages the memory to be read.
      *  @param[in] hdu         Number of the "header-data unit" to read (where 0 is the Primary HDU).
-     *                         The default value of INT_MIN is interpreted as "the first HDU with NAXIS != 0".
+     *                         The default value of afw::fits::DEFAULT_HDU is interpreted as
+     *                         "the first HDU with NAXIS != 0".
      *  @param[in] flags       Table-subclass-dependent bitflags that control the details of how to read
      *                         the catalog.  See e.g. SourceFitsFlags.
      */
-    static CatalogT readFits(fits::MemFileManager& manager, int hdu = INT_MIN, int flags = 0) {
+    static CatalogT readFits(fits::MemFileManager& manager, int hdu = fits::DEFAULT_HDU, int flags = 0) {
         return io::FitsReader::apply<CatalogT>(manager, hdu, flags);
     }
 

--- a/include/lsst/afw/table/Exposure.h
+++ b/include/lsst/afw/table/Exposure.h
@@ -24,6 +24,7 @@
 #define AFW_TABLE_Exposure_h_INCLUDED
 
 #include "lsst/afw/geom/Box.h"
+#include "lsst/afw/fitsDefaults.h"
 #include "lsst/afw/table/BaseRecord.h"
 #include "lsst/afw/table/BaseTable.h"
 #include "lsst/afw/table/SortedCatalog.h"
@@ -326,11 +327,13 @@ public:
      *
      *  @param[in] filename    Name of the file to read.
      *  @param[in] hdu         Number of the "header-data unit" to read (where 0 is the Primary HDU).
-     *                         The default value of INT_MIN is interpreted as "the first HDU with NAXIS != 0".
+     *                         The default value of afw::fits::DEFAULT_HDU is interpreted as
+     *                         "the first HDU with NAXIS != 0".
      *  @param[in] flags       Table-subclass-dependent bitflags that control the details of how to read
      *                         the catalog.  See e.g. SourceFitsFlags.
      */
-    static ExposureCatalogT readFits(std::string const& filename, int hdu = INT_MIN, int flags = 0) {
+    static ExposureCatalogT readFits(std::string const& filename, int hdu = fits::DEFAULT_HDU,
+                                     int flags = 0) {
         return io::FitsReader::apply<ExposureCatalogT>(filename, hdu, flags);
     }
 
@@ -339,11 +342,13 @@ public:
      *
      *  @param[in] manager     Object that manages the memory to be read.
      *  @param[in] hdu         Number of the "header-data unit" to read (where 0 is the Primary HDU).
-     *                         The default value of INT_MIN is interpreted as "the first HDU with NAXIS != 0".
+     *                         The default value of afw::fits::DEFAULT_HDU is interpreted as
+     *                         "the first HDU with NAXIS != 0".
      *  @param[in] flags       Table-subclass-dependent bitflags that control the details of how to read
      *                         the catalog.  See e.g. SourceFitsFlags.
      */
-    static ExposureCatalogT readFits(fits::MemFileManager& manager, int hdu = INT_MIN, int flags = 0) {
+    static ExposureCatalogT readFits(fits::MemFileManager& manager, int hdu = fits::DEFAULT_HDU,
+                                     int flags = 0) {
         return io::FitsReader::apply<ExposureCatalogT>(manager, hdu, flags);
     }
 

--- a/include/lsst/afw/table/Schema.h
+++ b/include/lsst/afw/table/Schema.h
@@ -7,6 +7,7 @@
 
 #include "ndarray.h"
 #include "lsst/base.h"
+#include "lsst/afw/fitsDefaults.h"
 #include "lsst/afw/table/Key.h"
 #include "lsst/afw/table/Field.h"
 #include "lsst/afw/table/detail/SchemaImpl.h"
@@ -283,10 +284,10 @@ public:
     /** Construct from reading a FITS file.
      *
      * Reads from the nominated 'hdu' (0=PHU which cannot be a catalog,
-     * INT_MIN is a special value meaning read from the first HDU with NAXIS != 0).
+     * afw::fits::DEFAULT_HDU is a special value meaning read from the first HDU with NAXIS != 0).
      */
-    static Schema readFits(std::string const& filename, int hdu = INT_MIN);
-    static Schema readFits(fits::MemFileManager& manager, int hdu = INT_MIN);
+    static Schema readFits(std::string const& filename, int hdu = fits::DEFAULT_HDU);
+    static Schema readFits(fits::MemFileManager& manager, int hdu = fits::DEFAULT_HDU);
     static Schema readFits(fits::Fits& fitsfile);
 
     /** Construct from reading a FITS header

--- a/include/lsst/afw/table/SortedCatalog.h
+++ b/include/lsst/afw/table/SortedCatalog.h
@@ -23,6 +23,7 @@
 #ifndef AFW_TABLE_SortedCatalog_h_INCLUDED
 #define AFW_TABLE_SortedCatalog_h_INCLUDED
 
+#include "lsst/afw/fitsDefaults.h"
 #include "lsst/afw/table/fwd.h"
 #include "lsst/afw/table/Catalog.h"
 
@@ -111,11 +112,12 @@ public:
      *
      *  @param[in] filename    Name of the file to read.
      *  @param[in] hdu         Number of the "header-data unit" to read (where 0 is the Primary HDU).
-     *                         The default value of INT_MIN is interpreted as "the first HDU with NAXIS != 0".
+     *                         The default value of afw::fits::DEFAULT_HDU is interpreted as
+     *                         "the first HDU with NAXIS != 0".
      *  @param[in] flags       Table-subclass-dependent bitflags that control the details of how to read
      *                         the catalog.  See e.g. SourceFitsFlags.
      */
-    static SortedCatalogT readFits(std::string const& filename, int hdu = INT_MIN, int flags = 0) {
+    static SortedCatalogT readFits(std::string const& filename, int hdu = fits::DEFAULT_HDU, int flags = 0) {
         return io::FitsReader::apply<SortedCatalogT>(filename, hdu, flags);
     }
 
@@ -124,11 +126,13 @@ public:
      *
      *  @param[in] manager     Object that manages the memory to be read.
      *  @param[in] hdu         Number of the "header-data unit" to read (where 0 is the Primary HDU).
-     *                         The default value of INT_MIN is interpreted as "the first HDU with NAXIS != 0".
+     *                         The default value of afw::fits::DEFAULT_HDU is interpreted as
+     *                         "the first HDU with NAXIS != 0".
      *  @param[in] flags       Table-subclass-dependent bitflags that control the details of how to read
      *                         the catalog.  See e.g. SourceFitsFlags.
      */
-    static SortedCatalogT readFits(fits::MemFileManager& manager, int hdu = INT_MIN, int flags = 0) {
+    static SortedCatalogT readFits(fits::MemFileManager& manager, int hdu = fits::DEFAULT_HDU,
+                                   int flags = 0) {
         return io::FitsReader::apply<SortedCatalogT>(manager, hdu, flags);
     }
 

--- a/include/lsst/afw/table/io/Persistable.h
+++ b/include/lsst/afw/table/io/Persistable.h
@@ -5,6 +5,7 @@
 #include <climits>
 #include "lsst/base.h"
 #include "lsst/pex/exceptions.h"
+#include "lsst/afw/fitsDefaults.h"
 
 namespace lsst {
 namespace afw {
@@ -145,9 +146,9 @@ private:
     template <typename T>
     friend class PersistableFacade;
 
-    static std::shared_ptr<Persistable> _readFits(std::string const& fileName, int hdu = INT_MIN);
+    static std::shared_ptr<Persistable> _readFits(std::string const& fileName, int hdu = fits::DEFAULT_HDU);
 
-    static std::shared_ptr<Persistable> _readFits(fits::MemFileManager& manager, int hdu = INT_MIN);
+    static std::shared_ptr<Persistable> _readFits(fits::MemFileManager& manager, int hdu = fits::DEFAULT_HDU);
 
     static std::shared_ptr<Persistable> _readFits(fits::Fits& fitsfile);
 };
@@ -185,10 +186,10 @@ public:
      *  Read an object from a regular FITS file.
      *
      *  @param[in]  fileName     Name of the file to read.
-     *  @param[in]  hdu          HDU to read, where 0 is the primary.  The special value of INT_MIN
-     *                           skips the primary HDU if it is empty.
+     *  @param[in]  hdu          HDU to read, where 0 is the primary.  The special value of
+     *                           afw::fits::DEFAULT_HDU skips the primary HDU if it is empty.
      */
-    static std::shared_ptr<T> readFits(std::string const& fileName, int hdu = INT_MIN) {
+    static std::shared_ptr<T> readFits(std::string const& fileName, int hdu = fits::DEFAULT_HDU) {
         return std::dynamic_pointer_cast<T>(Persistable::_readFits(fileName, hdu));
     }
 
@@ -196,10 +197,10 @@ public:
      *  Read an object from a FITS file in memory.
      *
      *  @param[in]  manager      Manager for the memory to read from.
-     *  @param[in]  hdu          HDU to read, where 0 is the primary.  The special value of INT_MIN
-     *                           skips the primary HDU if it is empty.
+     *  @param[in]  hdu          HDU to read, where 0 is the primary.  The special value of
+     *                           afw::fits::DEFAULT_HDU skips the primary HDU if it is empty.
      */
-    static std::shared_ptr<T> readFits(fits::MemFileManager& manager, int hdu = INT_MIN) {
+    static std::shared_ptr<T> readFits(fits::MemFileManager& manager, int hdu = fits::DEFAULT_HDU) {
         return std::dynamic_pointer_cast<T>(Persistable::_readFits(manager, hdu));
     }
 };

--- a/include/lsst/afw/table/io/python.h
+++ b/include/lsst/afw/table/io/python.h
@@ -67,10 +67,10 @@ void declarePersistableFacade(pybind11::module &module, std::string const &suffi
             module, ("PersistableFacade" + suffix).c_str());
     cls.def_static("readFits",
                    (std::shared_ptr<T>(*)(std::string const &, int)) & PersistableFacade<T>::readFits,
-                   "fileName"_a, "hdu"_a = INT_MIN);
+                   "fileName"_a, "hdu"_a = fits::DEFAULT_HDU);
     cls.def_static("readFits",
                    (std::shared_ptr<T>(*)(fits::MemFileManager &, int)) & PersistableFacade<T>::readFits,
-                   "manager"_a, "hdu"_a = INT_MIN);
+                   "manager"_a, "hdu"_a = fits::DEFAULT_HDU);
 }
 
 /**
@@ -88,11 +88,11 @@ template <typename Class, typename PyClass>
 void addPersistableMethods(PyClass &cls) {
     cls.def_static("readFits",
                    (std::shared_ptr<Class>(*)(std::string const &, int)) & PersistableFacade<Class>::readFits,
-                   "fileName"_a, "hdu"_a = INT_MIN);
+                   "fileName"_a, "hdu"_a = fits::DEFAULT_HDU);
     cls.def_static(
             "readFits",
             (std::shared_ptr<Class>(*)(fits::MemFileManager &, int)) & PersistableFacade<Class>::readFits,
-            "manager"_a, "hdu"_a = INT_MIN);
+            "manager"_a, "hdu"_a = fits::DEFAULT_HDU);
     cls.def("writeFits", (void (Class::*)(std::string const &, std::string const &) const) & Class::writeFits,
             "fileName"_a, "mode"_a = "w");
     cls.def("writeFits",

--- a/include/lsst/afw/table/python/catalog.h
+++ b/include/lsst/afw/table/python/catalog.h
@@ -140,9 +140,9 @@ PyCatalog<Record> declareCatalog(pybind11::module &mod, std::string const &name,
 
     /* Static Methods */
     cls.def_static("readFits", (Catalog(*)(std::string const &, int, int)) & Catalog::readFits, "filename"_a,
-                   "hdu"_a = INT_MIN, "flags"_a = 0);
+                   "hdu"_a = fits::DEFAULT_HDU, "flags"_a = 0);
     cls.def_static("readFits", (Catalog(*)(fits::MemFileManager &, int, int)) & Catalog::readFits,
-                   "manager"_a, "hdu"_a = INT_MIN, "flags"_a = 0);
+                   "manager"_a, "hdu"_a = fits::DEFAULT_HDU, "flags"_a = 0);
     // readFits taking Fits objects not wrapped, because Fits objects are not wrapped.
 
     /* Methods */

--- a/include/lsst/afw/table/python/sortedCatalog.h
+++ b/include/lsst/afw/table/python/sortedCatalog.h
@@ -77,9 +77,9 @@ PySortedCatalog<Record> declareSortedCatalog(pybind11::module &mod, std::string 
 
     /* Overridden and Variant Methods */
     cls.def_static("readFits", (Catalog(*)(std::string const &, int, int)) & Catalog::readFits, "filename"_a,
-                   "hdu"_a = INT_MIN, "flags"_a = 0);
+                   "hdu"_a = fits::DEFAULT_HDU, "flags"_a = 0);
     cls.def_static("readFits", (Catalog(*)(fits::MemFileManager &, int, int)) & Catalog::readFits,
-                   "manager"_a, "hdu"_a = INT_MIN, "flags"_a = 0);
+                   "manager"_a, "hdu"_a = fits::DEFAULT_HDU, "flags"_a = 0);
     // readFits taking Fits objects not wrapped, because Fits objects are not wrapped.
 
     cls.def("subset", (Catalog (Catalog::*)(ndarray::Array<bool const, 1> const &) const) & Catalog::subset);

--- a/python/lsst/afw/fits/fits.cc
+++ b/python/lsst/afw/fits/fits.cc
@@ -178,7 +178,7 @@ void declareFits(py::module & mod) {
             "strip"_a=false);
     cls.def("createEmpty", &Fits::createEmpty);
 
-    cls.def("gotoFirstHdu", [](Fits & self) { self.setHdu(INT_MIN); });
+    cls.def("gotoFirstHdu", [](Fits & self) { self.setHdu(DEFAULT_HDU); });
 
     cls.def("setImageCompression", &Fits::setImageCompression);
     cls.def("getImageCompression", &Fits::getImageCompression);
@@ -218,9 +218,9 @@ PYBIND11_PLUGIN(_fits) {
         memcpy(m.getData(), PyBytes_AsString(d.ptr()), size);
     });
     clsMemFileManager.def("readMetadata",
-                          [](MemFileManager & self, int hdu=INT_MIN, bool strip=false) {
+                          [](MemFileManager & self, int hdu=DEFAULT_HDU, bool strip=false) {
                               return readMetadata(self, hdu, strip);
-                          }, "hdu"_a=INT_MIN, "strip"_a=false);
+                          }, "hdu"_a=DEFAULT_HDU, "strip"_a=false);
 
     declareImageCompression(mod);
     declareImageScalingOptions(mod);
@@ -228,10 +228,11 @@ PYBIND11_PLUGIN(_fits) {
     declareImageWriteOptions(mod);
     declareFits(mod);
 
+    mod.attr("DEFAULT_HDU") = DEFAULT_HDU;
     mod.def("readMetadata",
-            [](std::string const& filename, int hdu=INT_MIN, bool strip=false) {
+            [](std::string const& filename, int hdu=DEFAULT_HDU, bool strip=false) {
                 return readMetadata(filename, hdu, strip);
-            }, "fileName"_a, "hdu"_a=INT_MIN, "strip"_a=false);
+            }, "fileName"_a, "hdu"_a=DEFAULT_HDU, "strip"_a=false);
     mod.def("setAllowImageCompression", &setAllowImageCompression, "allow"_a);
     mod.def("getAllowImageCompression", &getAllowImageCompression);
 

--- a/python/lsst/afw/image/image/image.cc
+++ b/python/lsst/afw/image/image/image.cc
@@ -119,11 +119,11 @@ static PyImage<PixelT> declareImage(py::module &mod, const std::string &suffix) 
             "deep"_a = false, "xy0"_a = geom::Point2I());
     cls.def(py::init<std::string const &, int, std::shared_ptr<daf::base::PropertySet>, geom::Box2I const &,
                      ImageOrigin>(),
-            "fileName"_a, "hdu"_a = INT_MIN, "metadata"_a = nullptr, "bbox"_a = geom::Box2I(),
+            "fileName"_a, "hdu"_a = fits::DEFAULT_HDU, "metadata"_a = nullptr, "bbox"_a = geom::Box2I(),
             "origin"_a = PARENT);
     cls.def(py::init<fits::MemFileManager &, int, std::shared_ptr<daf::base::PropertySet>,
                      geom::Box2I const &, ImageOrigin>(),
-            "manager"_a, "hdu"_a = INT_MIN, "metadata"_a = nullptr, "bbox"_a = geom::Box2I(),
+            "manager"_a, "hdu"_a = fits::DEFAULT_HDU, "metadata"_a = nullptr, "bbox"_a = geom::Box2I(),
             "origin"_a = PARENT);
     cls.def(py::init<fits::Fits &, std::shared_ptr<daf::base::PropertySet>, geom::Box2I const &,
                      ImageOrigin>(),
@@ -188,9 +188,9 @@ static PyImage<PixelT> declareImage(py::module &mod, const std::string &suffix) 
             "mask"_a=std::shared_ptr<image::Mask<image::MaskPixel>>());
 
     cls.def_static("readFits", (Image<PixelT>(*)(std::string const &, int))Image<PixelT>::readFits,
-                   "filename"_a, "hdu"_a = INT_MIN);
+                   "filename"_a, "hdu"_a = fits::DEFAULT_HDU);
     cls.def_static("readFits", (Image<PixelT>(*)(fits::MemFileManager &, int))Image<PixelT>::readFits,
-                   "manager"_a, "hdu"_a = INT_MIN);
+                   "manager"_a, "hdu"_a = fits::DEFAULT_HDU);
     cls.def("sqrt", &Image<PixelT>::sqrt);
 
     /* Add-ons for Python interface only */
@@ -219,7 +219,8 @@ static void declareDecoratedImage(py::module &mod, std::string const &suffix) {
     cls.def(py::init<std::shared_ptr<Image<PixelT>>>(), "rhs"_a);
     cls.def(py::init<DecoratedImage<PixelT> const &, const bool>(), "rhs"_a, "deep"_a = false);
     cls.def(py::init<std::string const &, const int, lsst::afw::geom::Box2I const &, ImageOrigin const>(),
-            "fileName"_a, "hdu"_a = INT_MIN, "bbox"_a = lsst::afw::geom::Box2I(), "origin"_a = PARENT);
+            "fileName"_a, "hdu"_a = fits::DEFAULT_HDU, "bbox"_a = lsst::afw::geom::Box2I(),
+            "origin"_a = PARENT);
 
     cls.def("getMetadata", &DecoratedImage<PixelT>::getMetadata);
     cls.def("setMetadata", &DecoratedImage<PixelT>::setMetadata);

--- a/python/lsst/afw/image/mask/mask.cc
+++ b/python/lsst/afw/image/mask/mask.cc
@@ -68,11 +68,11 @@ static void declareMask(py::module &mod, std::string const &suffix) {
             "deep"_a = false, "xy0"_a = geom::Point2I());
     cls.def(py::init<std::string const &, int, std::shared_ptr<lsst::daf::base::PropertySet>,
                      geom::Box2I const &, ImageOrigin, bool>(),
-            "fileName"_a, "hdu"_a = INT_MIN, "metadata"_a = nullptr, "bbox"_a = geom::Box2I(),
+            "fileName"_a, "hdu"_a = fits::DEFAULT_HDU, "metadata"_a = nullptr, "bbox"_a = geom::Box2I(),
             "origin"_a = PARENT, "conformMasks"_a = false);
     cls.def(py::init<fits::MemFileManager &, int, std::shared_ptr<lsst::daf::base::PropertySet>,
                      geom::Box2I const &, ImageOrigin, bool>(),
-            "manager"_a, "hdu"_a = INT_MIN, "metadata"_a = nullptr, "bbox"_a = geom::Box2I(),
+            "manager"_a, "hdu"_a = fits::DEFAULT_HDU, "metadata"_a = nullptr, "bbox"_a = geom::Box2I(),
             "origin"_a = PARENT, "conformMasks"_a = false);
     cls.def(py::init<fits::Fits &, std::shared_ptr<lsst::daf::base::PropertySet>, geom::Box2I const &,
                      ImageOrigin, bool>(),
@@ -124,9 +124,9 @@ static void declareMask(py::module &mod, std::string const &suffix) {
                 &Mask<MaskPixelT>::writeFits,
             "fits"_a, "options"_a, "header"_a=std::shared_ptr<daf::base::PropertyList>());
     cls.def_static("readFits", (Mask<MaskPixelT>(*)(std::string const &, int))Mask<MaskPixelT>::readFits,
-                   "filename"_a, "hdu"_a = INT_MIN);
+                   "filename"_a, "hdu"_a = fits::DEFAULT_HDU);
     cls.def_static("readFits", (Mask<MaskPixelT>(*)(fits::MemFileManager &, int))Mask<MaskPixelT>::readFits,
-                   "manager"_a, "hdu"_a = INT_MIN);
+                   "manager"_a, "hdu"_a = fits::DEFAULT_HDU);
     cls.def_static("interpret", Mask<MaskPixelT>::interpret);
     cls.def("getAsString", &Mask<MaskPixelT>::getAsString);
     cls.def("clearAllMaskPlanes", &Mask<MaskPixelT>::clearAllMaskPlanes);

--- a/python/lsst/afw/image/readMetadata.cc
+++ b/python/lsst/afw/image/readMetadata.cc
@@ -35,7 +35,7 @@ PYBIND11_PLUGIN(readMetadata) {  // wraps code in Utils.h, but there's an unrela
     py::module mod("readMetadata");
 
     /* Module level */
-    mod.def("readMetadata", readMetadata, "fileName"_a, "hdu"_a = INT_MIN, "strip"_a = false);
+    mod.def("readMetadata", readMetadata, "fileName"_a, "hdu"_a = fits::DEFAULT_HDU, "strip"_a = false);
 
     return mod.ptr();
 }

--- a/python/lsst/afw/math/backgroundList.py
+++ b/python/lsst/afw/math/backgroundList.py
@@ -25,7 +25,7 @@ import os
 import lsst.daf.base as dafBase
 import lsst.afw.geom as afwGeom
 import lsst.afw.image as afwImage
-from lsst.afw.fits import FitsError, MemFileManager, reduceToFits, Fits
+from lsst.afw.fits import FitsError, MemFileManager, reduceToFits, Fits, DEFAULT_HDU
 from . import mathLib as afwMath
 
 
@@ -139,8 +139,7 @@ afwMath.Background and extract the interpStyle and undersampleStyle from the as-
 
         self = BackgroundList()
 
-        INT_MIN = -(1 << 31)
-        if hdu == INT_MIN:
+        if hdu == DEFAULT_HDU:
             hdu = -1
         else:
             # we want to start at 0 (post RFC-304), but are about to increment

--- a/python/lsst/afw/table/exposure/exposure.cc
+++ b/python/lsst/afw/table/exposure/exposure.cc
@@ -129,9 +129,9 @@ PyExposureCatalog declareExposureCatalog(py::module &mod) {
     cls.def(py::init<Catalog const &>(), "other"_a);
     // Constructor taking C++ iterators not wrapped; we recommend .extend() (defined in pure Python) instead.
     cls.def_static("readFits", (Catalog(*)(std::string const &, int, int)) & Catalog::readFits, "filename"_a,
-                   "hdu"_a = INT_MIN, "flags"_a = 0);
+                   "hdu"_a = fits::DEFAULT_HDU, "flags"_a = 0);
     cls.def_static("readFits", (Catalog(*)(fits::MemFileManager &, int, int)) & Catalog::readFits,
-                   "manager"_a, "hdu"_a = INT_MIN, "flags"_a = 0);
+                   "manager"_a, "hdu"_a = fits::DEFAULT_HDU, "flags"_a = 0);
     // readFits taking Fits objects not wrapped, because Fits objects are not wrapped.
 
     cls.def("subset", (Catalog (Catalog::*)(ndarray::Array<bool const, 1> const &) const) & Catalog::subset,

--- a/python/lsst/afw/table/schema/schema.cc
+++ b/python/lsst/afw/table/schema/schema.cc
@@ -352,9 +352,9 @@ void declareSchema(py::module &mod) {
         return true;
     });
     cls.def_static("readFits", (Schema(*)(std::string const &, int)) & Schema::readFits, "filename"_a,
-                   "hdu"_a = INT_MIN);
+                   "hdu"_a = fits::DEFAULT_HDU);
     cls.def_static("readFits", (Schema(*)(fits::MemFileManager &, int)) & Schema::readFits, "manager"_a,
-                   "hdu"_a = INT_MIN);
+                   "hdu"_a = fits::DEFAULT_HDU);
 
     cls.def("join", (std::string (Schema::*)(std::string const &, std::string const &) const) & Schema::join,
             "a"_a, "b"_a);

--- a/src/fits.cc
+++ b/src/fits.cc
@@ -294,10 +294,10 @@ void Fits::setHdu(int hdu, bool relative) {
             LSST_FITS_CHECK_STATUS(*this, boost::format("Incrementing HDU by %d") % hdu);
         }
     } else {
-        if (hdu != INT_MIN) {
+        if (hdu != DEFAULT_HDU) {
             fits_movabs_hdu(reinterpret_cast<fitsfile *>(fptr), hdu + 1, 0, &status);
         }
-        if (hdu == INT_MIN && getHdu() == 0 && getImageDim() == 0) {
+        if (hdu == DEFAULT_HDU && getHdu() == 0 && getImageDim() == 0) {
             // want a silent failure here
             int tmpStatus = status;
             fits_movrel_hdu(reinterpret_cast<fitsfile *>(fptr), 1, 0, &tmpStatus);

--- a/src/formatters/TanWcsFormatter.cc
+++ b/src/formatters/TanWcsFormatter.cc
@@ -106,7 +106,7 @@ dafBase::Persistable* TanWcsFormatter::read(std::shared_ptr<dafPersist::Formatte
     auto fits = std::dynamic_pointer_cast<dafPersist::FitsStorage>(storage);
     if (fits) {
         LOGL_DEBUG(_log, "TanWcsFormatter read FitsStorage");
-        int hdu = additionalData->get<int>("hdu", INT_MIN);
+        int hdu = additionalData->get<int>("hdu", fits::DEFAULT_HDU);
         std::shared_ptr<dafBase::PropertySet> md = afw::fits::readMetadata(fits->getPath(), hdu);
         image::TanWcs* ip = new image::TanWcs(md);
         LOGL_DEBUG(_log, "TanWcsFormatter read end");

--- a/src/formatters/WcsFormatter.cc
+++ b/src/formatters/WcsFormatter.cc
@@ -106,7 +106,7 @@ dafBase::Persistable* WcsFormatter::read(std::shared_ptr<dafPersist::FormatterSt
     auto fits = std::dynamic_pointer_cast<dafPersist::FitsStorage>(storage);
     if (fits) {
         LOGL_DEBUG(_log, "WcsFormatter read FitsStorage");
-        int hdu = additionalData->get<int>("hdu", INT_MIN);
+        int hdu = additionalData->get<int>("hdu", fits::DEFAULT_HDU);
         std::shared_ptr<dafBase::PropertySet> md = afw::fits::readMetadata(fits->getPath(), hdu);
         image::Wcs* ip = new image::Wcs(md);
         LOGL_DEBUG(_log, "WcsFormatter read end");

--- a/src/image/MaskedImage.cc
+++ b/src/image/MaskedImage.cc
@@ -176,9 +176,9 @@ MaskedImage<ImagePixelT, MaskPixelT, VariancePixelT>::MaskedImage(
         fitsfile.setHdu(prevHdu);
     }
 
-    // setHdu(INT_MIN) jumps to the first extension iff the primary HDU is both
+    // setHdu(fits::DEFAULT_HDU) jumps to the first extension iff the primary HDU is both
     // empty and currently selected.
-    fitsfile.setHdu(INT_MIN);
+    fitsfile.setHdu(fits::DEFAULT_HDU);
     ensureMetadata(imageMetadata);
     _image.reset(new Image(fitsfile, imageMetadata, bbox, origin));
     checkExtType(fitsfile, imageMetadata, "IMAGE");

--- a/tests/ramFitsIO.cc
+++ b/tests/ramFitsIO.cc
@@ -101,7 +101,7 @@ void test6() {
 
     // Read FITS file from disk into an Image
     std::shared_ptr<dafBase::PropertySet> miMetadata(new dafBase::PropertySet);
-    std::shared_ptr<ImageF> image(new ImageF(gFilename, INT_MIN, miMetadata));
+    std::shared_ptr<ImageF> image(new ImageF(gFilename, afwFits::DEFAULT_HDU, miMetadata));
 
     // Write the Image to a RAM FITS file
     image->writeFits(string(gFilenameStripped + "_imageOut.fit").c_str());
@@ -124,7 +124,8 @@ void test7() {
 
     // Read FITS file from disk into an Exposure
     std::shared_ptr<dafBase::PropertySet> miMetadata(new dafBase::PropertySet);
-    std::shared_ptr<ImageF> image = std::shared_ptr<ImageF>(new ImageF(gFilename, INT_MIN, miMetadata));
+    std::shared_ptr<ImageF> image = std::shared_ptr<ImageF>(new ImageF(gFilename, afwFits::DEFAULT_HDU,
+                                                                       miMetadata));
     MaskedImageF maskedImage(image);
     std::shared_ptr<afwImage::Wcs> wcsFromFITS = afwImage::makeWcs(miMetadata);
     ExposureF exposure(maskedImage, wcsFromFITS);

--- a/tests/test_spanSets.cc
+++ b/tests/test_spanSets.cc
@@ -764,7 +764,7 @@ BOOST_AUTO_TEST_CASE(SpanSet_testPersistence) {
     outFits.closeFile();
     // Read back in the fits file and un-persist the SpanSet
     lsst::afw::fits::Fits inFits(manager, "r", lsst::afw::fits::Fits::AUTO_CHECK);
-    inFits.setHdu(INT_MIN);
+    inFits.setHdu(lsst::afw::fits::DEFAULT_HDU);
     lsst::afw::table::io::InputArchive inArchive = tableIo::InputArchive::readFits(inFits);
     inFits.closeFile();
     std::shared_ptr<afwGeom::SpanSet> spanSetPostArchive =

--- a/tests/test_tableArchives.cc
+++ b/tests/test_tableArchives.cc
@@ -30,6 +30,7 @@
 #include "lsst/afw/math/Kernel.h"
 
 #include "lsst/afw/image/Exposure.h"
+#include "lsst/afw/fitsDefaults.h"
 
 namespace lsst {
 namespace afw {
@@ -295,7 +296,7 @@ std::vector<ndarray::Vector<std::shared_ptr<Comparable>, M>> roundtripAndCompare
     outArchive.writeFits(outFits2);
     outFits2.closeFile();
     fits::Fits inFits2(manager, "r", fits::Fits::AUTO_CHECK);
-    inFits2.setHdu(INT_MIN);
+    inFits2.setHdu(fits::DEFAULT_HDU);
     InputArchive inArchive2 = InputArchive::readFits(inFits2);
     inFits2.closeFile();
     for (int i = 0; i < M; ++i) {
@@ -449,7 +450,7 @@ std::shared_ptr<T> roundtrip(T const *input) {
     outArchive.writeFits(outFits);
     outFits.closeFile();
     Fits inFits(manager, "r", Fits::AUTO_CHECK);
-    inFits.setHdu(INT_MIN);
+    inFits.setHdu(DEFAULT_HDU);
     InputArchive inArchive = InputArchive::readFits(inFits);
     inFits.closeFile();
     return std::dynamic_pointer_cast<T>(inArchive.get(id));

--- a/tests/test_ticket2352.py
+++ b/tests/test_ticket2352.py
@@ -31,6 +31,8 @@ import unittest
 import lsst.afw.image as afwImage
 import lsst.utils.tests
 
+from lsst.afw.fits import DEFAULT_HDU
+
 testPath = os.path.abspath(os.path.dirname(__file__))
 DATA = os.path.join(testPath, "data", "ticket2352.fits")
 
@@ -55,7 +57,7 @@ class ReadMefTest(unittest.TestCase):
 
     def checkExtNum(self, hdu, extNum):
         if hdu is None:
-            hdu = -(1 << 31)            # == INT_MIN
+            hdu = DEFAULT_HDU
         header = afwImage.readMetadata(DATA, hdu)
         self.assertEqual(header.get("EXT_NUM"), extNum)
 


### PR DESCRIPTION
We have used INT_MIN to indicate that the first non-empty HDU should
be selected, but never exported the symbol to python. Changed the name
(but kept the value) so it's clear what it is, and exported it to
python.