### PR TITLE
DM-13189: add FunctorKey for Boxes

### DIFF
--- a/include/lsst/afw/geom/Box.h
+++ b/include/lsst/afw/geom/Box.h
@@ -56,6 +56,7 @@ class Box2I {
 public:
     typedef Point2I Point;
     typedef Extent2I Extent;
+    typedef int Element;
 
     enum EdgeHandlingEnum { EXPAND, SHRINK };
 
@@ -267,6 +268,7 @@ class Box2D {
 public:
     typedef Point2D Point;
     typedef Extent2D Extent;
+    typedef double Element;
 
     /**
      *  Value the maximum coordinate is multiplied by to increase it by the smallest

--- a/include/lsst/afw/table/Exposure.h
+++ b/include/lsst/afw/table/Exposure.h
@@ -204,9 +204,11 @@ public:
     /// Key for the unique ID.
     static Key<RecordId> getIdKey() { return getMinimalSchema().id; }
     /// Key for the minimum point of the bbox.
-    static PointKey<int> getBBoxMinKey() { return getMinimalSchema().bboxMin; }
+    static PointKey<int> getBBoxMinKey() { return getMinimalSchema().bbox.getMin(); }
     /// Key for the maximum point of the bbox.
-    static PointKey<int> getBBoxMaxKey() { return getMinimalSchema().bboxMax; }
+    static PointKey<int> getBBoxMaxKey() { return getMinimalSchema().bbox.getMax(); }
+    /// Key for the full bbox.
+    static Box2IKey getBBoxKey() { return getMinimalSchema().bbox; }
     //@}
 
     /// @copydoc BaseTable::clone
@@ -241,8 +243,7 @@ private:
     struct MinimalSchema {
         Schema schema;
         Key<RecordId> id;
-        PointKey<int> bboxMin;
-        PointKey<int> bboxMax;
+        Box2IKey bbox;
 
         MinimalSchema();
     };

--- a/python/lsst/afw/table/aggregates/aggregatesContinued.py
+++ b/python/lsst/afw/table/aggregates/aggregatesContinued.py
@@ -40,6 +40,11 @@ PointKey.register((np.int32, 2), aggregates.Point2IKey)
 PointKey.register((np.float64, 2), aggregates.Point2DKey)
 
 
+# Because Boxes aren't templates themselves, we don't expose the fact that
+# BoxKey is a template to the Python user; it's considered an implementation
+# detail.
+
+
 class CovarianceMatrixKey(with_metaclass(TemplateMeta, object)):
     TEMPLATE_PARAMS = ("dtype", "dim")
 

--- a/src/table/Exposure.cc
+++ b/src/table/Exposure.cc
@@ -312,12 +312,11 @@ static ExposureFitsReader const exposureFitsReader;
 //-----------------------------------------------------------------------------------------------------------
 
 geom::Box2I ExposureRecord::getBBox() const {
-    return geom::Box2I(get(ExposureTable::getBBoxMinKey()), get(ExposureTable::getBBoxMaxKey()));
+    return geom::Box2I(get(ExposureTable::getBBoxKey()));
 }
 
 void ExposureRecord::setBBox(geom::Box2I const &bbox) {
-    set(ExposureTable::getBBoxMinKey(), bbox.getMin());
-    set(ExposureTable::getBBoxMaxKey(), bbox.getMax());
+    set(ExposureTable::getBBoxKey(), bbox);
 }
 
 bool ExposureRecord::contains(Coord const &coord, bool includeValidPolygon) const {
@@ -380,8 +379,7 @@ ExposureTable::ExposureTable(ExposureTable const &other) : BaseTable(other) {}
 
 ExposureTable::MinimalSchema::MinimalSchema() {
     id = schema.addField<RecordId>("id", "unique ID");
-    bboxMin = PointKey<int>::addFields(schema, "bbox_min", "bbox minimum point", "pixel");
-    bboxMax = PointKey<int>::addFields(schema, "bbox_max", "bbox maximum point", "pixel");
+    bbox = Box2IKey::addFields(schema, "bbox", "bounding box", "pixel");
     schema.getCitizen().markPersistent();
 }
 

--- a/src/table/aggregates.cc
+++ b/src/table/aggregates.cc
@@ -22,6 +22,7 @@
  */
 
 #include "lsst/afw/geom/ellipses/Quadrupole.h"
+#include "lsst/afw/geom/Box.h"
 #include "lsst/afw/table/aggregates.h"
 #include "lsst/afw/table/BaseRecord.h"
 
@@ -52,6 +53,30 @@ void PointKey<T>::set(BaseRecord &record, geom::Point<T, 2> const &value) const 
 
 template class PointKey<int>;
 template class PointKey<double>;
+
+//============ BoxKey =====================================================================================
+
+template <typename Box>
+BoxKey<Box> BoxKey<Box>::addFields(Schema & schema, std::string const & name, std::string const & doc,
+                                   std::string const & unit) {
+    auto minKey = PointKey<Element>::addFields(schema, schema.join(name, "min"), doc + " (minimum)", unit);
+    auto maxKey = PointKey<Element>::addFields(schema, schema.join(name, "max"), doc + " (maximum)", unit);
+    return BoxKey<Box>(minKey, maxKey);
+}
+
+template <typename Box>
+Box BoxKey<Box>::get(BaseRecord const & record) const {
+    return Box(record.get(_min), record.get(_max), /*invert=*/false);
+}
+
+template <typename Box>
+void BoxKey<Box>::set(BaseRecord & record, Box const & value) const {
+    _min.set(record, value.getMin());
+    _max.set(record, value.getMax());
+}
+
+template class BoxKey<geom::Box2I>;
+template class BoxKey<geom::Box2D>;
 
 //============ CoordKey =====================================================================================
 


### PR DESCRIPTION
This adds `FunctorKeys` for `Box2I` and `Box2D`, which should start us towards recording boxes in tables in a consistent way.

I've also updated three other classes in afw to use the new `FunctorKey` because they were already using the same convention and hence the change could be done in a backwards-compatible way.  Two others (`AmpInfoRecord` and `Chebyshev1Function2d`) use a different convention and cannot be converted without changing APIs and/or persistence formats.
  