### PR TITLE
DM-10819: Define Endpoint equality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,7 @@ tests/stacker
 tests/statistics
 tests/statisticsSpeed
 tests/testLib.py
+tests/test_endpoint
 tests/test_spherePoint
 tests/test_transform
 tests/test_trapezoidalPacker

--- a/include/lsst/afw/geom/Endpoint.h
+++ b/include/lsst/afw/geom/Endpoint.h
@@ -84,6 +84,33 @@ public:
     virtual int getNPoints(Array const &arr) const = 0;
 
     /**
+     * Determine whether two endpoints represent the same conversion.
+     *
+     * @param other the endpoint to compare
+     * @returns `true` iff this object and `other` are of exactly the same class
+     *         and all visible properties are identical. This implementation
+     *         requires that the objects have the same number of axes.
+     *
+     * @warning Two endpoints with different implementation classes will never
+     *          compare equal, even if one class is conceptually equivalent to
+     *          the other (e.g., a decorator). This may cause unexpected
+     *          behavior when mixing related concrete endpoint classes.
+     */
+    // Note: while defining operator==(BaseEndpoint<OtherPoint, OtherArray> const &)
+    // would be more Pythonic, it's very hard to get such a method template to play well with pybind11
+    virtual bool operator==(BaseEndpoint const & other) const noexcept;
+
+    /**
+     * Determine whether two endpoints do not represent the same conversion.
+     *
+     * @returns the inverse of operator==. See that operator's documentation
+     *          for important caveats.
+     */
+    bool operator!=(BaseEndpoint const & other) const noexcept {
+        return !(*this == other);
+    }
+
+    /**
      * Get raw data from a single point
      *
      * @param[in] point  data for a single point
@@ -131,7 +158,7 @@ public:
     /**
      * Adjust and check the frame as needed.
      *
-     * Do not obother to check the number of axes because that is done elsewhere.
+     * Do not bother to check the number of axes because that is done elsewhere.
      *
      * The base implementation does nothing.
      */
@@ -160,6 +187,7 @@ protected:
 private:
     int _nAxes;  /// number of axes in a point
 };
+
 
 /**
  * Base class for endpoints with Array = std::vector<Point> where Point has 2 dimensions

--- a/include/lsst/afw/geom/Endpoint.h
+++ b/include/lsst/afw/geom/Endpoint.h
@@ -74,7 +74,7 @@ public:
     BaseEndpoint &operator=(BaseEndpoint const &) = delete;
     BaseEndpoint &operator=(BaseEndpoint &&) = delete;
 
-    virtual ~BaseEndpoint(){};
+    virtual ~BaseEndpoint() = default;
 
     int getNAxes() const { return _nAxes; }
 

--- a/src/geom/Endpoint.cc
+++ b/src/geom/Endpoint.cc
@@ -24,6 +24,7 @@
 #include <sstream>
 #include <string>
 #include <memory>
+#include <typeinfo>
 #include <vector>
 
 #include "astshim.h"
@@ -57,6 +58,11 @@ BaseEndpoint<Point, Array>::BaseEndpoint(int nAxes) : _nAxes(nAxes) {
         throw LSST_EXCEPT(lsst::pex::exceptions::InvalidParameterError,
                           "nAxes = " + std::to_string(nAxes) + "; must be > 0");
     }
+}
+
+template <typename Point, typename Array>
+bool BaseEndpoint<Point, Array>::operator==(BaseEndpoint const & other) const noexcept {
+    return this->getNAxes() == other.getNAxes() && typeid(*this) == typeid(other);
 }
 
 template <typename Point, typename Array>

--- a/tests/test_endpoint.cc
+++ b/tests/test_endpoint.cc
@@ -1,0 +1,148 @@
+// -*- LSST-C++ -*-
+
+/*
+ * LSST Data Management System
+ * See COPYRIGHT file at the top of the source tree.
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program. If not,
+ * see <http://www.lsstcorp.org/LegalNotices/>.
+ */
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE EndpointCpp
+
+#include "boost/test/unit_test.hpp"
+
+#include <string>
+#include <vector>
+
+#include "lsst/afw/geom/Endpoint.h"
+
+using namespace std;
+
+/* C++ unit tests for Endpoint.
+ *
+ * In addition to tests of C++-only functionality, this test suite includes
+ * tests that need custom subclasses of standard endpoints. While these could
+ * be written in Python, allowing Python classes to inherit from pybind11
+ * wrappers requires a lot of extra support code.
+ *
+ * See test_endpoint.py for remaining unit tests.
+ */
+namespace lsst {
+namespace afw {
+namespace geom {
+
+namespace {
+/**
+ * An IcrsCoordEndpoint whose sole purpose is to be a nontrivial subclass
+ * of IcrsCoordEndpoint.
+ */
+class GratuitousIcrsCoordEndpoint : public IcrsCoordEndpoint {
+    // Default constructor is adequate
+};
+
+/**
+ * An IcrsCoordEndpoint that adds equality-relevant fields to IcrsCoordEndpoint.
+ */
+class CoolIcrsCoordEndpoint : public IcrsCoordEndpoint {
+public:
+    CoolIcrsCoordEndpoint(string const & coolness) : IcrsCoordEndpoint(), _coolness(coolness) {}
+    string getCoolness() const noexcept { return _coolness; }
+
+    bool operator==(BaseEndpoint const & other) const noexcept override {
+        if (!IcrsCoordEndpoint::operator==(other)) {
+            return false;
+        } else {
+            // Guaranteed not to throw by BaseEndpoint::operator==
+            auto coolOther = dynamic_cast<CoolIcrsCoordEndpoint const &>(other);
+            return _coolness == coolOther._coolness;
+        }
+    }
+
+private:
+    string const _coolness;
+};
+}
+
+/// Test whether Endpoint equality treats subclasses as non-substitutable.
+BOOST_AUTO_TEST_CASE(EndpointEqualsNotPolymorphic) {
+    IcrsCoordEndpoint superclass;
+    GratuitousIcrsCoordEndpoint subclass;
+
+    // Test both IcrsCoordEndpoint::operator== and GratuitousIcrsCoordEndpoint::operator==
+    BOOST_TEST(superclass != subclass);
+    BOOST_TEST(subclass != superclass);
+    BOOST_TEST(!(superclass == subclass));
+    BOOST_TEST(!(subclass == superclass));
+}
+
+string printEquals(bool equal, string const & name1, string const & name2) {
+    return name1 + (equal ? " == " : " != ") + name2;
+}
+
+/**
+ * Test whether Endpoint equality is symmetric and transitive even in the
+ * presence of subclasses that add value fields.
+ */
+BOOST_AUTO_TEST_CASE(EndpointEqualsAlgebraic) {
+    using namespace std::string_literals;
+
+    vector<std::shared_ptr<IcrsCoordEndpoint const>> endpoints = {
+        make_shared<CoolIcrsCoordEndpoint>("Very cool"s),
+        make_shared<CoolIcrsCoordEndpoint>("Slightly nifty"s),
+        make_shared<CoolIcrsCoordEndpoint>("Very cool"s),
+        make_shared<IcrsCoordEndpoint>()
+    };
+
+    BOOST_TEST(*(endpoints[0]) != *(endpoints[1]));
+    BOOST_TEST(*(endpoints[1]) != *(endpoints[0]));
+    BOOST_TEST(*(endpoints[0]) == *(endpoints[2]));
+    BOOST_TEST(*(endpoints[2]) == *(endpoints[0]));
+
+    for (auto const endpoint1 : endpoints) {
+        for (auto const endpoint2 : endpoints) {
+            // == and != must always disagree
+            if (*endpoint1 == *endpoint2) {
+                BOOST_TEST(!(*endpoint1 != *endpoint2));
+            } else {
+                BOOST_TEST(*endpoint1 != *endpoint2);
+            }
+
+            for (auto const endpoint3 : endpoints) {
+                bool const equals12 = *endpoint1 == *endpoint2;
+                bool const equals13 = *endpoint1 == *endpoint3;
+                bool const equals23 = *endpoint2 == *endpoint3;
+
+                // Test point1 == point2 && point1 == point3 => point2 == point3
+                // Iteration covers all permutations, so no need to test, for example,
+                //     point1 == point3 && point2 == point3 => point1 == point2
+                bool const transitive = !equals12 || !equals13 || equals23;
+                BOOST_TEST(
+                    transitive,
+                    "Not transitive: " << printEquals(equals12, "1", "2") << " "
+                                       << printEquals(equals13, "1", "3") << " "
+                                       << printEquals(equals23, "2", "3")
+                );
+            }
+        }
+    }
+}
+
+}
+}
+} /* namespace lsst::afw::geom */


### PR DESCRIPTION
The C++ operator only handles Endpoints with the same `BaseEndpoint` parent (a more general operator is hard to implement because of how templates and inheritance interact, and would not be useful in C++ anyway). The Pybind11 wrapper uses conditional templates to provide a universal comparison operator for the Python API.