### PR TITLE
DM-9932: Make afw classes RFC-209 compliant

### DIFF
--- a/include/lsst/afw/cameraGeom/CameraPoint.h
+++ b/include/lsst/afw/cameraGeom/CameraPoint.h
@@ -37,6 +37,11 @@ namespace cameraGeom {
 class CameraPoint {
 public:
     CameraPoint(geom::Point2D point, CameraSys const &cameraSys) : _point(point), _cameraSys(cameraSys) {}
+    ~CameraPoint() = default;
+    CameraPoint(CameraPoint const &) = default;
+    CameraPoint(CameraPoint &&) = default;
+    CameraPoint &operator=(CameraPoint const &) = default;
+    CameraPoint &operator=(CameraPoint &&) = default;
     geom::Point2D getPoint() const { return _point; }
     CameraSys getCameraSys() const { return _cameraSys; }
 

--- a/include/lsst/afw/cameraGeom/CameraSys.h
+++ b/include/lsst/afw/cameraGeom/CameraSys.h
@@ -47,6 +47,12 @@ public:
                              )
             : _sysName(sysName) {}
 
+    ~CameraSysPrefix() = default;
+    CameraSysPrefix(CameraSysPrefix const &) = default;
+    CameraSysPrefix(CameraSysPrefix &&) = default;
+    CameraSysPrefix &operator=(CameraSysPrefix const &) = default;
+    CameraSysPrefix &operator=(CameraSysPrefix &&) = default;
+
     /**
      * Get coordinate system name
      */
@@ -94,6 +100,12 @@ public:
 
     /// default constructor so SWIG can wrap a vector of pairs containing these
     CameraSys() : _sysName("?"), _detectorName(){};
+
+    ~CameraSys() = default;
+    CameraSys(CameraSys const &) = default;
+    CameraSys(CameraSys &&) = default;
+    CameraSys &operator=(CameraSys const &) = default;
+    CameraSys &operator=(CameraSys &&) = default;
 
     /**
      * Get coordinate system name

--- a/include/lsst/afw/cameraGeom/Detector.h
+++ b/include/lsst/afw/cameraGeom/Detector.h
@@ -93,9 +93,14 @@ public:
                       geom::Box2I const &bbox, lsst::afw::table::AmpInfoCatalog const &ampInfoCatalog,
                       Orientation const &orientation, geom::Extent2D const &pixelSize,
                       TransformMap::Transforms const &transforms,
-                      CrosstalkMatrix const &crosstalk=CrosstalkMatrix());
+                      CrosstalkMatrix const &crosstalk = CrosstalkMatrix());
 
-    ~Detector() {}
+    ~Detector() = default;
+
+    Detector(Detector const &);
+    Detector(Detector &&);
+    Detector &operator=(Detector const &) = delete;
+    Detector &operator=(Detector &&) = delete;
 
     /** Get the detector name */
     std::string getName() const { return _name; }

--- a/include/lsst/afw/cameraGeom/Orientation.h
+++ b/include/lsst/afw/cameraGeom/Orientation.h
@@ -64,6 +64,12 @@ public:
                     geom::Angle(0)  ///< roll: rotation about X'' (Y''=Y' to Z''), 3rd rotation
             );
 
+    ~Orientation();
+    Orientation(Orientation const &);
+    Orientation(Orientation &&);
+    Orientation &operator=(Orientation const &);
+    Orientation &operator=(Orientation &&);
+
     /// Return focal plane position of detector reference point (mm)
     geom::Point2D getFpPosition() const { return _fpPosition; }
 

--- a/include/lsst/afw/cameraGeom/TransformMap.h
+++ b/include/lsst/afw/cameraGeom/TransformMap.h
@@ -101,6 +101,8 @@ public:
     TransformMap &operator=(TransformMap &&) = delete;
     ///@}
 
+    ~TransformMap();
+
     /**
      * Convert a point from one camera coordinate system to another.
      *

--- a/include/lsst/afw/coord/Coord.h
+++ b/include/lsst/afw/coord/Coord.h
@@ -100,12 +100,15 @@ public:
     /**
      * Default constructor for the Coord base class
      *
-     * Set all values to NaN
-     * Don't call _veriftyValues() method ... it'll fail.
-     *
+     * Sets all values to NaN
      */
     Coord();
-    virtual ~Coord() {}
+    virtual ~Coord() = default;
+
+    Coord(Coord const &);
+    Coord(Coord &&);
+    Coord &operator=(Coord const &);
+    Coord &operator=(Coord &&);
 
     virtual std::shared_ptr<Coord> clone() const { return std::shared_ptr<Coord>(new Coord(*this)); }
 
@@ -294,7 +297,13 @@ public:
             : Coord(p3d, 2000.0, normalize, defaultLongitude) {}
     IcrsCoord(lsst::afw::geom::Angle const ra, lsst::afw::geom::Angle const dec) : Coord(ra, dec, 2000.0) {}
     IcrsCoord(std::string const ra, std::string const dec) : Coord(ra, dec, 2000.0) {}
-    IcrsCoord() : Coord() {}
+    IcrsCoord() = default;
+    virtual ~IcrsCoord() = default;
+
+    IcrsCoord(IcrsCoord const &) = default;
+    IcrsCoord(IcrsCoord &&) = default;
+    IcrsCoord &operator=(IcrsCoord const &) = default;
+    IcrsCoord &operator=(IcrsCoord &&) = default;
 
     virtual std::shared_ptr<Coord> clone() const { return std::shared_ptr<IcrsCoord>(new IcrsCoord(*this)); }
 
@@ -348,7 +357,13 @@ public:
             : Coord(ra, dec, epoch) {}
     Fk5Coord(std::string const ra, std::string const dec, double const epoch = 2000.0)
             : Coord(ra, dec, epoch) {}
-    Fk5Coord() : Coord() {}
+    Fk5Coord() = default;
+    virtual ~Fk5Coord() = default;
+
+    Fk5Coord(Fk5Coord const &) = default;
+    Fk5Coord(Fk5Coord &&) = default;
+    Fk5Coord &operator=(Fk5Coord const &) = default;
+    Fk5Coord &operator=(Fk5Coord &&) = default;
 
     virtual std::shared_ptr<Coord> clone() const { return std::shared_ptr<Fk5Coord>(new Fk5Coord(*this)); }
 
@@ -418,7 +433,13 @@ public:
             : Coord(p3d, normalize, defaultLongitude) {}
     GalacticCoord(lsst::afw::geom::Angle const l, lsst::afw::geom::Angle const b) : Coord(l, b) {}
     GalacticCoord(std::string const l, std::string const b) : Coord(l, b) {}
-    GalacticCoord() : Coord() {}
+    GalacticCoord() = default;
+    virtual ~GalacticCoord() = default;
+
+    GalacticCoord(GalacticCoord const &) = default;
+    GalacticCoord(GalacticCoord &&) = default;
+    GalacticCoord &operator=(GalacticCoord const &) = default;
+    GalacticCoord &operator=(GalacticCoord &&) = default;
 
     virtual std::shared_ptr<Coord> clone() const {
         return std::shared_ptr<GalacticCoord>(new GalacticCoord(*this));
@@ -482,7 +503,13 @@ public:
     EclipticCoord(std::string const lamb, std::string const beta, double const epoch = 2000.0)
             : Coord(lamb, beta, epoch) {}
 
-    EclipticCoord() : Coord() {}
+    EclipticCoord() = default;
+    virtual ~EclipticCoord() = default;
+
+    EclipticCoord(EclipticCoord const &) = default;
+    EclipticCoord(EclipticCoord &&) = default;
+    EclipticCoord &operator=(EclipticCoord const &) = default;
+    EclipticCoord &operator=(EclipticCoord &&) = default;
 
     virtual std::shared_ptr<Coord> clone() const {
         return std::shared_ptr<EclipticCoord>(new EclipticCoord(*this));
@@ -546,6 +573,13 @@ public:
             : Coord(az, alt, epoch), _obs(obs) {}
     TopocentricCoord(std::string const az, std::string const alt, double const epoch, Observatory const &obs)
             : Coord(az, alt, epoch), _obs(obs) {}
+
+    virtual ~TopocentricCoord() = default;
+
+    TopocentricCoord(TopocentricCoord const &) = default;
+    TopocentricCoord(TopocentricCoord &&) = default;
+    TopocentricCoord &operator=(TopocentricCoord const &) = default;
+    TopocentricCoord &operator=(TopocentricCoord &&) = default;
 
     virtual std::shared_ptr<Coord> clone() const {
         return std::shared_ptr<TopocentricCoord>(new TopocentricCoord(*this));

--- a/include/lsst/afw/coord/Observatory.h
+++ b/include/lsst/afw/coord/Observatory.h
@@ -60,6 +60,12 @@ public:
      */
     Observatory(std::string const& longitude, std::string const& latitude, double const elevation);
 
+    ~Observatory();
+    Observatory(Observatory const&);
+    Observatory(Observatory&&);
+    Observatory& operator=(Observatory const&);
+    Observatory& operator=(Observatory&&);
+
     /// set telescope longitude
     void setLongitude(lsst::afw::geom::Angle const longitude);
     /// set telescope latitude (positive values are E of Greenwich)

--- a/include/lsst/afw/coord/Weather.h
+++ b/include/lsst/afw/coord/Weather.h
@@ -47,7 +47,7 @@ public:
      */
     explicit Weather(double airTemperature, double airPressure, double humidity);
 
-    ~Weather(){};
+    ~Weather() = default;
 
     Weather(Weather const &) = default;
     Weather(Weather &&) = default;

--- a/include/lsst/afw/detection/Footprint.h
+++ b/include/lsst/afw/detection/Footprint.h
@@ -105,7 +105,7 @@ public:
     Footprint &operator=(Footprint const &other) = default;
     Footprint &operator=(Footprint &&) = default;
 
-    virtual ~Footprint() {}
+    virtual ~Footprint() = default;
 
     /** Indicates if this object is a HeavyFootprint
      */

--- a/include/lsst/afw/detection/FootprintCtrl.h
+++ b/include/lsst/afw/detection/FootprintCtrl.h
@@ -55,6 +55,11 @@ public:
               _right(right ? TRUE_ : FALSE_),
               _up(up ? TRUE_ : FALSE_),
               _down(down ? TRUE_ : FALSE_) {}
+    ~FootprintControl() = default;
+    FootprintControl(FootprintControl const &) = default;
+    FootprintControl(FootprintControl &&) = default;
+    FootprintControl &operator=(FootprintControl const &) = default;
+    FootprintControl &operator=(FootprintControl &&) = default;
 
 #define DEFINE_ACCESSORS(NAME, UNAME)                                \
     /** Set whether Footprint should be grown in a NAME sort of   */ \
@@ -100,6 +105,12 @@ public:
 
     explicit HeavyFootprintCtrl(ModifySource modifySource = NONE)
             : _modifySource(modifySource), _imageVal(0.0), _maskVal(0), _varianceVal(0.0) {}
+
+    ~HeavyFootprintCtrl() = default;
+    HeavyFootprintCtrl(HeavyFootprintCtrl const &) = default;
+    HeavyFootprintCtrl(HeavyFootprintCtrl &&) = default;
+    HeavyFootprintCtrl &operator=(HeavyFootprintCtrl const &) = default;
+    HeavyFootprintCtrl &operator=(HeavyFootprintCtrl &&) = default;
 
     ModifySource getModifySource() const { return _modifySource; }
     void setModifySource(ModifySource modifySource) { _modifySource = modifySource; }

--- a/include/lsst/afw/detection/FootprintMerge.h
+++ b/include/lsst/afw/detection/FootprintMerge.h
@@ -83,6 +83,12 @@ public:
      */
     FootprintMergeList(afw::table::Schema &sourceSchema, std::vector<std::string> const &filterList);
 
+    ~FootprintMergeList();
+    FootprintMergeList(FootprintMergeList const &);
+    FootprintMergeList(FootprintMergeList &&);
+    FootprintMergeList &operator=(FootprintMergeList const &);
+    FootprintMergeList &operator=(FootprintMergeList &&);
+
     /// Return the schema for PeakRecords in the merged footprints.
     afw::table::Schema getPeakSchema() const { return _peakTable->getSchema(); }
 

--- a/include/lsst/afw/detection/FootprintSet.h
+++ b/include/lsst/afw/detection/FootprintSet.h
@@ -112,6 +112,8 @@ public:
      */
     FootprintSet(FootprintSet const& rhs);
     FootprintSet(FootprintSet const& set, int rGrow, FootprintControl const& ctrl);
+    FootprintSet(FootprintSet && rhs);
+    ~FootprintSet();
     /**
      * Grow all the Footprints in the input FootprintSet, returning a new FootprintSet
      *
@@ -133,6 +135,7 @@ public:
 
     /// Assignment operator.
     FootprintSet& operator=(FootprintSet const& rhs);
+    FootprintSet& operator=(FootprintSet && rhs);
 
     void swap(FootprintSet& rhs) {
         using std::swap;  // See Meyers, Effective C++, Item 25

--- a/include/lsst/afw/detection/GaussianPsf.h
+++ b/include/lsst/afw/detection/GaussianPsf.h
@@ -59,6 +59,12 @@ public:
      */
     GaussianPsf(geom::Extent2I const& dimensions, double sigma);
 
+    ~GaussianPsf();
+    GaussianPsf(GaussianPsf const&);
+    GaussianPsf(GaussianPsf&&);
+    GaussianPsf& operator=(GaussianPsf const&) = delete;
+    GaussianPsf& operator=(GaussianPsf&&) = delete;
+
     /// Polymorphic deep copy; should usually be unnecessary because Psfs are immutable.
     virtual std::shared_ptr<afw::detection::Psf> clone() const;
 

--- a/include/lsst/afw/detection/HeavyFootprint.h
+++ b/include/lsst/afw/detection/HeavyFootprint.h
@@ -78,7 +78,8 @@ public:
      * Default constructor for HeavyFootprint. Most common use for this will be in combination
      * with the assignment operator
      */
-    HeavyFootprint() {}
+    HeavyFootprint() = default;
+    ~HeavyFootprint() = default;
 
     HeavyFootprint(HeavyFootprint const& other) = default;
     HeavyFootprint(HeavyFootprint&& other) = default;

--- a/include/lsst/afw/detection/Peak.h
+++ b/include/lsst/afw/detection/Peak.h
@@ -46,6 +46,12 @@ public:
     typedef afw::table::CatalogT<PeakRecord> Catalog;
     typedef afw::table::CatalogT<PeakRecord const> ConstCatalog;
 
+    virtual ~PeakRecord() = default;
+    PeakRecord(PeakRecord const&) = delete;
+    PeakRecord(PeakRecord&&) = delete;
+    PeakRecord& operator=(PeakRecord const&) = delete;
+    PeakRecord& operator=(PeakRecord&&) = delete;
+
     std::shared_ptr<PeakTable const> getTable() const {
         return std::static_pointer_cast<PeakTable const>(afw::table::BaseRecord::getTable());
     }
@@ -89,6 +95,10 @@ public:
     typedef afw::table::ColumnViewT<PeakRecord> ColumnView;
     typedef afw::table::CatalogT<Record> Catalog;
     typedef afw::table::CatalogT<Record const> ConstCatalog;
+
+    virtual ~PeakTable();
+    PeakTable& operator=(PeakTable const&) = delete;
+    PeakTable& operator=(PeakTable&&) = delete;
 
     /**
      *  Obtain a table that can be used to create records with given schema
@@ -170,6 +180,7 @@ protected:
     PeakTable(afw::table::Schema const& schema, std::shared_ptr<afw::table::IdFactory> const& idFactory);
 
     PeakTable(PeakTable const& other);
+    PeakTable(PeakTable&& other);
 
     std::shared_ptr<afw::table::BaseTable> _clone() const override;
 

--- a/include/lsst/afw/detection/Psf.h
+++ b/include/lsst/afw/detection/Psf.h
@@ -86,7 +86,12 @@ public:
                       */
     };
 
-    virtual ~Psf() {}
+    Psf(Psf const&) = default;
+    Psf(Psf&&) = default;
+    Psf& operator=(Psf const&) = delete;
+    Psf& operator=(Psf&&) = delete;
+
+    virtual ~Psf() = default;
 
     /**
      *  Polymorphic deep-copy.

--- a/include/lsst/afw/detection/PsfFormatter.h
+++ b/include/lsst/afw/detection/PsfFormatter.h
@@ -22,7 +22,12 @@ class PsfFormatter : public lsst::daf::persistence::Formatter {
 public:
     /** Minimal destructor.
      */
-    virtual ~PsfFormatter(void);
+    virtual ~PsfFormatter();
+
+    PsfFormatter(PsfFormatter const&);
+    PsfFormatter(PsfFormatter&&);
+    PsfFormatter& operator=(PsfFormatter const&);
+    PsfFormatter& operator=(PsfFormatter&&);
 
     virtual void write(lsst::daf::base::Persistable const* persistable,
                        std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,

--- a/include/lsst/afw/detection/Threshold.h
+++ b/include/lsst/afw/detection/Threshold.h
@@ -61,6 +61,12 @@ public:
               )
             : _value(value), _type(type), _polarity(polarity), _includeMultiplier(includeMultiplier) {}
 
+    ~Threshold() = default;
+    Threshold(Threshold const &) = default;
+    Threshold(Threshold &&) = default;
+    Threshold &operator=(Threshold const &) = default;
+    Threshold &operator=(Threshold &&) = default;
+
     /// return type of threshold
     ThresholdType getType() const { return _type; }
 

--- a/include/lsst/afw/formatters/DecoratedImageFormatter.h
+++ b/include/lsst/afw/formatters/DecoratedImageFormatter.h
@@ -43,7 +43,12 @@ namespace formatters {
 template <typename ImagePixelT>
 class DecoratedImageFormatter : public lsst::daf::persistence::Formatter {
 public:
-    virtual ~DecoratedImageFormatter(void);
+    virtual ~DecoratedImageFormatter();
+
+    DecoratedImageFormatter(DecoratedImageFormatter const&) = default;
+    DecoratedImageFormatter(DecoratedImageFormatter&&) = default;
+    DecoratedImageFormatter& operator=(DecoratedImageFormatter const&) = default;
+    DecoratedImageFormatter& operator=(DecoratedImageFormatter&&) = default;
 
     virtual void write(lsst::daf::base::Persistable const* persistable,
                        std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,

--- a/include/lsst/afw/formatters/ExposureFormatter.h
+++ b/include/lsst/afw/formatters/ExposureFormatter.h
@@ -43,7 +43,12 @@ namespace formatters {
 template <typename ImagePixelT, typename MaskPixelT, typename VariancePixelT>
 class ExposureFormatter : public lsst::daf::persistence::Formatter {
 public:
-    virtual ~ExposureFormatter(void);
+    virtual ~ExposureFormatter();
+
+    ExposureFormatter(ExposureFormatter const&) = default;
+    ExposureFormatter(ExposureFormatter&&) = default;
+    ExposureFormatter& operator=(ExposureFormatter const&) = default;
+    ExposureFormatter& operator=(ExposureFormatter&&) = default;
 
     virtual void write(lsst::daf::base::Persistable const* persistable,
                        std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,

--- a/include/lsst/afw/formatters/ImageFormatter.h
+++ b/include/lsst/afw/formatters/ImageFormatter.h
@@ -43,7 +43,12 @@ namespace formatters {
 template <typename ImagePixelT>
 class ImageFormatter : public lsst::daf::persistence::Formatter {
 public:
-    virtual ~ImageFormatter(void);
+    virtual ~ImageFormatter();
+
+    ImageFormatter(ImageFormatter const&) = default;
+    ImageFormatter(ImageFormatter&&) = default;
+    ImageFormatter& operator=(ImageFormatter const&) = default;
+    ImageFormatter& operator=(ImageFormatter&&) = default;
 
     virtual void write(lsst::daf::base::Persistable const* persistable,
                        std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,

--- a/include/lsst/afw/formatters/KernelFormatter.h
+++ b/include/lsst/afw/formatters/KernelFormatter.h
@@ -46,7 +46,12 @@ class KernelFormatter : public lsst::daf::persistence::Formatter {
 public:
     /** Minimal destructor.
      */
-    virtual ~KernelFormatter(void);
+    virtual ~KernelFormatter();
+
+    KernelFormatter(KernelFormatter const&);
+    KernelFormatter(KernelFormatter&&);
+    KernelFormatter& operator=(KernelFormatter const&);
+    KernelFormatter& operator=(KernelFormatter&&);
 
     virtual void write(lsst::daf::base::Persistable const* persistable,
                        std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,

--- a/include/lsst/afw/formatters/MaskFormatter.h
+++ b/include/lsst/afw/formatters/MaskFormatter.h
@@ -43,7 +43,12 @@ namespace formatters {
 template <typename MaskPixelT>
 class MaskFormatter : public lsst::daf::persistence::Formatter {
 public:
-    virtual ~MaskFormatter(void);
+    virtual ~MaskFormatter();
+
+    MaskFormatter(MaskFormatter const&) = default;
+    MaskFormatter(MaskFormatter&&) = default;
+    MaskFormatter& operator=(MaskFormatter const&) = default;
+    MaskFormatter& operator=(MaskFormatter&&) = default;
 
     virtual void write(lsst::daf::base::Persistable const* persistable,
                        std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,

--- a/include/lsst/afw/formatters/MaskedImageFormatter.h
+++ b/include/lsst/afw/formatters/MaskedImageFormatter.h
@@ -43,7 +43,12 @@ namespace formatters {
 template <typename ImagePixelT, typename MaskPixelT, typename VariancePixelT>
 class MaskedImageFormatter : public lsst::daf::persistence::Formatter {
 public:
-    virtual ~MaskedImageFormatter(void);
+    virtual ~MaskedImageFormatter();
+
+    MaskedImageFormatter(MaskedImageFormatter const&) = default;
+    MaskedImageFormatter(MaskedImageFormatter&&) = default;
+    MaskedImageFormatter& operator=(MaskedImageFormatter const&) = default;
+    MaskedImageFormatter& operator=(MaskedImageFormatter&&) = default;
 
     virtual void write(lsst::daf::base::Persistable const* persistable,
                        std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,

--- a/include/lsst/afw/formatters/PropertyListFormatter.h
+++ b/include/lsst/afw/formatters/PropertyListFormatter.h
@@ -38,7 +38,12 @@ namespace formatters {
  */
 class PropertyListFormatter : public daf::persistence::Formatter {
 public:
-    virtual ~PropertyListFormatter() {}
+    virtual ~PropertyListFormatter() = default;
+
+    PropertyListFormatter(PropertyListFormatter const&);
+    PropertyListFormatter(PropertyListFormatter&&);
+    PropertyListFormatter& operator=(PropertyListFormatter const&);
+    PropertyListFormatter& operator=(PropertyListFormatter&&);
 
     virtual void write(daf::base::Persistable const* persistable,
                        std::shared_ptr<daf::persistence::FormatterStorage> storage,

--- a/include/lsst/afw/formatters/TanWcsFormatter.h
+++ b/include/lsst/afw/formatters/TanWcsFormatter.h
@@ -47,7 +47,12 @@ namespace formatters {
 
 class TanWcsFormatter : public lsst::daf::persistence::Formatter {
 public:
-    virtual ~TanWcsFormatter(void);
+    virtual ~TanWcsFormatter();
+
+    TanWcsFormatter(TanWcsFormatter const&);
+    TanWcsFormatter(TanWcsFormatter&&);
+    TanWcsFormatter& operator=(TanWcsFormatter const&);
+    TanWcsFormatter& operator=(TanWcsFormatter&&);
 
     virtual void write(lsst::daf::base::Persistable const* persistable,
                        std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,

--- a/include/lsst/afw/formatters/WcsFormatter.h
+++ b/include/lsst/afw/formatters/WcsFormatter.h
@@ -44,7 +44,12 @@ namespace formatters {
  */
 class WcsFormatter : public lsst::daf::persistence::Formatter {
 public:
-    virtual ~WcsFormatter(void);
+    virtual ~WcsFormatter();
+
+    WcsFormatter(WcsFormatter const&);
+    WcsFormatter(WcsFormatter&&);
+    WcsFormatter& operator=(WcsFormatter const&);
+    WcsFormatter& operator=(WcsFormatter&&);
 
     virtual void write(lsst::daf::base::Persistable const* persistable,
                        std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,

--- a/include/lsst/afw/geom/AffineTransform.h
+++ b/include/lsst/afw/geom/AffineTransform.h
@@ -109,6 +109,10 @@ public:
     explicit AffineTransform(LinearTransform const &linear, Extent2D const &translation)
             : _linear(linear), _translation(translation) {}
 
+    AffineTransform(AffineTransform const &) = default;
+    AffineTransform(AffineTransform &&) = default;
+    ~AffineTransform() = default;
+
     /**
      * Return the inverse transform
      *
@@ -168,11 +172,8 @@ public:
                                getLinear()(other.getTranslation()) + getTranslation());
     }
 
-    AffineTransform &operator=(AffineTransform const &other) {
-        _linear = other._linear;
-        _translation = other._translation;
-        return *this;
-    }
+    AffineTransform &operator=(AffineTransform const &) = default;
+    AffineTransform &operator=(AffineTransform &&) = default;
 
     AffineTransform &operator+=(AffineTransform const &other) {
         _linear += other._linear;

--- a/include/lsst/afw/geom/Angle.h
+++ b/include/lsst/afw/geom/Angle.h
@@ -125,6 +125,8 @@ public:
     /// Move assignment.
     Angle& operator=(Angle&& other) noexcept = default;
 
+    ~Angle() = default;
+
     /// Convert an Angle to a double in radians.
     constexpr operator double() const noexcept { return _val; }
 

--- a/include/lsst/afw/geom/Box.h
+++ b/include/lsst/afw/geom/Box.h
@@ -101,7 +101,9 @@ public:
     explicit Box2I(Box2D const& other, EdgeHandlingEnum edgeHandling = EXPAND);
 
     /// Standard copy constructor.
-    Box2I(Box2I const& other) : _minimum(other._minimum), _dimensions(other._dimensions) {}
+    Box2I(Box2I const&) = default;
+    Box2I(Box2I&&) = default;
+    ~Box2I() = default;
 
     void swap(Box2I& other) {
         _minimum.swap(other._minimum);
@@ -109,11 +111,8 @@ public:
     }
 
     /// Standard assignment operator.
-    Box2I& operator=(Box2I const& other) {
-        _minimum = other._minimum;
-        _dimensions = other._dimensions;
-        return *this;
-    }
+    Box2I& operator=(Box2I const&) = default;
+    Box2I& operator=(Box2I&&) = default;
 
     /**
      *  @name Min/Max Accessors
@@ -316,7 +315,10 @@ public:
     explicit Box2D(Box2I const& other);
 
     /// Standard copy constructor.
-    Box2D(Box2D const& other) : _minimum(other._minimum), _maximum(other._maximum) {}
+    Box2D(Box2D const&) = default;
+    Box2D(Box2D&&) = default;
+
+    ~Box2D() = default;
 
     void swap(Box2D& other) {
         _minimum.swap(other._minimum);
@@ -324,11 +326,8 @@ public:
     }
 
     /// Standard assignment operator.
-    Box2D& operator=(Box2D const& other) {
-        _minimum = other._minimum;
-        _maximum = other._maximum;
-        return *this;
-    }
+    Box2D& operator=(Box2D const&) = default;
+    Box2D& operator=(Box2D&&) = default;
 
     /**
      *  @name Min/Max Accessors

--- a/include/lsst/afw/geom/CoordinateBase.h
+++ b/include/lsst/afw/geom/CoordinateBase.h
@@ -55,6 +55,12 @@ public:
     static int const dimensions = N;
     typedef Eigen::Matrix<T, N, 1, Eigen::DontAlign> EigenVector;
 
+    CoordinateBase(CoordinateBase const&) = default;
+    CoordinateBase(CoordinateBase&&) = default;
+    CoordinateBase& operator=(CoordinateBase const&) = default;
+    CoordinateBase& operator=(CoordinateBase&&) = default;
+    ~CoordinateBase() = default;
+
     T& operator[](int n) { return _vector[n]; }
     T const& operator[](int n) const { return const_cast<EigenVector&>(_vector)[n]; }
     T& coeffRef(int n) { return _vector.coeffRef(n); }
@@ -109,6 +115,12 @@ public:
     static int const dimensions = 2;
     typedef Eigen::Matrix<T, 2, 1, Eigen::DontAlign> EigenVector;
 
+    CoordinateBase(CoordinateBase const&) = default;
+    CoordinateBase(CoordinateBase&&) = default;
+    CoordinateBase& operator=(CoordinateBase const&) = default;
+    CoordinateBase& operator=(CoordinateBase&&) = default;
+    ~CoordinateBase() = default;
+
     T& operator[](int n) { return _vector[n]; }
     T const& operator[](int n) const { return const_cast<EigenVector&>(_vector)[n]; }
     T& coeffRef(int n) { return _vector.coeffRef(n); }
@@ -153,6 +165,12 @@ public:
     typedef T Element;
     static int const dimensions = 3;
     typedef Eigen::Matrix<T, 3, 1, Eigen::DontAlign> EigenVector;
+
+    CoordinateBase(CoordinateBase const&) = default;
+    CoordinateBase(CoordinateBase&&) = default;
+    CoordinateBase& operator=(CoordinateBase const&) = default;
+    CoordinateBase& operator=(CoordinateBase&&) = default;
+    ~CoordinateBase() = default;
 
     T& operator[](int n) { return _vector[n]; }
     T const& operator[](int n) const { return const_cast<EigenVector&>(_vector)[n]; }

--- a/include/lsst/afw/geom/CoordinateExpr.h
+++ b/include/lsst/afw/geom/CoordinateExpr.h
@@ -62,6 +62,12 @@ public:
     template <typename Vector>
     explicit CoordinateExpr(Eigen::MatrixBase<Vector> const& vector) : Super(vector) {}
 
+    CoordinateExpr(CoordinateExpr const&) = default;
+    CoordinateExpr(CoordinateExpr&&) = default;
+    CoordinateExpr& operator=(CoordinateExpr const&) = default;
+    CoordinateExpr& operator=(CoordinateExpr&&) = default;
+    ~CoordinateExpr() = default;
+
     /**
      *  @name Logical operators
      *

--- a/include/lsst/afw/geom/Endpoint.h
+++ b/include/lsst/afw/geom/Endpoint.h
@@ -205,7 +205,7 @@ public:
     BaseVectorEndpoint &operator=(BaseVectorEndpoint const &) = delete;
     BaseVectorEndpoint &operator=(BaseVectorEndpoint &&) = delete;
 
-    virtual ~BaseVectorEndpoint(){};
+    virtual ~BaseVectorEndpoint() = default;
 
     virtual int getNPoints(Array const &arr) const override;
 
@@ -242,7 +242,7 @@ public:
      */
     explicit GenericEndpoint(int nAxes) : BaseEndpoint(nAxes){};
 
-    virtual ~GenericEndpoint(){};
+    virtual ~GenericEndpoint() = default;
 
     virtual int getNPoints(Array const &arr) const override { return arr.getSize<1>(); }
 
@@ -285,7 +285,7 @@ public:
      */
     explicit Point2Endpoint(int nAxes);
 
-    virtual ~Point2Endpoint(){};
+    virtual ~Point2Endpoint() = default;
 
     virtual std::vector<double> dataFromPoint(Point const &point) const override;
 
@@ -339,7 +339,7 @@ public:
      */
     explicit IcrsCoordEndpoint(int nAxes);
 
-    virtual ~IcrsCoordEndpoint(){};
+    virtual ~IcrsCoordEndpoint() = default;
 
     virtual std::vector<double> dataFromPoint(Point const &point) const override;
 

--- a/include/lsst/afw/geom/Extent.h
+++ b/include/lsst/afw/geom/Extent.h
@@ -61,6 +61,12 @@ class ExtentBase : public CoordinateBase<Extent<T, N>, T, N> {
     typedef CoordinateBase<Extent<T, N>, T, N> Super;
 
 public:
+    ExtentBase(ExtentBase const &) = default;
+    ExtentBase(ExtentBase &&) = default;
+    ExtentBase &operator=(ExtentBase const &) = default;
+    ExtentBase &operator=(ExtentBase &&) = default;
+    ~ExtentBase() = default;
+
     /// Return the squared L2 norm of the Extent (x^2 + y^2 + ...).
     T computeSquaredNorm() const { return this->asEigen().squaredNorm(); }
 
@@ -205,6 +211,13 @@ public:
     template <typename U>
     explicit Extent(Point<U, N> const &other);
 
+    Extent(Extent const &other);
+    Extent(Extent &&other);
+    ~Extent() = default;
+
+    Extent &operator=(Extent const &other) = default;
+    Extent &operator=(Extent &&other) = default;
+
     /// Return the squared L2 norm of the Extent (x^2 + y^2 + ...).
     T computeSquaredNorm() const { return this->asEigen().squaredNorm(); }
 
@@ -253,6 +266,13 @@ public:
     /// Construct from std::tuple.
     explicit Extent(std::tuple<T, T> const &xy) : Super(EigenVector(std::get<0>(xy), std::get<1>(xy))) {}
 
+    Extent(Extent const &other);
+    Extent(Extent &&other);
+    ~Extent() = default;
+
+    Extent &operator=(Extent const &other) = default;
+    Extent &operator=(Extent &&other) = default;
+
     void swap(Extent &other) { this->_swap(other); }
 };
 
@@ -293,6 +313,13 @@ public:
     explicit Extent(std::tuple<T, T, T> const &xyz)
             : Super(EigenVector(std::get<0>(xyz), std::get<1>(xyz), std::get<2>(xyz))) {}
 
+    Extent(Extent const &other);
+    Extent(Extent &&other);
+    ~Extent() = default;
+
+    Extent &operator=(Extent const &other) = default;
+    Extent &operator=(Extent &&other) = default;
+
     void swap(Extent &other) { this->_swap(other); }
 };
 
@@ -305,6 +332,12 @@ Extent<T, 2>::Extent(Extent<U, 2> const &other) {
     this->setX(static_cast<T>(other.getX()));
     this->setY(static_cast<T>(other.getY()));
 };
+
+// Should be consistent with converting constructor
+template <typename T>
+Extent<T, 2>::Extent(Extent<T, 2> const &) = default;
+template <typename T>
+Extent<T, 2>::Extent(Extent<T, 2> &&) = default;
 
 template <typename T>
 template <typename U>
@@ -325,6 +358,12 @@ Extent<T, 3>::Extent(Extent<U, 3> const &other) {
     this->setY(static_cast<T>(other.getY()));
     this->setZ(static_cast<T>(other.getZ()));
 };
+
+// Should be consistent with converting constructor
+template <typename T>
+Extent<T, 3>::Extent(Extent<T, 3> const &) = default;
+template <typename T>
+Extent<T, 3>::Extent(Extent<T, 3> &&) = default;
 
 // Constructor for any 3D type from 3I type
 template <typename T>

--- a/include/lsst/afw/geom/Functor.h
+++ b/include/lsst/afw/geom/Functor.h
@@ -55,7 +55,12 @@ public:
      */
     explicit Functor(std::string const& name);
 
-    virtual ~Functor() {}
+    Functor(Functor const &);
+    Functor(Functor &&);
+    Functor &operator=(Functor const &);
+    Functor &operator=(Functor &&);
+
+    virtual ~Functor() = default;
 
     virtual std::shared_ptr<Functor> clone() const = 0;
 
@@ -91,7 +96,12 @@ class LinearFunctor : public Functor {
 public:
     LinearFunctor(double slope, double intercept);
 
-    ~LinearFunctor() {}
+    LinearFunctor(LinearFunctor const &);
+    LinearFunctor(LinearFunctor &&);
+    LinearFunctor &operator=(LinearFunctor const &);
+    LinearFunctor &operator=(LinearFunctor &&);
+
+    ~LinearFunctor() = default;
 
     virtual std::shared_ptr<Functor> clone() const;
 

--- a/include/lsst/afw/geom/LinearTransform.h
+++ b/include/lsst/afw/geom/LinearTransform.h
@@ -84,6 +84,10 @@ public:
     /** Construct an LinearTransform from an Eigen::Matrix. */
     explicit LinearTransform(Matrix const& matrix) : _matrix(matrix) {}
 
+    LinearTransform(LinearTransform const&) = default;
+    LinearTransform(LinearTransform&&) = default;
+    ~LinearTransform() = default;
+
     LinearTransform operator*(LinearTransform const& other) const {
         return LinearTransform(getMatrix() * other.getMatrix());
     }
@@ -100,10 +104,8 @@ public:
         return LinearTransform(Matrix(Eigen::Rotation2D<double>(t.asRadians())));
     }
 
-    LinearTransform& operator=(LinearTransform const& other) {
-        _matrix = other._matrix;
-        return *this;
-    }
+    LinearTransform& operator=(LinearTransform const&) = default;
+    LinearTransform& operator=(LinearTransform&&) = default;
 
     LinearTransform& operator+=(LinearTransform const& other) {
         _matrix += other._matrix;

--- a/include/lsst/afw/geom/Point.h
+++ b/include/lsst/afw/geom/Point.h
@@ -43,6 +43,12 @@ class PointBase : public CoordinateBase<Point<T, N>, T, N> {
     typedef CoordinateBase<Point<T, N>, T, N> Super;
 
 public:
+    PointBase(PointBase const &) = default;
+    PointBase(PointBase &&) = default;
+    PointBase &operator=(PointBase const &) = default;
+    PointBase &operator=(PointBase &&) = default;
+    ~PointBase() = default;
+
     /**
      *  Standard equality comparison.
      *
@@ -157,6 +163,13 @@ public:
     /// Construct a Point with all elements set to the same scalar value.
     explicit Point(T val = static_cast<T>(0)) : Super(val) {}
 
+    Point(Point const &) = default;
+    Point(Point &&) = default;
+    ~Point() = default;
+
+    Point &operator=(Point const &) = default;
+    Point &operator=(Point &&) = default;
+
     /**
      *  Explicit converting constructor.
      *
@@ -190,6 +203,13 @@ public:
 
     /// Construct a Point with all elements set to the same scalar value.
     explicit Point(T val = static_cast<T>(0)) : Super(val) {}
+
+    Point(Point const &) = default;
+    Point(Point &&) = default;
+    ~Point() = default;
+
+    Point &operator=(Point const &) = default;
+    Point &operator=(Point &&) = default;
 
     /**
      *  Explicit converting constructor.
@@ -236,6 +256,13 @@ public:
 
     /// Construct a Point with all elements set to the same scalar value.
     explicit Point(T val = static_cast<T>(0)) : Super(val) {}
+
+    Point(Point const &) = default;
+    Point(Point &&) = default;
+    ~Point() = default;
+
+    Point &operator=(Point const &) = default;
+    Point &operator=(Point &&) = default;
 
     /**
      *  Explicit converting constructor.

--- a/include/lsst/afw/geom/SeparableXYTransform.h
+++ b/include/lsst/afw/geom/SeparableXYTransform.h
@@ -58,7 +58,12 @@ public:
      */
     SeparableXYTransform(Functor const& xfunctor, Functor const& yfunctor);
 
-    virtual ~SeparableXYTransform() {}
+    SeparableXYTransform(SeparableXYTransform const&);
+    SeparableXYTransform(SeparableXYTransform&&);
+    SeparableXYTransform& operator=(SeparableXYTransform const&);
+    SeparableXYTransform& operator=(SeparableXYTransform&&);
+
+    virtual ~SeparableXYTransform() = default;
 
     virtual std::shared_ptr<XYTransform> clone() const;
 

--- a/include/lsst/afw/geom/SkyWcs.h
+++ b/include/lsst/afw/geom/SkyWcs.h
@@ -117,6 +117,7 @@ public:
     SkyWcs(SkyWcs &&) = default;
     SkyWcs &operator=(SkyWcs const &) = delete;
     SkyWcs &operator=(SkyWcs &&) = delete;
+    ~SkyWcs() = default;
 
     /**
      * Equality is based on the string representations being equal

--- a/include/lsst/afw/geom/Span.h
+++ b/include/lsst/afw/geom/Span.h
@@ -67,6 +67,12 @@ public:
     /// Construct an empty Span with zero width at the origin.
     Span() : _y(0), _x0(0), _x1(-1) {}
 
+    Span(Span const&) = default;
+    Span(Span&&) = default;
+    Span& operator=(Span const&) = default;
+    Span& operator=(Span&&) = default;
+    ~Span() = default;
+
     /// Return an iterator to the first pixel in the Span.
     Iterator begin() const { return Iterator(Point2I(_x0, _y)); }
 

--- a/include/lsst/afw/geom/SpanPixelIterator.h
+++ b/include/lsst/afw/geom/SpanPixelIterator.h
@@ -44,6 +44,12 @@ class SpanPixelIterator : public boost::iterator_facade<SpanPixelIterator, Point
 public:
     explicit SpanPixelIterator(Point2I const& p = Point2I()) : _p(p) {}
 
+    SpanPixelIterator(SpanPixelIterator const&) = default;
+    SpanPixelIterator(SpanPixelIterator&&) = default;
+    SpanPixelIterator& operator=(SpanPixelIterator const&) = default;
+    SpanPixelIterator& operator=(SpanPixelIterator&&) = default;
+    ~SpanPixelIterator() = default;
+
 private:
     friend class boost::iterator_core_access;
 

--- a/include/lsst/afw/geom/SpanSet.h
+++ b/include/lsst/afw/geom/SpanSet.h
@@ -160,6 +160,11 @@ public:
     // Explicitly delete copy and move constructors
     SpanSet(SpanSet const &other) = delete;
     SpanSet(SpanSet &&other) = delete;
+    ~SpanSet() = default;
+
+    SpanSet &operator=(SpanSet const &) = default;
+    // Delegate to copy-assignment for backwards compatibility
+    SpanSet &operator=(SpanSet &&other) { return *this = other; }
 
     // Define class methods
     /** Return the number of pixels in the SpanSet

--- a/include/lsst/afw/geom/SpanSetFunctorGetters.h
+++ b/include/lsst/afw/geom/SpanSetFunctorGetters.h
@@ -41,7 +41,7 @@ namespace geom {
 namespace details {
 
 /* These variadic functions exist because of a current limitation in c++ where
- * calls of the form foo(x)... are not possibe unless it is used as a parameter
+ * calls of the form foo(x)... are not possible unless it is used as a parameter
  * for a second function. The following functions take in a variadic parameter
  * pack, and make recursive calls until the corresponding class method has been
  * called on all the variadic parameters
@@ -104,6 +104,12 @@ public:
     using type = typename std::iterator_traits<T>::value_type;
     explicit IterGetter(T iter) : _iter(iter) {}
 
+    IterGetter(IterGetter const&) = default;
+    IterGetter(IterGetter&&) = default;
+    IterGetter& operator=(IterGetter const&) = default;
+    IterGetter& operator=(IterGetter&&) = default;
+    ~IterGetter() = default;
+
     // There is no good way to check the extents of a generic iterator, so make
     // a no-op function to satisfy api
     void checkExtents(Box2I const& bbox, int area) const {}
@@ -124,6 +130,12 @@ class ConstantGetter {
     // for each iteration
 public:
     explicit ConstantGetter(T constant) : _const(constant) {}
+
+    ConstantGetter(ConstantGetter const&) = default;
+    ConstantGetter(ConstantGetter&&) = default;
+    ConstantGetter& operator=(ConstantGetter const&) = default;
+    ConstantGetter& operator=(ConstantGetter&&) = default;
+    ~ConstantGetter() = default;
 
     // Constants are simply repeated, so no need to check extents, make no-op
     // function
@@ -148,6 +160,12 @@ public:
 
     ImageNdGetter(ndarray::Array<T, N, C> const& array, geom::Point2I const& xy0)
             : _array(array), _xy0(xy0) {}
+
+    ImageNdGetter(ImageNdGetter const&) = default;
+    ImageNdGetter(ImageNdGetter&&) = default;
+    ImageNdGetter& operator=(ImageNdGetter const&) = default;
+    ImageNdGetter& operator=(ImageNdGetter&&) = default;
+    ~ImageNdGetter() = default;
 
     void checkExtents(Box2I const& bbox, int area) const {
         // If the bounding box lays outside the are of the image, throw an error
@@ -181,6 +199,12 @@ public:
     using Reference = typename ndarray::Array<T, inA, inC>::Reference;
 
     explicit FlatNdGetter(ndarray::Array<T, inA, inC> const& array) : _array(array), _iter(_array.begin()) {}
+
+    FlatNdGetter(FlatNdGetter const&) = default;
+    FlatNdGetter(FlatNdGetter&&) = default;
+    FlatNdGetter& operator=(FlatNdGetter const&) = default;
+    FlatNdGetter& operator=(FlatNdGetter&&) = default;
+    ~FlatNdGetter() = default;
 
     void checkExtents(Box2I const& bbox, int area) const {
         // If the area of the array is greater than the size of the array, throw an error

--- a/include/lsst/afw/geom/SpherePoint.h
+++ b/include/lsst/afw/geom/SpherePoint.h
@@ -124,6 +124,8 @@ public:
      */
     SpherePoint(SpherePoint&& other) noexcept;
 
+    ~SpherePoint();
+
     /**
      * Overwrite this object with the value of another SpherePoint.
      *

--- a/include/lsst/afw/geom/Transform.h
+++ b/include/lsst/afw/geom/Transform.h
@@ -83,6 +83,7 @@ public:
     Transform(Transform &&) = default;
     Transform &operator=(Transform const &) = delete;
     Transform &operator=(Transform &&) = delete;
+    ~Transform() = default;
 
     /**
      * Construct a Transform from a deep copy of an ast::Mapping

--- a/include/lsst/afw/geom/XYTransform.h
+++ b/include/lsst/afw/geom/XYTransform.h
@@ -52,7 +52,11 @@ public:
     typedef afw::geom::AffineTransform AffineTransform;
 
     explicit XYTransform();
-    virtual ~XYTransform() {}
+    XYTransform(XYTransform const &);
+    XYTransform(XYTransform &&);
+    XYTransform &operator=(XYTransform const &);
+    XYTransform &operator=(XYTransform &&);
+    virtual ~XYTransform() = default;
 
     /// returns a deep copy
     virtual std::shared_ptr<XYTransform> clone() const = 0;
@@ -100,6 +104,11 @@ public:
 class IdentityXYTransform : public XYTransform {
 public:
     IdentityXYTransform();
+    IdentityXYTransform(IdentityXYTransform const &);
+    IdentityXYTransform(IdentityXYTransform &&);
+    IdentityXYTransform &operator=(IdentityXYTransform const &);
+    IdentityXYTransform &operator=(IdentityXYTransform &&);
+    ~IdentityXYTransform();
 
     virtual std::shared_ptr<XYTransform> clone() const;
     virtual Point2D forwardTransform(Point2D const &point) const;
@@ -117,6 +126,11 @@ public:
 class InvertedXYTransform : public XYTransform {
 public:
     InvertedXYTransform(std::shared_ptr<XYTransform const> base);
+    InvertedXYTransform(InvertedXYTransform const &);
+    InvertedXYTransform(InvertedXYTransform &&);
+    InvertedXYTransform &operator=(InvertedXYTransform const &);
+    InvertedXYTransform &operator=(InvertedXYTransform &&);
+    ~InvertedXYTransform();
 
     virtual std::shared_ptr<XYTransform> clone() const;
     /** Return the wrapped XYTransform */
@@ -145,6 +159,12 @@ class MultiXYTransform : public XYTransform {
 public:
     typedef std::vector<std::shared_ptr<XYTransform const>> TransformList;
     MultiXYTransform(TransformList const &transformList);
+    MultiXYTransform(MultiXYTransform const &);
+    MultiXYTransform(MultiXYTransform &&);
+    MultiXYTransform &operator=(MultiXYTransform const &);
+    MultiXYTransform &operator=(MultiXYTransform &&);
+    ~MultiXYTransform();
+
     virtual std::shared_ptr<XYTransform> clone() const;
     virtual Point2D forwardTransform(Point2D const &point) const;
     virtual Point2D reverseTransform(Point2D const &point) const;
@@ -165,6 +185,11 @@ private:
 class AffineXYTransform : public XYTransform {
 public:
     AffineXYTransform(AffineTransform const &affineTransform);
+    AffineXYTransform(AffineXYTransform const &);
+    AffineXYTransform(AffineXYTransform &&);
+    AffineXYTransform &operator=(AffineXYTransform const &);
+    AffineXYTransform &operator=(AffineXYTransform &&);
+    ~AffineXYTransform();
 
     virtual std::shared_ptr<XYTransform> clone() const;
     virtual Point2D forwardTransform(Point2D const &position) const;
@@ -205,7 +230,12 @@ public:
      */
     RadialXYTransform(std::vector<double> const &coeffs
 
-                      );
+    );
+    RadialXYTransform(RadialXYTransform const &);
+    RadialXYTransform(RadialXYTransform &&);
+    RadialXYTransform &operator=(RadialXYTransform const &);
+    RadialXYTransform &operator=(RadialXYTransform &&);
+    ~RadialXYTransform();
 
     virtual std::shared_ptr<XYTransform> clone() const;
     virtual std::shared_ptr<XYTransform> invert() const;

--- a/include/lsst/afw/geom/ellipses/Axes.h
+++ b/include/lsst/afw/geom/ellipses/Axes.h
@@ -78,6 +78,8 @@ public:
         _vector = other._vector;
         return *this;
     }
+    // Delegate to copy-assignment for backwards compatibility
+    Axes& operator=(Axes&& other) { return *this = other; }
 
     /// Converting assignment.
     Axes& operator=(BaseCore const& other) {
@@ -98,6 +100,9 @@ public:
 
     /// Copy constructor.
     Axes(Axes const& other) : _vector(other._vector) {}
+    // Delegate to copy-constructor for backwards compatibility
+    Axes(Axes&& other) : Axes(other) {}
+    ~Axes() = default;
 
     /// Converting copy constructor.
     Axes(BaseCore const& other) { *this = other; }

--- a/include/lsst/afw/geom/ellipses/BaseCore.h
+++ b/include/lsst/afw/geom/ellipses/BaseCore.h
@@ -172,6 +172,7 @@ public:
      *  This does not change the parametrization of the ellipse core.
      */
     BaseCore& operator=(BaseCore const& other);
+    BaseCore& operator=(BaseCore&& other);
 
     /// Assign other to this and return the derivative of the conversion, d(this)/d(other).
     Jacobian dAssign(BaseCore const& other);
@@ -182,10 +183,14 @@ public:
     template <typename Output>
     Converter<Output> as() const;
 
-    virtual ~BaseCore() {}
+    virtual ~BaseCore() = default;
 
 protected:
     friend class Parametric;
+
+    BaseCore() = default;
+    BaseCore(BaseCore const&) = default;
+    BaseCore(BaseCore&&) = default;
 
     static void registerSubclass(std::shared_ptr<BaseCore> const& example);
 

--- a/include/lsst/afw/geom/ellipses/ConformalShear.h
+++ b/include/lsst/afw/geom/ellipses/ConformalShear.h
@@ -49,6 +49,9 @@ public:
     explicit ConformalShear(double e1 = 0.0, double e2 = 0.0) : detail::EllipticityBase(e1, e2) {}
 
     ConformalShear(ConformalShear const& other) : detail::EllipticityBase(other.getComplex()) {}
+    // Delegate to copy-constructor for backwards compatibility
+    ConformalShear(ConformalShear&& other) : ConformalShear(other) {}
+    ~ConformalShear() = default;
 
     explicit ConformalShear(Distortion const& other) { this->operator=(other); }
 
@@ -58,6 +61,8 @@ public:
         _complex = other._complex;
         return *this;
     }
+    // Delegate to copy-assignment for backwards compatibility
+    ConformalShear& operator=(ConformalShear&& other) { return *this = other; }
 
     ConformalShear& operator=(Distortion const& other);
 

--- a/include/lsst/afw/geom/ellipses/Distortion.h
+++ b/include/lsst/afw/geom/ellipses/Distortion.h
@@ -48,6 +48,9 @@ public:
     explicit Distortion(double e1 = 0.0, double e2 = 0.0) : detail::EllipticityBase(e1, e2) {}
 
     Distortion(Distortion const& other) : detail::EllipticityBase(other.getComplex()) {}
+    // Delegate to copy-constructor for backwards compatibility
+    Distortion(Distortion&& other) : Distortion(other) {}
+    ~Distortion() = default;
 
     explicit Distortion(ConformalShear const& other) { this->operator=(other); }
 
@@ -57,6 +60,8 @@ public:
         _complex = other._complex;
         return *this;
     }
+    // Delegate to copy-assignment for backwards compatibility
+    Distortion& operator=(Distortion&& other) { return *this = other; }
 
     Distortion& operator=(ConformalShear const& other);
 

--- a/include/lsst/afw/geom/ellipses/Ellipse.h
+++ b/include/lsst/afw/geom/ellipses/Ellipse.h
@@ -141,6 +141,7 @@ public:
      *  This does not change the parametrization of the ellipse.
      */
     Ellipse& operator=(Ellipse const& other);
+    Ellipse& operator=(Ellipse&& other);
 
     /**
      *  Compare two ellipses for equality.
@@ -158,7 +159,7 @@ public:
      */
     bool operator!=(Ellipse const& other) const { return !operator==(other); }
 
-    virtual ~Ellipse() {}
+    virtual ~Ellipse() = default;
 
     explicit Ellipse(BaseCore const& core, Point2D const& center = Point2D())
             : _core(core.clone()), _center(center) {}
@@ -170,6 +171,8 @@ public:
     Ellipse(Convolution const& other);
 
     Ellipse(Ellipse const& other) : _core(other.getCore().clone()), _center(other.getCenter()) {}
+    // Delegate to copy-constructor for backwards compatibility
+    Ellipse(Ellipse&& other) : Ellipse(other) {}
 
 private:
     std::shared_ptr<BaseCore> _core;

--- a/include/lsst/afw/geom/ellipses/EllipticityBase.h
+++ b/include/lsst/afw/geom/ellipses/EllipticityBase.h
@@ -77,6 +77,12 @@ public:
 
     double getTheta() const { return 0.5 * std::arg(_complex); }
 
+    EllipticityBase(EllipticityBase const&) = default;
+    EllipticityBase(EllipticityBase&&) = default;
+    EllipticityBase& operator=(EllipticityBase const&) = default;
+    EllipticityBase& operator=(EllipticityBase&&) = default;
+    ~EllipticityBase() = default;
+
 protected:
     explicit EllipticityBase(std::complex<double> const& complex) : _complex(complex) {}
 

--- a/include/lsst/afw/geom/ellipses/PixelRegion.h
+++ b/include/lsst/afw/geom/ellipses/PixelRegion.h
@@ -48,6 +48,12 @@ public:
 
     explicit PixelRegion(Ellipse const& ellipse);
 
+    PixelRegion(PixelRegion const&) = default;
+    PixelRegion(PixelRegion&&) = default;
+    PixelRegion& operator=(PixelRegion const&) = default;
+    PixelRegion& operator=(PixelRegion&&) = default;
+    ~PixelRegion() = default;
+
 private:
     Point2D _center;
     double _detQ;
@@ -61,6 +67,12 @@ class PixelRegion::Iterator : public boost::iterator_facade<PixelRegion::Iterato
 public:
     explicit Iterator(Span const& s = Span(0, 0, 0), PixelRegion const* region = NULL)
             : _s(s), _region(region) {}
+
+    Iterator(Iterator const&) = default;
+    Iterator(Iterator&&) = default;
+    Iterator& operator=(Iterator const&) = default;
+    Iterator& operator=(Iterator&&) = default;
+    ~Iterator() = default;
 
 private:
     friend class boost::iterator_core_access;

--- a/include/lsst/afw/geom/ellipses/Quadrupole.h
+++ b/include/lsst/afw/geom/ellipses/Quadrupole.h
@@ -88,6 +88,9 @@ public:
         return *this;
     }
 
+    // Delegate to copy-assignment for backwards compatibility
+    Quadrupole& operator=(Quadrupole&& other) { return *this = other; }
+
     /// Converting assignment.
     Quadrupole& operator=(BaseCore const& other) {
         BaseCore::operator=(other);
@@ -105,6 +108,11 @@ public:
 
     /// Copy constructor.
     Quadrupole(Quadrupole const& other) : _matrix(other._matrix) {}
+
+    // Delegate to copy-constructor for backwards compatibility
+    Quadrupole(Quadrupole&& other) : Quadrupole(other) {}
+
+    ~Quadrupole() = default;
 
     /// Converting copy constructor.
     Quadrupole(BaseCore const& other) { *this = other; }

--- a/include/lsst/afw/geom/ellipses/ReducedShear.h
+++ b/include/lsst/afw/geom/ellipses/ReducedShear.h
@@ -49,6 +49,9 @@ public:
     explicit ReducedShear(double e1 = 0.0, double e2 = 0.0) : detail::EllipticityBase(e1, e2) {}
 
     ReducedShear(ReducedShear const& other) : detail::EllipticityBase(other.getComplex()) {}
+    // Delegate to copy-constructor for backwards compatibility
+    ReducedShear(ReducedShear&& other) : ReducedShear(other) {}
+    ~ReducedShear() = default;
 
     explicit ReducedShear(Distortion const& other) { this->operator=(other); }
 
@@ -58,6 +61,8 @@ public:
         _complex = other._complex;
         return *this;
     }
+    // Delegate to copy-assignment for backwards compatibility
+    ReducedShear& operator=(ReducedShear&& other) { return *this = other; }
 
     ReducedShear& operator=(Distortion const& other);
 

--- a/include/lsst/afw/geom/ellipses/Separable.h
+++ b/include/lsst/afw/geom/ellipses/Separable.h
@@ -87,6 +87,8 @@ public:
     /// Standard assignment.
     Separable& operator=(Separable const& other);
 
+    Separable& operator=(Separable&& other);
+
     /// Converting assignment.
     Separable& operator=(BaseCore const& other) {
         BaseCore::operator=(other);
@@ -107,6 +109,11 @@ public:
 
     /// Copy constructor.
     Separable(Separable const& other) : _ellipticity(other._ellipticity), _radius(other._radius) {}
+
+    // Delegate to copy-constructor for backwards compatibility
+    Separable(Separable&& other) : Separable(other) {}
+
+    ~Separable() = default;
 
     /// Converting copy constructor.
     Separable(BaseCore const& other) { *this = other; }

--- a/include/lsst/afw/geom/ellipses/radii.h
+++ b/include/lsst/afw/geom/ellipses/radii.h
@@ -68,6 +68,10 @@ public:
 
     explicit DeterminantRadius(LogDeterminantRadius const &other);
 
+    DeterminantRadius(DeterminantRadius const &) = default;
+    DeterminantRadius(DeterminantRadius &&) = default;
+    ~DeterminantRadius() = default;
+
     operator double const &() const { return _value; }
 
     operator double &() { return _value; }
@@ -78,15 +82,17 @@ public:
     }
 
     DeterminantRadius &operator=(LogDeterminantRadius const &other);
+    DeterminantRadius &operator=(DeterminantRadius const &) = default;
+    DeterminantRadius &operator=(DeterminantRadius &&) = default;
+
+    /// Conversion between trace and determinant radii requires ellipticity.
+    DeterminantRadius &operator=(TraceRadius const &) = delete;
+    /// Conversion between trace and determinant radii requires ellipticity.
+    DeterminantRadius &operator=(LogTraceRadius const &) = delete;
 
 private:
     template <typename T1, typename T2>
     friend class Separable;
-
-    /// Undefined and disabled; conversion between trace and determinant radii requires ellipticity.
-    void operator=(TraceRadius const &);
-    /// Undefined and disabled; conversion between trace and determinant radii requires ellipticity.
-    void operator=(LogTraceRadius const &);
 
     void assignFromQuadrupole(double ixx, double iyy, double ixy, Distortion &distortion);
 
@@ -119,6 +125,10 @@ public:
 
     explicit TraceRadius(LogTraceRadius const &other);
 
+    TraceRadius(TraceRadius const &) = default;
+    TraceRadius(TraceRadius &&) = default;
+    ~TraceRadius() = default;
+
     operator double const &() const { return _value; }
 
     operator double &() { return _value; }
@@ -129,15 +139,17 @@ public:
     }
 
     TraceRadius &operator=(LogTraceRadius const &other);
+    TraceRadius &operator=(TraceRadius const &) = default;
+    TraceRadius &operator=(TraceRadius &&) = default;
+
+    /// Conversion between trace and determinant radii requires ellipticity.
+    TraceRadius &operator=(DeterminantRadius const &) = delete;
+    /// Conversion between trace and determinant radii requires ellipticity.
+    TraceRadius &operator=(LogDeterminantRadius const &) = delete;
 
 private:
     template <typename T1, typename T2>
     friend class Separable;
-
-    /// Undefined and disabled; conversion between trace and determinant radii requires ellipticity.
-    void operator=(DeterminantRadius const &);
-    /// Undefined and disabled; conversion between trace and determinant radii requires ellipticity.
-    void operator=(LogDeterminantRadius const &);
 
     void assignFromQuadrupole(double ixx, double iyy, double ixy, Distortion &distortion);
 
@@ -164,6 +176,10 @@ public:
 
     explicit LogDeterminantRadius(DeterminantRadius const &other);
 
+    LogDeterminantRadius(LogDeterminantRadius const &) = default;
+    LogDeterminantRadius(LogDeterminantRadius &&) = default;
+    ~LogDeterminantRadius() = default;
+
     operator double const &() const { return _value; }
 
     operator double &() { return _value; }
@@ -174,15 +190,17 @@ public:
     }
 
     LogDeterminantRadius &operator=(DeterminantRadius const &other);
+    LogDeterminantRadius &operator=(LogDeterminantRadius const &) = default;
+    LogDeterminantRadius &operator=(LogDeterminantRadius &&) = default;
+
+    /// Conversion between trace and determinant radii requires ellipticity.
+    LogDeterminantRadius &operator=(TraceRadius const &) = delete;
+    /// Conversion between trace and determinant radii requires ellipticity.
+    LogDeterminantRadius &operator=(LogTraceRadius const &) = delete;
 
 private:
     template <typename T1, typename T2>
     friend class Separable;
-
-    /// Undefined and disabled; conversion between trace and determinant radii requires ellipticity.
-    void operator=(TraceRadius const &);
-    /// Undefined and disabled; conversion between trace and determinant radii requires ellipticity.
-    void operator=(LogTraceRadius const &);
 
     void assignFromQuadrupole(double ixx, double iyy, double ixy, Distortion &distortion);
 
@@ -209,6 +227,10 @@ public:
 
     explicit LogTraceRadius(TraceRadius const &other);
 
+    LogTraceRadius(LogTraceRadius const &) = default;
+    LogTraceRadius(LogTraceRadius &&) = default;
+    ~LogTraceRadius() = default;
+
     operator double const &() const { return _value; }
 
     operator double &() { return _value; }
@@ -219,15 +241,17 @@ public:
     }
 
     LogTraceRadius &operator=(TraceRadius const &value);
+    LogTraceRadius &operator=(LogTraceRadius const &) = default;
+    LogTraceRadius &operator=(LogTraceRadius &&) = default;
+
+    /// Conversion between trace and determinant radii requires ellipticity.
+    LogTraceRadius &operator=(DeterminantRadius const &) = delete;
+    /// Conversion between trace and determinant radii requires ellipticity.
+    LogTraceRadius &operator=(LogDeterminantRadius const &) = delete;
 
 private:
     template <typename T1, typename T2>
     friend class Separable;
-
-    /// Undefined and disabled; conversion between trace and determinant radii requires ellipticity.
-    void operator=(DeterminantRadius const &);
-    /// Undefined and disabled; conversion between trace and determinant radii requires ellipticity.
-    void operator=(LogDeterminantRadius const &);
 
     void assignFromQuadrupole(double ixx, double iyy, double ixy, Distortion &distortion);
 

--- a/include/lsst/afw/geom/polygon/Polygon.h
+++ b/include/lsst/afw/geom/polygon/Polygon.h
@@ -67,6 +67,13 @@ public:
      */
     explicit Polygon(Box const& box);
 
+    Polygon(Polygon const&);
+    Polygon(Polygon&&);
+    Polygon& operator=(Polygon const&);
+    Polygon& operator=(Polygon&&);
+
+    virtual ~Polygon();
+
     /**
      * Construct a 4-sided Polygon from a transformed box
      *

--- a/include/lsst/afw/image/ApCorrMap.h
+++ b/include/lsst/afw/image/ApCorrMap.h
@@ -52,6 +52,13 @@ public:
     /// pair<string,std::shared_ptr<BoundedField>>.
     typedef Internal::const_iterator Iterator;
 
+    ApCorrMap() = default;
+    ApCorrMap(ApCorrMap const&) = default;
+    ApCorrMap(ApCorrMap&&) = default;
+    ApCorrMap& operator=(ApCorrMap const&) = default;
+    ApCorrMap& operator=(ApCorrMap&&) = default;
+    virtual ~ApCorrMap() = default;
+
     Iterator begin() const { return _internal.begin(); }
     Iterator end() const { return _internal.end(); }
 

--- a/include/lsst/afw/image/Calib.h
+++ b/include/lsst/afw/image/Calib.h
@@ -116,6 +116,12 @@ public:
      */
     explicit Calib(std::shared_ptr<lsst::daf::base::PropertySet const>);
 
+    Calib(Calib const&);
+    Calib(Calib&&);
+    Calib& operator=(Calib const&);
+    Calib& operator=(Calib&&);
+    virtual ~Calib();
+
     /**
      * Set the flux of a zero-magnitude object
      *

--- a/include/lsst/afw/image/CoaddInputs.h
+++ b/include/lsst/afw/image/CoaddInputs.h
@@ -64,6 +64,12 @@ public:
     /// Construct from shallow copies of the given catalogs.
     CoaddInputs(table::ExposureCatalog const& visits_, table::ExposureCatalog const& ccds_);
 
+    CoaddInputs(CoaddInputs const&);
+    CoaddInputs(CoaddInputs&&);
+    CoaddInputs& operator=(CoaddInputs const&);
+    CoaddInputs& operator=(CoaddInputs&&);
+    virtual ~CoaddInputs();
+
     /**
      *  Whether the object is in fact persistable - in this case, always true.
      *

--- a/include/lsst/afw/image/Color.h
+++ b/include/lsst/afw/image/Color.h
@@ -27,6 +27,12 @@ class Color {
 public:
     explicit Color(double g_r = std::numeric_limits<double>::quiet_NaN()) : _g_r(g_r) {}
 
+    Color(Color const &) = default;
+    Color(Color &&) = default;
+    Color &operator=(Color const &) = default;
+    Color &operator=(Color &&) = default;
+    ~Color() = default;
+
     /// Whether the color is the special value that indicates that it is unspecified.
     bool isIndeterminate() const { return std::isnan(_g_r); }
 

--- a/include/lsst/afw/image/Defect.h
+++ b/include/lsst/afw/image/Defect.h
@@ -43,7 +43,11 @@ public:
     explicit DefectBase(const geom::Box2I& bbox  ///< Bad pixels' bounding box
                         )
             : _bbox(bbox) {}
-    virtual ~DefectBase() {}
+    DefectBase(DefectBase const&) = default;
+    DefectBase(DefectBase&&) = default;
+    DefectBase& operator=(DefectBase const&) = default;
+    DefectBase& operator=(DefectBase&&) = default;
+    virtual ~DefectBase() = default;
 
     geom::Box2I const& getBBox() const { return _bbox; }  ///< Return the Defect's bounding box
     int getX0() const { return _bbox.getMinX(); }         ///< Return the Defect's left column

--- a/include/lsst/afw/image/DistortedTanWcs.h
+++ b/include/lsst/afw/image/DistortedTanWcs.h
@@ -63,7 +63,12 @@ public:
      */
     DistortedTanWcs(TanWcs const &tanWcs, Transform const &pixelsToTanPixels);
 
-    virtual ~DistortedTanWcs(){};
+    DistortedTanWcs(DistortedTanWcs const &);
+    DistortedTanWcs(DistortedTanWcs &&);
+    DistortedTanWcs &operator=(DistortedTanWcs const &) = delete;
+    DistortedTanWcs &operator=(DistortedTanWcs &&) = delete;
+
+    virtual ~DistortedTanWcs() = default;
 
     /// Polymorphic deep-copy.
     virtual std::shared_ptr<Wcs> clone() const;

--- a/include/lsst/afw/image/Exposure.h
+++ b/include/lsst/afw/image/Exposure.h
@@ -165,6 +165,7 @@ public:
      * @param deep Should we copy the pixels?
      */
     Exposure(Exposure const& src, bool const deep = false);
+    Exposure(Exposure&& src);
 
     /** Construct a subExposure given an Exposure and a bounding box
      *
@@ -195,6 +196,9 @@ public:
                               "Exposure's converting copy constructor must make a deep copy");
         }
     }
+
+    Exposure& operator=(Exposure const&);
+    Exposure& operator=(Exposure&&);
 
     /** Destructor
      */

--- a/include/lsst/afw/image/ExposureInfo.h
+++ b/include/lsst/afw/image/ExposureInfo.h
@@ -228,12 +228,14 @@ public:
 
     /// Copy constructor; deep-copies all components except the metadata.
     ExposureInfo(ExposureInfo const& other);
+    ExposureInfo(ExposureInfo&& other);
 
     /// Copy constructor; deep-copies everything, possibly including the metadata.
     ExposureInfo(ExposureInfo const& other, bool copyMetadata);
 
     /// Assignment; deep-copies all components except the metadata.
     ExposureInfo& operator=(ExposureInfo const& other);
+    ExposureInfo& operator=(ExposureInfo&& other);
 
     // Destructor defined in source file because we need access to destructors of forward-declared components
     ~ExposureInfo();

--- a/include/lsst/afw/image/Filter.h
+++ b/include/lsst/afw/image/Filter.h
@@ -75,6 +75,13 @@ public:
      */
     explicit FilterProperty(std::string const& name, lsst::pex::policy::Policy const& pol,
                             bool force = false);
+
+    FilterProperty(FilterProperty const&) = default;
+    FilterProperty(FilterProperty&&) = default;
+    FilterProperty& operator=(FilterProperty const&) = default;
+    FilterProperty& operator=(FilterProperty&&) = default;
+    ~FilterProperty() = default;
+
     /**
      * Return a filter's name
      */
@@ -156,6 +163,12 @@ public:
      * @param force Allow us to construct an unknown Filter
      */
     explicit Filter(std::shared_ptr<lsst::daf::base::PropertySet const>, bool const force = false);
+
+    Filter(Filter const&) = default;
+    Filter(Filter&&) = default;
+    Filter& operator=(Filter const&) = default;
+    Filter& operator=(Filter&&) = default;
+    ~Filter() = default;
 
     /**
      * Are two filters identical?

--- a/include/lsst/afw/image/Image.h
+++ b/include/lsst/afw/image/Image.h
@@ -136,6 +136,7 @@ public:
      * this may not be what you want.  See also assign(rhs) to copy pixels between Image%s
      */
     Image(const Image& rhs, const bool deep = false);
+    Image(Image&& rhs);
 
     /**
      *  Construct an Image by reading a regular FITS file.
@@ -192,7 +193,7 @@ public:
                    geom::Point2I const& xy0 = geom::Point2I())
             : image::ImageBase<PixelT>(array, deep, xy0) {}
 
-    virtual ~Image() {}
+    virtual ~Image() = default;
     //
     // Assignment operators are not inherited
     //
@@ -208,6 +209,7 @@ public:
      * private
      */
     Image& operator=(const Image& rhs);
+    Image& operator=(Image&& rhs);
 
     /**
      *  Write an image to a regular FITS file.

--- a/include/lsst/afw/image/ImageBase.h
+++ b/include/lsst/afw/image/ImageBase.h
@@ -194,6 +194,7 @@ public:
      * this may not be what you want.  See also assign(rhs) to copy pixels between Image%s
      */
     ImageBase(const ImageBase& src, const bool deep = false);
+    ImageBase(ImageBase&& src);
     /**
      * Copy constructor to make a copy of part of an %image.
      *
@@ -241,7 +242,7 @@ public:
      */
     explicit ImageBase(Array const& array, bool deep = false, geom::Point2I const& xy0 = geom::Point2I());
 
-    virtual ~ImageBase() {}
+    virtual ~ImageBase() = default;
     /** Shallow assignment operator.
      *
      * @note that this has the effect of making the lhs share pixels with the rhs which may
@@ -251,6 +252,7 @@ public:
      * declare this function private
      */
     ImageBase& operator=(const ImageBase& rhs);
+    ImageBase& operator=(ImageBase&& rhs);
     /// Set the %image's pixels to rhs
     ImageBase& operator=(const PixelT rhs);
     /**

--- a/include/lsst/afw/image/ImagePca.h
+++ b/include/lsst/afw/image/ImagePca.h
@@ -53,7 +53,12 @@ public:
      * @param constantWeight Should all stars be weighted equally?
      */
     explicit ImagePca(bool constantWeight = true);
-    virtual ~ImagePca() {}
+    virtual ~ImagePca() = default;
+
+    ImagePca(ImagePca const&);
+    ImagePca(ImagePca&&);
+    ImagePca& operator=(ImagePca const&);
+    ImagePca& operator=(ImagePca&&);
 
     /**
      * Add an image to the set to be analyzed

--- a/include/lsst/afw/image/Mask.h
+++ b/include/lsst/afw/image/Mask.h
@@ -227,6 +227,8 @@ public:
      * @param deep deep copy? (construct a view with shared pixels if false)
      */
     Mask(const Mask& src, const bool deep = false);
+    Mask(Mask&& src);
+    ~Mask();
     /**
      * Construct a Mask from a subregion of another Mask
      *
@@ -246,6 +248,7 @@ public:
 
     Mask& operator=(MaskPixelT const rhs);
     Mask& operator=(const Mask& rhs);
+    Mask& operator=(Mask&& rhs);
 
     /// OR a Mask into a Mask
     Mask& operator|=(Mask const& rhs);

--- a/include/lsst/afw/image/MaskedImage.h
+++ b/include/lsst/afw/image/MaskedImage.h
@@ -717,6 +717,8 @@ public:
      * @param deep Make deep copy?
      */
     MaskedImage(MaskedImage const& rhs, bool const deep = false);
+    MaskedImage(MaskedImage&& rhs);
+
     /**
      * Copy constructor of the pixels specified by bbox;  shallow, unless deep is true.
      *
@@ -749,7 +751,6 @@ public:
         _variance = VariancePtr(new Variance(*rhs.getVariance(), deep));
     }
 
-#if defined(DOXYGEN)
     /**
      * Make the lhs use the rhs's pixels
      *
@@ -760,9 +761,9 @@ public:
      * @param rhs Right hand side
      */
     MaskedImage& operator=(MaskedImage const& rhs);
-#endif
+    MaskedImage& operator=(MaskedImage&& rhs);
 
-    virtual ~MaskedImage() {}
+    virtual ~MaskedImage() = default;
 
     void swap(MaskedImage& rhs);
 

--- a/include/lsst/afw/image/PhotoCalib.h
+++ b/include/lsst/afw/image/PhotoCalib.h
@@ -86,6 +86,8 @@ public:
     PhotoCalib &operator=(PhotoCalib const &) = delete;
     PhotoCalib &operator=(PhotoCalib &&) = delete;
 
+    virtual ~PhotoCalib() = default;
+
     /**
      * Create a empty, zeroed calibration.
      */

--- a/include/lsst/afw/image/Pixel.h
+++ b/include/lsst/afw/image/Pixel.h
@@ -166,6 +166,10 @@ public:
     Pixel(SinglePixel<ImagePixelT, MaskPixelT, VariancePixelT>& rhs)
             : _image(rhs._image), _mask(rhs._mask), _variance(rhs._variance) {}
 
+    Pixel(Pixel const& rhs) = default;
+    Pixel(Pixel&& rhs) = default;
+    ~Pixel() = default;
+
     Pixel operator=(Pixel const& rhs) {  // the following template won't stop the compiler trying to generate
                                          // operator=
         _variance = rhs.variance();      // evaluate before we update image()
@@ -187,6 +191,8 @@ public:
 
         return *this;
     }
+    // Delegate to copy-assignment for backwards compatibility
+    Pixel operator=(Pixel&& rhs) { return *this = rhs; }
 
     /// set the image part of a Pixel to rhs_image (the mask and variance are set to 0)
     Pixel operator=(double const& rhs_image) {

--- a/include/lsst/afw/image/TanWcs.h
+++ b/include/lsst/afw/image/TanWcs.h
@@ -106,7 +106,7 @@ public:
            Eigen::MatrixXd const &sipBp, double equinox = 2000, std::string const &raDecSys = "FK5",
            std::string const &cunits1 = "deg", std::string const &cunits2 = "deg");
 
-    virtual ~TanWcs(){};
+    virtual ~TanWcs() = default;
 
     /// Polymorphic deep-copy.
     std::shared_ptr<Wcs> clone() const override;
@@ -160,8 +160,12 @@ public:
     /// Whether the object is persistable using afw::table::io archives.
     bool isPersistable() const override;
 
+    TanWcs &operator=(const TanWcs &) = delete;
+    TanWcs &operator=(TanWcs &&) = delete;
+
 protected:
     TanWcs(TanWcs const &rhs);
+    TanWcs(TanWcs &&rhs);
 
     void pixelToSkyImpl(double pixel1, double pixel2, geom::Angle skyTmp[2]) const override;
     geom::Point2D skyToPixelImpl(geom::Angle sky1, geom::Angle sky2) const override;
@@ -189,8 +193,6 @@ private:
     TanWcs(std::shared_ptr<daf::base::PropertySet const> const &fitsMetadata);
 
     TanWcs(afw::table::BaseRecord const &mainRecord, std::shared_ptr<afw::table::BaseRecord const> sipRecord);
-
-    TanWcs &operator=(const TanWcs &);
 
     // Allow the formatter to access private goo
     LSST_PERSIST_FORMATTER(lsst::afw::formatters::TanWcsFormatter)

--- a/include/lsst/afw/image/VisitInfo.h
+++ b/include/lsst/afw/image/VisitInfo.h
@@ -109,7 +109,7 @@ public:
 
     explicit VisitInfo(daf::base::PropertySet const &metadata);
 
-    ~VisitInfo(){};
+    virtual ~VisitInfo() = default;
 
     VisitInfo(VisitInfo const &) = default;
     VisitInfo(VisitInfo &&) = default;

--- a/include/lsst/afw/image/Wcs.h
+++ b/include/lsst/afw/image/Wcs.h
@@ -391,7 +391,9 @@ protected:
 
     /// Copy constructor
     Wcs(Wcs const& rhs);
+    Wcs(Wcs&& rhs);
     Wcs& operator=(const Wcs&);
+    Wcs& operator=(Wcs&&);
 
     /**
      * Worker routine for pixelToSky

--- a/include/lsst/afw/math/Approximate.h
+++ b/include/lsst/afw/math/Approximate.h
@@ -116,8 +116,13 @@ public:
                                                                   image::MaskedImage<PixelT> const& im,
                                                                   geom::Box2I const& bbox,
                                                                   ApproximateControl const& ctrl);
+    Approximate(Approximate const&) = delete;
+    Approximate(Approximate &&) = delete;
+    Approximate& operator=(Approximate const&) = delete;
+    Approximate& operator=(Approximate &&) = delete;
+
     /// dtor
-    virtual ~Approximate() {}
+    virtual ~Approximate() = default;
     /// Return the approximate %image as a Image
     std::shared_ptr<image::Image<OutPixelT>> getImage(int orderX = -1, int orderY = -1) const {
         return doGetImage(orderX, orderY);
@@ -143,8 +148,6 @@ protected:
     geom::Box2I const _bbox;          ///< Domain for approximation
     ApproximateControl const _ctrl;   ///< desired approximation algorithm
 private:
-    Approximate(Approximate const&);
-    Approximate& operator=(Approximate const&);
     virtual std::shared_ptr<image::Image<OutPixelT>> doGetImage(int orderX, int orderY) const = 0;
     virtual std::shared_ptr<image::MaskedImage<OutPixelT>> doGetMaskedImage(int orderX, int orderY) const = 0;
 };

--- a/include/lsst/afw/math/Background.h
+++ b/include/lsst/afw/math/Background.h
@@ -169,7 +169,12 @@ public:
         }
     }
 
-    virtual ~BackgroundControl() {}
+    BackgroundControl(BackgroundControl const &) = default;
+    BackgroundControl(BackgroundControl &&) = default;
+    BackgroundControl & operator=(BackgroundControl const &) = default;
+    BackgroundControl & operator=(BackgroundControl &&) = default;
+
+    virtual ~BackgroundControl() = default;
     void setNxSample(int nxSample) {
         if (nxSample <= 0) {
             throw LSST_EXCEPT(lsst::pex::exceptions::LengthError,
@@ -261,10 +266,15 @@ protected:
      */
     explicit Background(geom::Box2I const imageBBox, int const nx, int const ny);
     /// dtor
-    virtual ~Background() {}
+    virtual ~Background() = default;
 
 public:
     typedef float InternalPixelT;  ///< type used for any internal images, and returned by getApproximate
+
+    Background(Background const&) = delete;
+    Background(Background &&) = delete;
+    Background& operator=(Background const&) = delete;
+    Background& operator=(Background &&) = delete;
 
     /// Add a constant level to a background
     virtual Background& operator+=(float const delta) = 0;
@@ -402,8 +412,6 @@ protected:
     BOOST_PP_SEQ_FOR_EACH(LSST_makeBackground_getImage, = 0, LSST_makeBackground_getImage_types)
     BOOST_PP_SEQ_FOR_EACH(LSST_makeBackground_getApproximate, = 0, LSST_makeBackground_getApproximate_types)
 private:
-    Background(Background const&);
-    Background& operator=(Background const&);
     /**
      * Compute the centers, origins, and sizes of the patches used to compute image statistics
      * when estimating the Background
@@ -471,6 +479,12 @@ public:
      */
     explicit BackgroundMI(geom::Box2I const imageDimensions,
                           image::MaskedImage<InternalPixelT> const& statsImage);
+
+    BackgroundMI(BackgroundMI const &) = delete;
+    BackgroundMI(BackgroundMI &&) = delete;
+    BackgroundMI & operator=(BackgroundMI const &) = delete;
+    BackgroundMI & operator=(BackgroundMI &&) = delete;
+    ~BackgroundMI() = default;
 
     /**
      * Add a scalar to the Background (equivalent to adding a constant to the original image)

--- a/include/lsst/afw/math/BoundedField.h
+++ b/include/lsst/afw/math/BoundedField.h
@@ -197,7 +197,11 @@ public:
     /// @copydoc operator==
     bool operator!=(BoundedField const& rhs) const { return !(*this == rhs); };
 
-    virtual ~BoundedField() {}
+    virtual ~BoundedField() = default;
+    BoundedField(BoundedField const &) = default;
+    BoundedField(BoundedField &&) = default;
+    BoundedField & operator=(BoundedField const &) = delete;
+    BoundedField & operator=(BoundedField &&) = delete;
 
     friend std::ostream & operator<<(std::ostream & os, BoundedField const & bf)
     { return os << bf.toString() << " on " << bf.getBBox(); }

--- a/include/lsst/afw/math/ChebyshevBoundedField.h
+++ b/include/lsst/afw/math/ChebyshevBoundedField.h
@@ -115,6 +115,12 @@ public:
     ChebyshevBoundedField(afw::geom::Box2I const& bbox,
                           ndarray::Array<double const, 2, 2> const& coefficients);
 
+    ChebyshevBoundedField(ChebyshevBoundedField const &);
+    ChebyshevBoundedField(ChebyshevBoundedField &&);
+    ChebyshevBoundedField & operator=(ChebyshevBoundedField const &) = delete;
+    ChebyshevBoundedField & operator=(ChebyshevBoundedField &&) = delete;
+    ~ChebyshevBoundedField();
+
     /**
      *  Fit a Chebyshev approximation to non-gridded data with equal weights.
      *

--- a/include/lsst/afw/math/Function.h
+++ b/include/lsst/afw/math/Function.h
@@ -100,7 +100,12 @@ public:
               _params(params),
               _isCacheValid(false) {}
 
-    virtual ~Function() {}
+    Function(Function const &) = default;
+    Function(Function &&) = default;
+    Function & operator=(Function const &) = default;
+    Function & operator=(Function &&) = default;
+
+    virtual ~Function() = default;
 
     /**
      * Return the number of function parameters
@@ -220,7 +225,12 @@ public:
     explicit Function1(std::vector<double> const& params)  ///< function parameters
             : Function<ReturnT>(params) {}
 
-    virtual ~Function1() {}
+    Function1(Function1 const &) = default;
+    Function1(Function1 &&) = default;
+    Function1 & operator=(Function1 const &) = default;
+    Function1 & operator=(Function1 &&) = default;
+
+    virtual ~Function1() = default;
 
     /**
      * Return a pointer to a deep copy of this function
@@ -281,7 +291,12 @@ public:
     explicit Function2(std::vector<double> const& params)  ///< function parameters
             : Function<ReturnT>(params) {}
 
-    virtual ~Function2() {}
+    Function2(Function2 const &) = default;
+    Function2(Function2 &&) = default;
+    Function2 & operator=(Function2 const &) = default;
+    Function2 & operator=(Function2 &&) = default;
+
+    virtual ~Function2() = default;
 
     /**
      * Return a pointer to a deep copy of this function
@@ -357,7 +372,12 @@ public:
             : Function2<ReturnT>(params),
               _order(BasePolynomialFunction2::orderFromNParameters(static_cast<int>(params.size()))) {}
 
-    virtual ~BasePolynomialFunction2() {}
+    BasePolynomialFunction2(BasePolynomialFunction2 const &) = default;
+    BasePolynomialFunction2(BasePolynomialFunction2 &&) = default;
+    BasePolynomialFunction2 & operator=(BasePolynomialFunction2 const &) = default;
+    BasePolynomialFunction2 & operator=(BasePolynomialFunction2 &&) = default;
+
+    virtual ~BasePolynomialFunction2() = default;
 
     /**
      * Get the polynomial order

--- a/include/lsst/afw/math/FunctionLibrary.h
+++ b/include/lsst/afw/math/FunctionLibrary.h
@@ -58,7 +58,11 @@ public:
      */
     explicit IntegerDeltaFunction1(double xo) : Function1<ReturnT>(0), _xo(xo) {}
 
-    virtual ~IntegerDeltaFunction1(){};
+    IntegerDeltaFunction1(IntegerDeltaFunction1 const &) = default;
+    IntegerDeltaFunction1(IntegerDeltaFunction1 &&) = default;
+    IntegerDeltaFunction1 & operator=(IntegerDeltaFunction1 const &) = default;
+    IntegerDeltaFunction1 & operator=(IntegerDeltaFunction1 &&) = default;
+    virtual ~IntegerDeltaFunction1() = default;
 
     virtual std::shared_ptr<Function1<ReturnT>> clone() const {
         return std::shared_ptr<Function1<ReturnT>>(new IntegerDeltaFunction1(_xo));
@@ -107,7 +111,11 @@ public:
      */
     explicit IntegerDeltaFunction2(double xo, double yo) : Function2<ReturnT>(0), _xo(xo), _yo(yo) {}
 
-    virtual ~IntegerDeltaFunction2() {}
+    IntegerDeltaFunction2(IntegerDeltaFunction2 const &) = default;
+    IntegerDeltaFunction2(IntegerDeltaFunction2 &&) = default;
+    IntegerDeltaFunction2 & operator=(IntegerDeltaFunction2 const &) = default;
+    IntegerDeltaFunction2 & operator=(IntegerDeltaFunction2 &&) = default;
+    virtual ~IntegerDeltaFunction2() = default;
 
     virtual std::shared_ptr<Function2<ReturnT>> clone() const {
         return std::shared_ptr<Function2<ReturnT>>(new IntegerDeltaFunction2(_xo, _yo));
@@ -163,7 +171,11 @@ public:
               _multFac(1.0 / std::sqrt(lsst::afw::geom::TWOPI)) {
         this->_params[0] = sigma;
     }
-    virtual ~GaussianFunction1() {}
+    GaussianFunction1(GaussianFunction1 const &) = default;
+    GaussianFunction1(GaussianFunction1 &&) = default;
+    GaussianFunction1 & operator=(GaussianFunction1 const &) = default;
+    GaussianFunction1 & operator=(GaussianFunction1 &&) = default;
+    virtual ~GaussianFunction1() = default;
 
     virtual std::shared_ptr<Function1<ReturnT>> clone() const {
         return std::shared_ptr<Function1<ReturnT>>(new GaussianFunction1(this->_params[0]));
@@ -227,7 +239,11 @@ public:
         _updateCache();
     }
 
-    virtual ~GaussianFunction2() {}
+    GaussianFunction2(GaussianFunction2 const &) = default;
+    GaussianFunction2(GaussianFunction2 &&) = default;
+    GaussianFunction2 & operator=(GaussianFunction2 const &) = default;
+    GaussianFunction2 & operator=(GaussianFunction2 &&) = default;
+    virtual ~GaussianFunction2() = default;
 
     virtual std::shared_ptr<Function2<ReturnT>> clone() const {
         return std::shared_ptr<Function2<ReturnT>>(
@@ -338,7 +354,11 @@ public:
         this->_params[2] = ampl2;
     }
 
-    virtual ~DoubleGaussianFunction2() {}
+    DoubleGaussianFunction2(DoubleGaussianFunction2 const &) = default;
+    DoubleGaussianFunction2(DoubleGaussianFunction2 &&) = default;
+    DoubleGaussianFunction2 & operator=(DoubleGaussianFunction2 const &) = default;
+    DoubleGaussianFunction2 & operator=(DoubleGaussianFunction2 &&) = default;
+    virtual ~DoubleGaussianFunction2() = default;
 
     virtual std::shared_ptr<Function2<ReturnT>> clone() const {
         return std::shared_ptr<Function2<ReturnT>>(
@@ -417,7 +437,11 @@ public:
         }
     }
 
-    virtual ~PolynomialFunction1() {}
+    PolynomialFunction1(PolynomialFunction1 const &) = default;
+    PolynomialFunction1(PolynomialFunction1 &&) = default;
+    PolynomialFunction1 & operator=(PolynomialFunction1 const &) = default;
+    PolynomialFunction1 & operator=(PolynomialFunction1 &&) = default;
+    virtual ~PolynomialFunction1() = default;
 
     virtual std::shared_ptr<Function1<ReturnT>> clone() const {
         return std::shared_ptr<Function1<ReturnT>>(new PolynomialFunction1(this->_params));
@@ -504,7 +528,11 @@ public:
               _oldY(0),
               _xCoeffs(this->_order + 1) {}
 
-    virtual ~PolynomialFunction2() {}
+    PolynomialFunction2(PolynomialFunction2 const &) = default;
+    PolynomialFunction2(PolynomialFunction2 &&) = default;
+    PolynomialFunction2 & operator=(PolynomialFunction2 const &) = default;
+    PolynomialFunction2 & operator=(PolynomialFunction2 &&) = default;
+    virtual ~PolynomialFunction2() = default;
 
     virtual std::shared_ptr<Function2<ReturnT>> clone() const {
         return std::shared_ptr<Function2<ReturnT>>(new PolynomialFunction2(this->_params));
@@ -646,7 +674,11 @@ public:
         _initialize(minX, maxX);
     }
 
-    virtual ~Chebyshev1Function1() {}
+    Chebyshev1Function1(Chebyshev1Function1 const &) = default;
+    Chebyshev1Function1(Chebyshev1Function1 &&) = default;
+    Chebyshev1Function1 & operator=(Chebyshev1Function1 const &) = default;
+    Chebyshev1Function1 & operator=(Chebyshev1Function1 &&) = default;
+    virtual ~Chebyshev1Function1() = default;
 
     virtual std::shared_ptr<Function1<ReturnT>> clone() const {
         return std::shared_ptr<Function1<ReturnT>>(new Chebyshev1Function1(this->_params, _minX, _maxX));
@@ -797,7 +829,11 @@ public:
         _initialize(xyRange);
     }
 
-    virtual ~Chebyshev1Function2() {}
+    Chebyshev1Function2(Chebyshev1Function2 const &) = default;
+    Chebyshev1Function2(Chebyshev1Function2 &&) = default;
+    Chebyshev1Function2 & operator=(Chebyshev1Function2 const &) = default;
+    Chebyshev1Function2 & operator=(Chebyshev1Function2 &&) = default;
+    virtual ~Chebyshev1Function2() = default;
 
     virtual std::shared_ptr<Function2<ReturnT>> clone() const {
         return std::shared_ptr<Function2<ReturnT>>(
@@ -994,7 +1030,11 @@ public:
         this->_params[0] = xOffset;
     }
 
-    virtual ~LanczosFunction1() {}
+    LanczosFunction1(LanczosFunction1 const &) = default;
+    LanczosFunction1(LanczosFunction1 &&) = default;
+    LanczosFunction1 & operator=(LanczosFunction1 const &) = default;
+    LanczosFunction1 & operator=(LanczosFunction1 &&) = default;
+    virtual ~LanczosFunction1() = default;
 
     virtual std::shared_ptr<Function1<ReturnT>> clone() const {
         return std::shared_ptr<Function1<ReturnT>>(new LanczosFunction1(this->getOrder(), this->_params[0]));
@@ -1066,7 +1106,11 @@ public:
         this->_params[1] = yOffset;
     }
 
-    virtual ~LanczosFunction2() {}
+    LanczosFunction2(LanczosFunction2 const &) = default;
+    LanczosFunction2(LanczosFunction2 &&) = default;
+    LanczosFunction2 & operator=(LanczosFunction2 const &) = default;
+    LanczosFunction2 & operator=(LanczosFunction2 &&) = default;
+    virtual ~LanczosFunction2() = default;
 
     virtual std::shared_ptr<Function2<ReturnT>> clone() const {
         return std::shared_ptr<Function2<ReturnT>>(

--- a/include/lsst/afw/math/GaussianProcess.h
+++ b/include/lsst/afw/math/GaussianProcess.h
@@ -64,6 +64,12 @@ class GaussianProcessTimer {
 public:
     GaussianProcessTimer();
 
+    GaussianProcessTimer(GaussianProcessTimer const &) = default;
+    GaussianProcessTimer(GaussianProcessTimer &&) = default;
+    GaussianProcessTimer & operator=(GaussianProcessTimer const &) = default;
+    GaussianProcessTimer & operator=(GaussianProcessTimer &&) = default;
+    ~GaussianProcessTimer() = default;
+
     /**
      * Resets all of the data members of GaussianProcessTimer to zero.
      *

--- a/include/lsst/afw/math/Integrate.h
+++ b/include/lsst/afw/math/Integrate.h
@@ -211,6 +211,12 @@ public:
     IntRegion(T const a, T const b, std::ostream *dbgout = 0)
             : _a(a), _b(b), _error(0.0), _area(0), _dbgout(dbgout) {}
 
+    IntRegion(IntRegion const &) = default;
+    IntRegion(IntRegion &&) = default;
+    IntRegion & operator=(IntRegion const &) = default;
+    IntRegion & operator=(IntRegion &&) = default;
+    ~IntRegion() = default;
+
     bool operator<(IntRegion<T> const &r2) const { return _error < r2._error; }
     bool operator>(IntRegion<T> const &r2) const { return _error > r2._error; }
 

--- a/include/lsst/afw/math/Interpolate.h
+++ b/include/lsst/afw/math/Interpolate.h
@@ -51,7 +51,11 @@ public:
                                                         std::vector<double> const &y,
                                                         Interpolate::Style const style);
 
-    virtual ~Interpolate() {}
+    Interpolate(Interpolate const &) = delete;
+    Interpolate(Interpolate &&) = delete;
+    Interpolate &operator=(Interpolate const &) = delete;
+    Interpolate &operator=(Interpolate &&) = delete;
+    virtual ~Interpolate() = default;
     virtual double interpolate(double const x) const = 0;
     std::vector<double> interpolate(std::vector<double> const &x) const;
     ndarray::Array<double, 1> interpolate(ndarray::Array<double const, 1> const &x) const;
@@ -79,10 +83,6 @@ protected:
     std::vector<double> const _x;
     std::vector<double> const _y;
     Interpolate::Style const _style;
-
-private:
-    Interpolate(Interpolate const &);
-    Interpolate &operator=(Interpolate const &);
 };
 
 /**

--- a/include/lsst/afw/math/Kernel.h
+++ b/include/lsst/afw/math/Kernel.h
@@ -169,7 +169,13 @@ public:
      */
     explicit Kernel(int width, int height, const std::vector<SpatialFunctionPtr> spatialFunctionList);
 
-    virtual ~Kernel() {}
+    // prevent copying and assignment (to avoid problems from type slicing)
+    Kernel(const Kernel &) = delete;
+    Kernel(Kernel &&) = delete;
+    Kernel &operator=(const Kernel &) = delete;
+    Kernel &operator=(Kernel &&) = delete;
+
+    virtual ~Kernel() = default;
 
     /**
      * Return a pointer to a deep copy of this kernel
@@ -502,9 +508,6 @@ private:
     int _ctrY;
     unsigned int _nKernelParams;
 
-    // prevent copying and assignment (to avoid problems from type slicing)
-    Kernel(const Kernel &);
-    Kernel &operator=(const Kernel &);
     // Set the Kernel's ideas about the x- and y- coordinates
     virtual void _setKernelXY() {}
 };
@@ -538,7 +541,12 @@ public:
                          lsst::afw::geom::Point2D const &pos     ///< desired position
                          );
 
-    virtual ~FixedKernel() {}
+    FixedKernel(const FixedKernel &) = delete;
+    FixedKernel(FixedKernel &&) = delete;
+    FixedKernel &operator=(const FixedKernel &) = delete;
+    FixedKernel &operator=(FixedKernel &&) = delete;
+
+    virtual ~FixedKernel() = default;
 
     virtual std::shared_ptr<Kernel> clone() const;
 
@@ -626,7 +634,12 @@ public:
     explicit AnalyticKernel(int width, int height, KernelFunction const &kernelFunction,
                             std::vector<Kernel::SpatialFunctionPtr> const &spatialFunctionList);
 
-    virtual ~AnalyticKernel() {}
+    AnalyticKernel(const AnalyticKernel &) = delete;
+    AnalyticKernel(AnalyticKernel &&) = delete;
+    AnalyticKernel &operator=(const AnalyticKernel &) = delete;
+    AnalyticKernel &operator=(AnalyticKernel &&) = delete;
+
+    virtual ~AnalyticKernel() = default;
 
     virtual std::shared_ptr<Kernel> clone() const;
 
@@ -711,7 +724,12 @@ public:
      */
     explicit DeltaFunctionKernel(int width, int height, lsst::afw::geom::Point2I const &point);
 
-    virtual ~DeltaFunctionKernel() {}
+    DeltaFunctionKernel(const DeltaFunctionKernel &) = delete;
+    DeltaFunctionKernel(DeltaFunctionKernel &&) = delete;
+    DeltaFunctionKernel &operator=(const DeltaFunctionKernel &) = delete;
+    DeltaFunctionKernel &operator=(DeltaFunctionKernel &&) = delete;
+
+    virtual ~DeltaFunctionKernel() = default;
 
     virtual std::shared_ptr<Kernel> clone() const;
 
@@ -796,7 +814,12 @@ public:
     explicit LinearCombinationKernel(KernelList const &kernelList,
                                      std::vector<Kernel::SpatialFunctionPtr> const &spatialFunctionList);
 
-    virtual ~LinearCombinationKernel() {}
+    LinearCombinationKernel(const LinearCombinationKernel &) = delete;
+    LinearCombinationKernel(LinearCombinationKernel &&) = delete;
+    LinearCombinationKernel &operator=(const LinearCombinationKernel &) = delete;
+    LinearCombinationKernel &operator=(LinearCombinationKernel &&) = delete;
+
+    virtual ~LinearCombinationKernel() = default;
 
     virtual std::shared_ptr<Kernel> clone() const;
 
@@ -966,7 +989,13 @@ public:
     explicit SeparableKernel(int width, int height, KernelFunction const &kernelColFunction,
                              KernelFunction const &kernelRowFunction,
                              std::vector<Kernel::SpatialFunctionPtr> const &spatialFunctionList);
-    virtual ~SeparableKernel() {}
+
+    SeparableKernel(const SeparableKernel &) = delete;
+    SeparableKernel(SeparableKernel &&) = delete;
+    SeparableKernel &operator=(const SeparableKernel &) = delete;
+    SeparableKernel &operator=(SeparableKernel &&) = delete;
+
+    virtual ~SeparableKernel() = default;
 
     virtual std::shared_ptr<Kernel> clone() const;
 

--- a/include/lsst/afw/math/LeastSquares.h
+++ b/include/lsst/afw/math/LeastSquares.h
@@ -307,6 +307,11 @@ public:
      */
     LeastSquares(Factorization factorization, int dimension);
 
+    LeastSquares(LeastSquares const &);
+    LeastSquares(LeastSquares &&);
+    LeastSquares & operator=(LeastSquares const &);
+    LeastSquares & operator=(LeastSquares &&);
+
     // Need to define dtor in source file so it can see Impl declaration.
     ~LeastSquares();
 

--- a/include/lsst/afw/math/MaskedVector.h
+++ b/include/lsst/afw/math/MaskedVector.h
@@ -44,6 +44,12 @@ public:
             :  //, MaskPlaneDict const& planeDict=MaskPlaneDict()) :
               lsst::afw::image::MaskedImage<EntryT>(geom::Extent2I(width, 1)) {}  //, planeDict) {}
 
+    MaskedVector(MaskedVector const &) = default;
+    MaskedVector(MaskedVector &&) = default;
+    MaskedVector & operator=(MaskedVector const &) = default;
+    MaskedVector & operator=(MaskedVector &&) = default;
+    ~MaskedVector() = default;
+
     // Getters
     /// Return a (Ptr to) the MaskedImage's %image
     std::shared_ptr<std::vector<EntryT> > getVector(bool const noThrow = false) const {

--- a/include/lsst/afw/math/Random.h
+++ b/include/lsst/afw/math/Random.h
@@ -143,7 +143,13 @@ public:
      *      Thrown if memory allocation for internal generator state fails.
      */
     explicit Random(std::shared_ptr<pex::policy::Policy> const policy);
+
     // Use compiler generated destructor and shallow copy constructor/assignment operator
+    Random(Random const &) = default;
+    Random(Random &&) = default;
+    Random & operator=(Random const &) = default;
+    Random & operator=(Random &&) = default;
+    ~Random() = default;
 
     /**
      * Creates a deep copy of this random number generator. Both this random number

--- a/include/lsst/afw/math/SpatialCell.h
+++ b/include/lsst/afw/math/SpatialCell.h
@@ -76,10 +76,15 @@ public:
                          )
             : _id(++_CandidateId), _status(UNKNOWN), _xCenter(xCenter), _yCenter(yCenter) {}
 
+    SpatialCellCandidate(SpatialCellCandidate const &) = default;
+    SpatialCellCandidate(SpatialCellCandidate &&) = default;
+    SpatialCellCandidate & operator=(SpatialCellCandidate const &) = default;
+    SpatialCellCandidate & operator=(SpatialCellCandidate &&) = default;
+
     /**
      * (virtual) destructor -- this is a base class you know
      */
-    virtual ~SpatialCellCandidate() {}
+    virtual ~SpatialCellCandidate() = default;
 
     /// Return the object's column-centre
     float getXCenter() const { return _xCenter; }
@@ -125,7 +130,11 @@ public:
                               float const yCenter   ///< The object's row-centre
                               )
             : SpatialCellCandidate(xCenter, yCenter), _chi2(std::numeric_limits<double>::max()) {}
-    virtual ~SpatialCellImageCandidate() {}
+    SpatialCellImageCandidate(SpatialCellImageCandidate const &) = default;
+    SpatialCellImageCandidate(SpatialCellImageCandidate &&) = default;
+    SpatialCellImageCandidate & operator=(SpatialCellImageCandidate const &) = default;
+    SpatialCellImageCandidate & operator=(SpatialCellImageCandidate &&) = default;
+    virtual ~SpatialCellImageCandidate() = default;
 
     /// Set the width of the image that getImage should return
     static void setWidth(int width) { _width = width; }
@@ -229,10 +238,15 @@ public:
     SpatialCell(std::string const& label, lsst::afw::geom::Box2I const& bbox = lsst::afw::geom::Box2I(),
                 CandidateList const& candidateList = CandidateList());
 
+    SpatialCell(SpatialCell const &) = default;
+    SpatialCell(SpatialCell &&) = default;
+    SpatialCell & operator=(SpatialCell const &) = default;
+    SpatialCell & operator=(SpatialCell &&) = default;
+
     /**
      * Destructor
      */
-    virtual ~SpatialCell() { ; };
+    virtual ~SpatialCell() = default;
 
     /**
      * Determine if cell has no usable candidates
@@ -385,10 +399,15 @@ public:
      */
     SpatialCellSet(lsst::afw::geom::Box2I const& region, int xSize, int ySize = 0);
 
+    SpatialCellSet(SpatialCellSet const &) = default;
+    SpatialCellSet(SpatialCellSet &&) = default;
+    SpatialCellSet & operator=(SpatialCellSet const &) = default;
+    SpatialCellSet & operator=(SpatialCellSet &&) = default;
+
     /**
      * Destructor
      */
-    virtual ~SpatialCellSet() { ; };
+    virtual ~SpatialCellSet() = default;
 
     /**
      * Return our SpatialCells

--- a/include/lsst/afw/math/Statistics.h
+++ b/include/lsst/afw/math/Statistics.h
@@ -245,6 +245,12 @@ public:
     explicit Statistics(ImageT const &img, MaskT const &msk, VarianceT const &var, WeightT const &weights,
                         int const flags, StatisticsControl const &sctrl = StatisticsControl());
 
+    Statistics(Statistics const &) = default;
+    Statistics(Statistics &&) = default;
+    Statistics & operator=(Statistics const &) = default;
+    Statistics & operator=(Statistics &&) = default;
+    ~Statistics() = default;
+
     /** Return the value and error in the specified statistic (e.g. MEAN)
      *
      * @param prop the afw::math::Property to retrieve. If NOTHING (default) and you only asked for

--- a/include/lsst/afw/math/TransformBoundedField.h
+++ b/include/lsst/afw/math/TransformBoundedField.h
@@ -50,7 +50,7 @@ public:
      */
     TransformBoundedField(geom::Box2I const &bbox, Transform const &transform);
 
-    ~TransformBoundedField() {}
+    ~TransformBoundedField() = default;
 
     TransformBoundedField(TransformBoundedField const &) = default;
     TransformBoundedField(TransformBoundedField &&) = default;

--- a/include/lsst/afw/math/detail/PositionFunctor.h
+++ b/include/lsst/afw/math/detail/PositionFunctor.h
@@ -52,8 +52,12 @@ namespace detail {
  */
 class PositionFunctor {
 public:
-    explicit PositionFunctor(){};
-    virtual ~PositionFunctor(){};
+    explicit PositionFunctor() = default;
+    virtual ~PositionFunctor() = default;
+    PositionFunctor(PositionFunctor const &) = default;
+    PositionFunctor(PositionFunctor &&) = default;
+    PositionFunctor & operator=(PositionFunctor const &) = default;
+    PositionFunctor & operator=(PositionFunctor &&) = default;
 
     virtual lsst::afw::geom::Point2D operator()(int destCol, int destRow) const = 0;
 };
@@ -70,7 +74,11 @@ public:
             )
             : PositionFunctor(), _destXY0(destXY0), _xyTransformPtr(XYTransform.clone()) {}
 
-    virtual ~XYTransformPositionFunctor(){};
+    virtual ~XYTransformPositionFunctor() = default;
+    XYTransformPositionFunctor(XYTransformPositionFunctor const &) = default;
+    XYTransformPositionFunctor(XYTransformPositionFunctor &&) = default;
+    XYTransformPositionFunctor & operator=(XYTransformPositionFunctor const &) = default;
+    XYTransformPositionFunctor & operator=(XYTransformPositionFunctor &&) = default;
 
     virtual lsst::afw::geom::Point2D operator()(int destCol, int destRow) const {
         afw::geom::Point2D const destPos{lsst::afw::image::indexToPosition(destCol + _destXY0[0]),

--- a/include/lsst/afw/math/detail/Spline.h
+++ b/include/lsst/afw/math/detail/Spline.h
@@ -13,7 +13,12 @@ namespace detail {
  */
 class Spline {
 public:
-    virtual ~Spline() {}
+    virtual ~Spline() = default;
+
+    Spline(Spline const &) = default;
+    Spline(Spline &&) = default;
+    Spline & operator=(Spline const &) = default;
+    Spline & operator=(Spline &&) = default;
 
     /**
      * Interpolate a Spline.
@@ -41,7 +46,7 @@ public:
     std::vector<double> roots(double const value, double const x0, double const x1) const;
 
 protected:
-    Spline() {}
+    Spline() = default;
     /**
      * Allocate the storage a Spline needs
      */

--- a/include/lsst/afw/math/warpExposure.h
+++ b/include/lsst/afw/math/warpExposure.h
@@ -68,7 +68,12 @@ public:
             : SeparableKernel(2 * order, 2 * order, LanczosFunction1<Kernel::Pixel>(order),
                               LanczosFunction1<Kernel::Pixel>(order)) {}
 
-    virtual ~LanczosWarpingKernel() {}
+    LanczosWarpingKernel(const LanczosWarpingKernel &) = delete;
+    LanczosWarpingKernel(LanczosWarpingKernel &&) = delete;
+    LanczosWarpingKernel &operator=(const LanczosWarpingKernel &) = delete;
+    LanczosWarpingKernel &operator=(LanczosWarpingKernel &&) = delete;
+
+    virtual ~LanczosWarpingKernel() = default;
 
     virtual std::shared_ptr<Kernel> clone() const;
 
@@ -95,7 +100,12 @@ public:
     explicit BilinearWarpingKernel()
             : SeparableKernel(2, 2, BilinearFunction1(0.0), BilinearFunction1(0.0)) {}
 
-    virtual ~BilinearWarpingKernel() {}
+    BilinearWarpingKernel(const BilinearWarpingKernel &) = delete;
+    BilinearWarpingKernel(BilinearWarpingKernel &&) = delete;
+    BilinearWarpingKernel &operator=(const BilinearWarpingKernel &) = delete;
+    BilinearWarpingKernel &operator=(BilinearWarpingKernel &&) = delete;
+
+    virtual ~BilinearWarpingKernel() = default;
 
     virtual std::shared_ptr<Kernel> clone() const;
 
@@ -153,7 +163,12 @@ class NearestWarpingKernel : public SeparableKernel {
 public:
     explicit NearestWarpingKernel() : SeparableKernel(2, 2, NearestFunction1(0.0), NearestFunction1(0.0)) {}
 
-    virtual ~NearestWarpingKernel() {}
+    NearestWarpingKernel(const NearestWarpingKernel &) = delete;
+    NearestWarpingKernel(NearestWarpingKernel &&) = delete;
+    NearestWarpingKernel &operator=(const NearestWarpingKernel &) = delete;
+    NearestWarpingKernel &operator=(NearestWarpingKernel &&) = delete;
+
+    virtual ~NearestWarpingKernel() = default;
 
     virtual std::shared_ptr<Kernel> clone() const;
 

--- a/include/lsst/afw/table/AliasMap.h
+++ b/include/lsst/afw/table/AliasMap.h
@@ -46,6 +46,12 @@ public:
      *  The new AliasMap will not be linked to any tables, even if other is.
      */
     AliasMap(AliasMap const& other) : _internal(other._internal), _table(0) {}
+    // Delegate to copy-constructor for backwards compatibility
+    AliasMap(AliasMap && other) : AliasMap(other) {}
+
+    AliasMap & operator=(AliasMap const &) = default;
+    AliasMap & operator=(AliasMap &&) = default;
+    ~AliasMap() = default;
 
     /// An iterator over alias->target pairs.
     typedef std::map<std::string, std::string>::const_iterator Iterator;

--- a/include/lsst/afw/table/AmpInfo.h
+++ b/include/lsst/afw/table/AmpInfo.h
@@ -83,6 +83,12 @@ public:
     typedef CatalogT<AmpInfoRecord> Catalog;
     typedef CatalogT<AmpInfoRecord const> ConstCatalog;
 
+    AmpInfoRecord(AmpInfoRecord const &) = delete;
+    AmpInfoRecord(AmpInfoRecord &&) = delete;
+    AmpInfoRecord & operator=(AmpInfoRecord const &) = delete;
+    AmpInfoRecord & operator=(AmpInfoRecord &&) = delete;
+    ~AmpInfoRecord();
+
     std::shared_ptr<AmpInfoTable const> getTable() const {
         return std::static_pointer_cast<AmpInfoTable const>(BaseRecord::getTable());
     }
@@ -175,6 +181,10 @@ public:
     static int const MAX_LINEARITY_COEFFS = 4;        // max number of linearity coefficients
     static int const MAX_LINEARITY_TYPE_LENGTH = 64;  // max length for linearity type
 
+    AmpInfoTable & operator=(AmpInfoTable const &) = delete;
+    AmpInfoTable & operator=(AmpInfoTable &&) = delete;
+    ~AmpInfoTable();
+
     /**
      *  Construct a new table.
      *
@@ -265,6 +275,7 @@ protected:
     explicit AmpInfoTable(Schema const &schema);
 
     explicit AmpInfoTable(AmpInfoTable const &other);
+    explicit AmpInfoTable(AmpInfoTable &&other);
 
     std::shared_ptr<BaseTable> _clone() const override;
 

--- a/include/lsst/afw/table/BaseColumnView.h
+++ b/include/lsst/afw/table/BaseColumnView.h
@@ -147,6 +147,11 @@ public:
     static bool isRangeContiguous(std::shared_ptr<BaseTable> const& table, InputIterator first,
                                   InputIterator last);
 
+    BaseColumnView(BaseColumnView const &);
+    BaseColumnView(BaseColumnView &&);
+    BaseColumnView & operator=(BaseColumnView const &);
+    BaseColumnView & operator=(BaseColumnView &&);
+
     ~BaseColumnView();
 
 protected:
@@ -177,6 +182,12 @@ public:
     static ColumnViewT make(std::shared_ptr<Table> const& table, InputIterator first, InputIterator last) {
         return ColumnViewT(BaseColumnView::make(table, first, last));
     }
+
+    ColumnViewT(ColumnViewT const &) = default;
+    ColumnViewT(ColumnViewT &&) = default;
+    ColumnViewT & operator=(ColumnViewT const &) = default;
+    ColumnViewT & operator=(ColumnViewT &&) = default;
+    ~ColumnViewT() = default;
 
 protected:
     explicit ColumnViewT(BaseColumnView const& base) : BaseColumnView(base) {}

--- a/include/lsst/afw/table/BaseTable.h
+++ b/include/lsst/afw/table/BaseTable.h
@@ -154,6 +154,10 @@ public:
      */
     static std::shared_ptr<BaseTable> make(Schema const& schema);
 
+    // Tables are not assignable to prevent type slicing.
+    BaseTable & operator=(BaseTable const& other) = delete;
+    BaseTable & operator=(BaseTable && other) = delete;
+
     virtual ~BaseTable();
 
 protected:
@@ -185,6 +189,8 @@ protected:
             : daf::base::Citizen(other), _schema(other._schema), _metadata(other._metadata) {
         if (_metadata) _metadata = std::static_pointer_cast<daf::base::PropertyList>(_metadata->deepCopy());
     }
+    // Delegate to copy-constructor for backwards compatibility
+    BaseTable(BaseTable && other) : BaseTable(other) {}
 
 private:
     friend class BaseRecord;
@@ -205,10 +211,6 @@ private:
      *  records contiguous as much as possible to allow ColumnView to be used.
      */
     void _destroy(BaseRecord& record);
-
-    // Tables are not assignable to prevent type slicing; this is intentionally not implemented,
-    // so we get linker errors if we do try to use the assignment operator.
-    void operator=(BaseTable const& other);
 
     // Return a writer object that knows how to save in FITS format.  See also FitsWriter.
     virtual std::shared_ptr<io::FitsWriter> makeFitsWriter(fits::Fits* fitsfile, int flags) const;

--- a/include/lsst/afw/table/Catalog.h
+++ b/include/lsst/afw/table/Catalog.h
@@ -146,6 +146,10 @@ public:
 
     /// Shallow copy constructor.
     CatalogT(CatalogT const& other) : _table(other._table), _internal(other._internal) {}
+    // Delegate to copy constructor for backward compatibility
+    CatalogT(CatalogT && other) : CatalogT(other) {}
+
+    ~CatalogT() = default;
 
     /**
      *  Shallow copy constructor from a container containing a related record type.
@@ -165,6 +169,8 @@ public:
         }
         return *this;
     }
+    // Delegate to copy assignment for backward compatibility
+    CatalogT& operator=(CatalogT && other) { return *this = other; }
 
     /**
      *  Return the subset of a catalog corresponding to the True values of the given mask array.

--- a/include/lsst/afw/table/Exposure.h
+++ b/include/lsst/afw/table/Exposure.h
@@ -138,6 +138,12 @@ public:
     }
     //@}
 
+    ExposureRecord(ExposureRecord const &) = delete;
+    ExposureRecord(ExposureRecord &&) = delete;
+    ExposureRecord & operator=(ExposureRecord const &) = delete;
+    ExposureRecord & operator=(ExposureRecord &&) = delete;
+    ~ExposureRecord();
+
 protected:
     explicit ExposureRecord(std::shared_ptr<ExposureTable> const& table);
 
@@ -229,10 +235,15 @@ public:
         return std::static_pointer_cast<ExposureRecord>(BaseTable::copyRecord(other, mapper));
     }
 
+    ExposureTable & operator=(ExposureTable const &) = delete;
+    ExposureTable & operator=(ExposureTable &&) = delete;
+    ~ExposureTable();
+
 protected:
     explicit ExposureTable(Schema const& schema);
 
     ExposureTable(ExposureTable const& other);
+    ExposureTable(ExposureTable && other);
 
     std::shared_ptr<BaseTable> _clone() const override;
 
@@ -315,6 +326,12 @@ public:
      */
     template <typename OtherRecordT>
     ExposureCatalogT(ExposureCatalogT<OtherRecordT> const& other) : Base(other) {}
+
+    ExposureCatalogT(ExposureCatalogT const &) = default;
+    ExposureCatalogT(ExposureCatalogT &&) = default;
+    ExposureCatalogT & operator=(ExposureCatalogT const &) = default;
+    ExposureCatalogT & operator=(ExposureCatalogT &&) = default;
+    ~ExposureCatalogT() = default;
 
     using Base::writeFits;
 

--- a/include/lsst/afw/table/Field.h
+++ b/include/lsst/afw/table/Field.h
@@ -67,6 +67,12 @@ struct Field : public FieldBase<T> {
     Field(std::string const& name, std::string const& doc, FieldBase<T> const& size)
             : FieldBase<T>(size), _name(name), _doc(doc), _units() {}
 
+    Field(Field const &) = default;
+    Field(Field &&) = default;
+    Field & operator=(Field const &) = default;
+    Field & operator=(Field &&) = default;
+    ~Field() = default;
+
     /// Return the name of the field.
     std::string const& getName() const { return _name; }
 

--- a/include/lsst/afw/table/FieldBase.h
+++ b/include/lsst/afw/table/FieldBase.h
@@ -56,11 +56,16 @@ struct FieldBase {
     // Only the first of these constructors is valid for this specializations, but
     // it's convenient to be able to instantiate both, since the other is used
     // by other specializations.
-    FieldBase() {}
+    FieldBase() = default;
     FieldBase(int) {
         throw LSST_EXCEPT(lsst::pex::exceptions::LogicError,
                           "Constructor disabled (this Field type is not sized).");
     }
+    FieldBase(FieldBase const &) = default;
+    FieldBase(FieldBase &&) = default;
+    FieldBase & operator=(FieldBase const &) = default;
+    FieldBase & operator=(FieldBase &&) = default;
+    ~FieldBase() = default;
 
 protected:
     /// Needed to allow Keys to be default-constructed.
@@ -121,6 +126,12 @@ struct FieldBase<Array<U> > {
             throw LSST_EXCEPT(lsst::pex::exceptions::LogicError,
                               "A non-negative size must be provided when constructing an array field.");
     }
+
+    FieldBase(FieldBase const &) = default;
+    FieldBase(FieldBase &&) = default;
+    FieldBase & operator=(FieldBase const &) = default;
+    FieldBase & operator=(FieldBase &&) = default;
+    ~FieldBase() = default;
 
     /// Return a string description of the field type.
     static std::string getTypeString();
@@ -236,6 +247,12 @@ struct FieldBase<std::string> {
      *  ...even though the third argument to the Field constructor takes a FieldBase, not an int.
      */
     FieldBase(int size = -1);
+
+    FieldBase(FieldBase const &) = default;
+    FieldBase(FieldBase &&) = default;
+    FieldBase & operator=(FieldBase const &) = default;
+    FieldBase & operator=(FieldBase &&) = default;
+    ~FieldBase() = default;
 
     /// Return a string description of the field type.
     static std::string getTypeString();

--- a/include/lsst/afw/table/Flag.h
+++ b/include/lsst/afw/table/Flag.h
@@ -41,11 +41,17 @@ struct FieldBase<Flag> {
     // Only the first of these constructors is valid for this specializations, but
     // it's convenient to be able to instantiate both, since the other is used
     // by other specializations.
-    FieldBase() {}
+    FieldBase() = default;
     FieldBase(int) {
         throw LSST_EXCEPT(lsst::pex::exceptions::LogicError,
                           "Constructor disabled (this Field type is not sized).");
     }
+
+    FieldBase(FieldBase const &) = default;
+    FieldBase(FieldBase &&) = default;
+    FieldBase & operator=(FieldBase const &) = default;
+    FieldBase & operator=(FieldBase &&) = default;
+    ~FieldBase() = default;
 
 protected:
     /// Defines how fields are printed.
@@ -62,6 +68,13 @@ public:
 
     /// Return a key corresponding to the integer element where this field's bit is packed.
     Key<FieldBase<Flag>::Element> getStorage() const;
+
+    KeyBase() = default;
+    KeyBase(KeyBase const &) = default;
+    KeyBase(KeyBase &&) = default;
+    KeyBase & operator=(KeyBase const &) = default;
+    KeyBase & operator=(KeyBase &&) = default;
+    ~KeyBase() = default;
 };
 
 /**
@@ -123,6 +136,12 @@ public:
      *  The new field will be invalid until a valid Key is assigned to it.
      */
     Key() : FieldBase<Flag>(), _offset(-1), _bit(0) {}
+
+    Key(Key const &) = default;
+    Key(Key &&) = default;
+    Key & operator=(Key const &) = default;
+    Key & operator=(Key &&) = default;
+    ~Key() = default;
 
     /// Stringification.
     inline friend std::ostream &operator<<(std::ostream &os, Key<Flag> const &key) {

--- a/include/lsst/afw/table/FunctorKey.h
+++ b/include/lsst/afw/table/FunctorKey.h
@@ -41,7 +41,7 @@ class OutputFunctorKey {
 public:
     virtual T get(BaseRecord const& record) const = 0;
 
-    virtual ~OutputFunctorKey() {}
+    virtual ~OutputFunctorKey() = default;
 };
 
 /**
@@ -55,7 +55,7 @@ class InputFunctorKey {
 public:
     virtual void set(BaseRecord& record, T const& value) const = 0;
 
-    virtual ~InputFunctorKey() {}
+    virtual ~InputFunctorKey() = default;
 };
 
 /**
@@ -82,7 +82,7 @@ class ReferenceFunctorKey {
 public:
     virtual T getReference(BaseRecord& record) const = 0;
 
-    virtual ~ReferenceFunctorKey() {}
+    virtual ~ReferenceFunctorKey() = default;
 };
 
 /**
@@ -100,7 +100,7 @@ class ConstReferenceFunctorKey {
 public:
     virtual T getConstReference(BaseRecord const& record) const = 0;
 
-    virtual ~ConstReferenceFunctorKey() {}
+    virtual ~ConstReferenceFunctorKey() = default;
 };
 }
 }

--- a/include/lsst/afw/table/IdFactory.h
+++ b/include/lsst/afw/table/IdFactory.h
@@ -48,11 +48,16 @@ public:
      */
     static std::shared_ptr<IdFactory> makeSource(RecordId expId, int reserved);
 
-    virtual ~IdFactory() {}
+    IdFactory() = default;
+    IdFactory(IdFactory const &) = default;
+    IdFactory(IdFactory &&) = default;
+
+    // Protected to prevent slicing.
+    IdFactory & operator=(IdFactory const& other) = delete;
+    IdFactory & operator=(IdFactory && other) = delete;
+    virtual ~IdFactory() = default;
 
 private:
-    // Protected to prevent slicing.
-    void operator=(IdFactory const& other) {}
 };
 }
 }

--- a/include/lsst/afw/table/Key.h
+++ b/include/lsst/afw/table/Key.h
@@ -95,6 +95,12 @@ public:
      */
     Key() : FieldBase<T>(FieldBase<T>::makeDefault()), _offset(-1) {}
 
+    Key(Key const &) = default;
+    Key(Key &&) = default;
+    Key & operator=(Key const &) = default;
+    Key & operator=(Key &&) = default;
+    ~Key() = default;
+
     /// Stringification.
     inline friend std::ostream& operator<<(std::ostream& os, Key<T> const& key) {
         return os << "Key<" << Key<T>::getTypeString() << ">(offset=" << key.getOffset()

--- a/include/lsst/afw/table/Schema.h
+++ b/include/lsst/afw/table/Schema.h
@@ -280,6 +280,11 @@ public:
 
     /// Copy constructor.
     Schema(Schema const& other);
+    Schema(Schema && other);
+
+    Schema &operator=(Schema const& other);
+    Schema &operator=(Schema && other);
+    ~Schema();
 
     /** Construct from reading a FITS file.
      *

--- a/include/lsst/afw/table/SchemaMapper.h
+++ b/include/lsst/afw/table/SchemaMapper.h
@@ -184,9 +184,13 @@ public:
 
     /// Copy construct (copy-on-write).
     SchemaMapper(SchemaMapper const& other);
+    SchemaMapper(SchemaMapper && other);
 
-    /// Assignement (copy-on-write).
+    /// Assignment (copy-on-write).
     SchemaMapper& operator=(SchemaMapper const& other);
+    SchemaMapper& operator=(SchemaMapper && other);
+
+    ~SchemaMapper();
 
     /**
      *  Combine a sequence of schemas into one, creating a SchemaMapper for each.

--- a/include/lsst/afw/table/Simple.h
+++ b/include/lsst/afw/table/Simple.h
@@ -72,6 +72,12 @@ public:
     void setDec(Angle dec);
     //@}
 
+    SimpleRecord(const SimpleRecord&) = delete;
+    SimpleRecord& operator=(const SimpleRecord&) = delete;
+    SimpleRecord(SimpleRecord&&) = delete;
+    SimpleRecord& operator=(SimpleRecord&&) = delete;
+    ~SimpleRecord();
+
 protected:
     friend class SimpleTable;
 
@@ -174,10 +180,15 @@ public:
         return std::static_pointer_cast<SimpleRecord>(BaseTable::copyRecord(other, mapper));
     }
 
+    SimpleTable& operator=(SimpleTable const&) = delete;
+    SimpleTable& operator=(SimpleTable&&) = delete;
+    ~SimpleTable();
+
 protected:
     SimpleTable(Schema const& schema, std::shared_ptr<IdFactory> const& idFactory);
 
     explicit SimpleTable(SimpleTable const& other);
+    explicit SimpleTable(SimpleTable && other);
 
     std::shared_ptr<BaseTable> _clone() const override;
 

--- a/include/lsst/afw/table/SortedCatalog.h
+++ b/include/lsst/afw/table/SortedCatalog.h
@@ -53,6 +53,12 @@ public:
     using Base::sort;
     using Base::find;
 
+    SortedCatalogT(SortedCatalogT const &) = default;
+    SortedCatalogT(SortedCatalogT &&) = default;
+    SortedCatalogT & operator=(SortedCatalogT const &) = default;
+    SortedCatalogT & operator=(SortedCatalogT &&) = default;
+    ~SortedCatalogT() = default;
+
     /// Return true if the vector is in ascending ID order.
     bool isSorted() const { return this->isSorted(Table::getIdKey()); }
 

--- a/include/lsst/afw/table/Source.h.m4
+++ b/include/lsst/afw/table/Source.h.m4
@@ -228,6 +228,12 @@ public:
     /// Update the coord field using the given Wcs and the image center from the given key.
     void updateCoord(image::Wcs const & wcs, PointKey<double> const & key);
 
+    SourceRecord(const SourceRecord&) = delete;
+    SourceRecord& operator=(const SourceRecord&) = delete;
+    SourceRecord(SourceRecord&&) = delete;
+    SourceRecord& operator=(SourceRecord&&) = delete;
+    ~SourceRecord();
+
 protected:
 
     explicit SourceRecord(std::shared_ptr<SourceTable> const & table);
@@ -328,11 +334,15 @@ public:
     DECLARE_SLOT_DEFINERS(`', `Centroid')
     DECLARE_SLOT_DEFINERS(`', `Shape')
 
+    SourceTable & operator=(SourceTable const &) = delete;
+    SourceTable & operator=(SourceTable &&) = delete;
+
 protected:
 
     SourceTable(Schema const & schema, std::shared_ptr<IdFactory> const & idFactory);
 
     SourceTable(SourceTable const & other);
+    SourceTable(SourceTable && other);
 
     void handleAliasChange(std::string const & alias) override;
 
@@ -400,6 +410,12 @@ public:
     static SourceColumnViewT make(std::shared_ptr<Table> const & table, InputIterator first, InputIterator last) {
         return SourceColumnViewT(BaseColumnView::make(table, first, last));
     }
+
+    SourceColumnViewT(SourceColumnViewT const &) = default;
+    SourceColumnViewT(SourceColumnViewT &&) = default;
+    SourceColumnViewT & operator=(SourceColumnViewT const &) = default;
+    SourceColumnViewT & operator=(SourceColumnViewT &&) = default;
+    ~SourceColumnViewT() = default;
 
 protected:
     explicit SourceColumnViewT(BaseColumnView const & base) : ColumnViewT<RecordT>(base) {}

--- a/include/lsst/afw/table/aggregates.h
+++ b/include/lsst/afw/table/aggregates.h
@@ -70,6 +70,12 @@ public:
     /// Construct from a pair of Keys
     PointKey(Key<T> const& x, Key<T> const& y) : _x(x), _y(y) {}
 
+    PointKey(PointKey const &) = default;
+    PointKey(PointKey &&) = default;
+    PointKey & operator=(PointKey const &) = default;
+    PointKey & operator=(PointKey &&) = default;
+    virtual ~PointKey() = default;
+
     /**
      *  Construct from a subschema, assuming x and y subfields
      *
@@ -224,6 +230,12 @@ public:
      */
     CoordKey(SubSchema const& s) : _ra(s["ra"]), _dec(s["dec"]) {}
 
+    CoordKey(CoordKey const &) = default;
+    CoordKey(CoordKey &&) = default;
+    CoordKey & operator=(CoordKey const &) = default;
+    CoordKey & operator=(CoordKey &&) = default;
+    virtual ~CoordKey() = default;
+
     /// Get an IcrsCoord from the given record
     virtual coord::IcrsCoord get(BaseRecord const& record) const;
 
@@ -297,6 +309,12 @@ public:
      */
     QuadrupoleKey(SubSchema const& s) : _ixx(s["xx"]), _iyy(s["yy"]), _ixy(s["xy"]) {}
 
+    QuadrupoleKey(QuadrupoleKey const &) = default;
+    QuadrupoleKey(QuadrupoleKey &&) = default;
+    QuadrupoleKey & operator=(QuadrupoleKey const &) = default;
+    QuadrupoleKey & operator=(QuadrupoleKey &&) = default;
+    virtual ~QuadrupoleKey() = default;
+
     /// Get a Quadrupole from the given record
     virtual geom::ellipses::Quadrupole get(BaseRecord const& record) const;
 
@@ -360,6 +378,12 @@ public:
      *      EllipseKey k(schema["a"]);
      */
     EllipseKey(SubSchema const& s) : _qKey(s), _pKey(s) {}
+
+    EllipseKey(EllipseKey const &) = default;
+    EllipseKey(EllipseKey &&) = default;
+    EllipseKey & operator=(EllipseKey const &) = default;
+    EllipseKey & operator=(EllipseKey &&) = default;
+    virtual ~EllipseKey() = default;
 
     /// Get an Ellipse from the given record
     virtual geom::ellipses::Ellipse get(BaseRecord const& record) const;
@@ -463,6 +487,12 @@ public:
      *  "x_y_Cov".
      */
     CovarianceMatrixKey(SubSchema const& s, NameArray const& names);
+
+    CovarianceMatrixKey(CovarianceMatrixKey const &);
+    CovarianceMatrixKey(CovarianceMatrixKey &&);
+    CovarianceMatrixKey & operator=(CovarianceMatrixKey const &);
+    CovarianceMatrixKey & operator=(CovarianceMatrixKey &&);
+    virtual ~CovarianceMatrixKey();
 
     /// Get a covariance matrix from the given record
     virtual Eigen::Matrix<T, N, N> get(BaseRecord const& record) const;

--- a/include/lsst/afw/table/arrays.h
+++ b/include/lsst/afw/table/arrays.h
@@ -72,7 +72,7 @@ public:
     static ArrayKey addFields(Schema& schema, std::string const& name, std::string const& doc,
                               std::string const& unit, int size);
 
-    /// Default constructor; instance will not be usuable unless subsequently assigned to.
+    /// Default constructor; instance will not be usable unless subsequently assigned to.
     ArrayKey() : _begin() {}
 
     /// Construct from a vector of scalar Keys
@@ -95,6 +95,12 @@ public:
      *      ArrayKey<T> k(schema["a"]);
      */
     ArrayKey(SubSchema const& s);
+
+    ArrayKey(ArrayKey const &);
+    ArrayKey(ArrayKey &&);
+    ArrayKey & operator=(ArrayKey const &);
+    ArrayKey & operator=(ArrayKey &&);
+    ~ArrayKey();
 
     /// Return the number of elements in the array.
     int getSize() const { return _size; }

--- a/include/lsst/afw/table/io/FitsReader.h
+++ b/include/lsst/afw/table/io/FitsReader.h
@@ -42,6 +42,11 @@ public:
      */
     explicit FitsReader(std::string const& persistedClassName);
 
+    FitsReader(FitsReader const &) = default;
+    FitsReader(FitsReader &&) = default;
+    FitsReader & operator=(FitsReader const &) = default;
+    FitsReader & operator=(FitsReader &&) = default;
+
     /**
      *  Create a new Catalog by reading a FITS binary table.
      *
@@ -132,7 +137,7 @@ public:
      */
     virtual bool usesArchive(int ioFlags) const { return false; }
 
-    virtual ~FitsReader() {}
+    virtual ~FitsReader() = default;
 
 private:
     static FitsReader const* _lookupFitsReader(daf::base::PropertyList const& metadata);

--- a/include/lsst/afw/table/io/FitsSchemaInputMapper.h
+++ b/include/lsst/afw/table/io/FitsSchemaInputMapper.h
@@ -14,7 +14,7 @@ namespace io {
 
 class FitsColumnReader {
 public:
-    FitsColumnReader() {}
+    FitsColumnReader() = default;
 
     // Neither copyable nor moveable.
     FitsColumnReader(FitsColumnReader const &) = delete;
@@ -25,7 +25,7 @@ public:
     virtual void readCell(BaseRecord &record, std::size_t row, fits::Fits &fits,
                           std::shared_ptr<InputArchive> const &archive) const = 0;
 
-    virtual ~FitsColumnReader() {}
+    virtual ~FitsColumnReader() = default;
 };
 
 /**
@@ -66,6 +66,12 @@ public:
 
     /// Construct a mapper from a PropertyList of FITS header values, stripping recognized keys if desired.
     FitsSchemaInputMapper(daf::base::PropertyList &metadata, bool stripMetadata);
+
+    FitsSchemaInputMapper(FitsSchemaInputMapper const &);
+    FitsSchemaInputMapper(FitsSchemaInputMapper &&);
+    FitsSchemaInputMapper & operator=(FitsSchemaInputMapper const &);
+    FitsSchemaInputMapper & operator=(FitsSchemaInputMapper &&);
+    ~FitsSchemaInputMapper();
 
     /**
      *  Set the Archive to an externally-provided one, overriding any that may have been read.

--- a/include/lsst/afw/table/io/FitsWriter.h
+++ b/include/lsst/afw/table/io/FitsWriter.h
@@ -78,6 +78,12 @@ public:
     /// Construct from a wrapped cfitsio pointer.
     explicit FitsWriter(Fits* fits, int flags) : _fits(fits), _flags(flags) {}
 
+    FitsWriter(FitsWriter const &) = default;
+    FitsWriter(FitsWriter &&) = default;
+    FitsWriter & operator=(FitsWriter const &) = default;
+    FitsWriter & operator=(FitsWriter &&) = default;
+    ~FitsWriter() = default;
+
 protected:
     /// Write a table and its schema.
     virtual void _writeTable(std::shared_ptr<BaseTable const> const& table, std::size_t nRows);

--- a/include/lsst/afw/table/io/InputArchive.h
+++ b/include/lsst/afw/table/io/InputArchive.h
@@ -40,9 +40,11 @@ public:
 
     /// Copy-constructor.  Does not deep-copy loaded Persistables.
     InputArchive(InputArchive const& other);
+    InputArchive(InputArchive && other);
 
     /// Assignment.  Does not deep-copy loaded Persistables.
     InputArchive& operator=(InputArchive const& other);
+    InputArchive& operator=(InputArchive && other);
 
     ~InputArchive();
 

--- a/include/lsst/afw/table/io/OutputArchive.h
+++ b/include/lsst/afw/table/io/OutputArchive.h
@@ -40,9 +40,11 @@ public:
 
     /// Copy-construct an OutputArchive.  Saved objects are not deep-copied.
     OutputArchive(OutputArchive const& other);
+    OutputArchive(OutputArchive && other);
 
     /// Assign from another OutputArchive.  Saved objects are not deep-copied.
     OutputArchive& operator=(OutputArchive const& other);
+    OutputArchive& operator=(OutputArchive && other);
 
     // (trivial) destructor must be defined in the source for pimpl idiom.
     ~OutputArchive();

--- a/include/lsst/afw/table/io/Persistable.h
+++ b/include/lsst/afw/table/io/Persistable.h
@@ -101,7 +101,7 @@ public:
     /// Return true if this particular object can be persisted using afw::table::io.
     virtual bool isPersistable() const { return false; }
 
-    virtual ~Persistable() {}
+    virtual ~Persistable() = default;
 
 protected:
     // convenient for derived classes not in afw::table::io
@@ -133,11 +133,13 @@ protected:
      */
     virtual void write(OutputArchiveHandle& handle) const;
 
-    Persistable() {}
+    Persistable() = default;
 
-    Persistable(Persistable const& other) {}
+    Persistable(Persistable const& other) = default;
+    Persistable(Persistable && other) = default;
 
-    void operator=(Persistable const& other) {}
+    Persistable & operator=(Persistable const& other) = default;
+    Persistable & operator=(Persistable && other) = default;
 
 private:
     friend class io::OutputArchive;
@@ -244,7 +246,7 @@ public:
      */
     static PersistableFactory const& lookup(std::string const& name, std::string const& module = "");
 
-    virtual ~PersistableFactory() {}
+    virtual ~PersistableFactory() = default;
 
     // No copying
     PersistableFactory(const PersistableFactory&) = delete;

--- a/include/lsst/afw/table/slots.h
+++ b/include/lsst/afw/table/slots.h
@@ -59,6 +59,12 @@ public:
      */
     std::string getAlias() const { return "slot_" + _name; }
 
+    SlotDefinition(SlotDefinition const &) = default;
+    SlotDefinition(SlotDefinition &&) = default;
+    SlotDefinition & operator=(SlotDefinition const &) = default;
+    SlotDefinition & operator=(SlotDefinition &&) = default;
+    ~SlotDefinition() = default;
+
 protected:
     std::string _name;
 };
@@ -97,6 +103,12 @@ public:
      *  @param[in] schema    Schema to search for Keys.
      */
     void setKeys(std::string const& alias, Schema const& schema);
+
+    FluxSlotDefinition(FluxSlotDefinition const &) = default;
+    FluxSlotDefinition(FluxSlotDefinition &&) = default;
+    FluxSlotDefinition & operator=(FluxSlotDefinition const &) = default;
+    FluxSlotDefinition & operator=(FluxSlotDefinition &&) = default;
+    ~FluxSlotDefinition() = default;
 
 private:
     MeasKey _measKey;
@@ -139,6 +151,12 @@ public:
      */
     void setKeys(std::string const& alias, Schema const& schema);
 
+    CentroidSlotDefinition(CentroidSlotDefinition const &) = default;
+    CentroidSlotDefinition(CentroidSlotDefinition &&) = default;
+    CentroidSlotDefinition & operator=(CentroidSlotDefinition const &) = default;
+    CentroidSlotDefinition & operator=(CentroidSlotDefinition &&) = default;
+    ~CentroidSlotDefinition() = default;
+
 private:
     MeasKey _measKey;
     ErrKey _errKey;
@@ -179,6 +197,12 @@ public:
      *  @param[in] schema    Schema to search for Keys.
      */
     void setKeys(std::string const& alias, Schema const& schema);
+
+    ShapeSlotDefinition(ShapeSlotDefinition const &) = default;
+    ShapeSlotDefinition(ShapeSlotDefinition &&) = default;
+    ShapeSlotDefinition & operator=(ShapeSlotDefinition const &) = default;
+    ShapeSlotDefinition & operator=(ShapeSlotDefinition &&) = default;
+    ~ShapeSlotDefinition() = default;
 
 private:
     MeasKey _measKey;

--- a/src/cameraGeom/Detector.cc
+++ b/src/cameraGeom/Detector.cc
@@ -47,6 +47,9 @@ Detector::Detector(std::string const &name, int id, DetectorType type, std::stri
     _init();
 }
 
+Detector::Detector(Detector const &) = default;
+Detector::Detector(Detector &&) = default;
+
 std::vector<geom::Point2D> Detector::getCorners(CameraSys const &cameraSys) const {
     std::vector<geom::Point2D> fromVec = geom::Box2D(_bbox).getCorners();
     return _transformMap.transform(fromVec, _nativeSys, cameraSys);

--- a/src/cameraGeom/Orientation.cc
+++ b/src/cameraGeom/Orientation.cc
@@ -45,6 +45,12 @@ Orientation::Orientation(geom::Point2D const fpPosition, geom::Point2D const ref
             cosYaw * cosRoll + sinYaw * sinPitch * sinRoll;
 }
 
+Orientation::~Orientation() = default;
+Orientation::Orientation(Orientation const &) = default;
+Orientation::Orientation(Orientation &&) = default;
+Orientation &Orientation::operator=(Orientation const &) = default;
+Orientation &Orientation::operator=(Orientation &&) = default;
+
 int Orientation::getNQuarter() const {
     float yawDeg = _yaw.asDegrees();
     while (yawDeg < 0.) {

--- a/src/cameraGeom/TransformMap.cc
+++ b/src/cameraGeom/TransformMap.cc
@@ -124,6 +124,9 @@ TransformMap::TransformMap(TransformMap const &other) = default;
 // Cannot do any move optimizations without breaking immutability
 TransformMap::TransformMap(TransformMap const &&other) : TransformMap(other) {}
 
+// All resources owned by value or by smart pointer
+TransformMap::~TransformMap() = default;
+
 geom::Point2D TransformMap::transform(geom::Point2D const &point, CameraSys const &fromSys,
                                       CameraSys const &toSys) const {
     auto mapping = _getMapping(fromSys, toSys);

--- a/src/coord/Coord.cc
+++ b/src/coord/Coord.cc
@@ -320,7 +320,13 @@ Coord::Coord(std::string const ra, std::string const dec, double const epoch)
     _verifyValues();
 }
 
+// Don't call _verifyValues() method ... it'll fail
 Coord::Coord() : _longitude(geom::Angle(NaN)), _latitude(geom::Angle(NaN)), _epoch(NaN) {}
+
+Coord::Coord(Coord const &) = default;
+Coord::Coord(Coord &&) = default;
+Coord &Coord::operator=(Coord const &) = default;
+Coord &Coord::operator=(Coord &&) = default;
 
 void Coord::_verifyValues() const {
     if (_latitude.asRadians() < -geom::HALFPI || _latitude.asRadians() > geom::HALFPI) {

--- a/src/coord/Observatory.cc
+++ b/src/coord/Observatory.cc
@@ -44,6 +44,13 @@ Observatory::Observatory(std::string const& longitude, std::string const& latitu
           _longitude(dmsStringToAngle(longitude)),
           _elevation(elevation) {}
 
+Observatory::~Observatory() = default;
+
+Observatory::Observatory(Observatory const&) = default;
+Observatory::Observatory(Observatory&&) = default;
+Observatory& Observatory::operator=(Observatory const&) = default;
+Observatory& Observatory::operator=(Observatory&&) = default;
+
 afw::geom::Angle Observatory::getLongitude() const { return _longitude; }
 
 afw::geom::Angle Observatory::getLatitude() const { return _latitude; }

--- a/src/detection/FootprintMerge.cc
+++ b/src/detection/FootprintMerge.cc
@@ -55,6 +55,12 @@ public:
         _source->setFootprint(newFootprint);
     }
 
+    ~FootprintMerge() = default;
+    FootprintMerge(FootprintMerge const &) = default;
+    FootprintMerge(FootprintMerge &&) = default;
+    FootprintMerge &operator=(FootprintMerge const &) = default;
+    FootprintMerge &operator=(FootprintMerge &&) = default;
+
     /*
      *  Does this Footprint overlap the merged Footprint.
      *
@@ -209,6 +215,12 @@ FootprintMergeList::FootprintMergeList(afw::table::Schema &sourceSchema,
         : _peakSchemaMapper(PeakTable::makeMinimalSchema()) {
     _initialize(sourceSchema, filterList);
 }
+
+FootprintMergeList::~FootprintMergeList() = default;
+FootprintMergeList::FootprintMergeList(FootprintMergeList const &) = default;
+FootprintMergeList::FootprintMergeList(FootprintMergeList &&) = default;
+FootprintMergeList &FootprintMergeList::operator=(FootprintMergeList const &) = default;
+FootprintMergeList &FootprintMergeList::operator=(FootprintMergeList &&) = default;
 
 void FootprintMergeList::_initialize(afw::table::Schema &sourceSchema,
                                      std::vector<std::string> const &filterList) {

--- a/src/detection/FootprintSet.cc
+++ b/src/detection/FootprintSet.cc
@@ -1251,11 +1251,19 @@ FootprintSet::FootprintSet(FootprintSet const &rhs)
     }
 }
 
+// Delegate to copy-constructor for backward-compatibility
+FootprintSet::FootprintSet(FootprintSet &&rhs) : FootprintSet(rhs) {}
+
 FootprintSet &FootprintSet::operator=(FootprintSet const &rhs) {
     FootprintSet tmp(rhs);
     swap(tmp);  // See Meyers, Effective C++, Item 11
     return *this;
 }
+
+// Delegate to copy-assignment for backward-compatibility
+FootprintSet &FootprintSet::operator=(FootprintSet &&rhs) { return *this = rhs; }
+
+FootprintSet::~FootprintSet() = default;
 
 void FootprintSet::merge(FootprintSet const &rhs, int tGrow, int rGrow, bool isotropic) {
     FootprintControl const ctrl(true, isotropic);

--- a/src/detection/GaussianPsf.cc
+++ b/src/detection/GaussianPsf.cc
@@ -103,6 +103,10 @@ GaussianPsf::GaussianPsf(geom::Extent2I const& dimensions, double sigma)
     checkDimensions(_dimensions);
 }
 
+GaussianPsf::GaussianPsf(GaussianPsf const&) = default;
+GaussianPsf::GaussianPsf(GaussianPsf&&) = default;
+GaussianPsf::~GaussianPsf() = default;
+
 std::shared_ptr<afw::detection::Psf> GaussianPsf::clone() const {
     return std::make_shared<GaussianPsf>(_dimensions, _sigma);
 }

--- a/src/detection/Peak.cc
+++ b/src/detection/Peak.cc
@@ -138,6 +138,10 @@ PeakTable::PeakTable(afw::table::Schema const& schema,
 PeakTable::PeakTable(PeakTable const& other)
         : afw::table::BaseTable(other),
           _idFactory(other._idFactory ? other._idFactory->clone() : other._idFactory) {}
+// Delegate to copy-constructor for backwards-compatibility
+PeakTable::PeakTable(PeakTable&& other) : PeakTable(other) {}
+
+PeakTable::~PeakTable() = default;
 
 PeakTable::MinimalSchema::MinimalSchema() {
     id = schema.addField<afw::table::RecordId>("id", "unique ID");

--- a/src/detection/PsfFormatter.cc
+++ b/src/detection/PsfFormatter.cc
@@ -39,7 +39,12 @@ dafPersist::FormatterRegistration PsfFormatter::registration("Psf", typeid(Psf),
 PsfFormatter::PsfFormatter(std::shared_ptr<pexPolicy::Policy> policy)
         : dafPersist::Formatter(typeid(this)), _policy(policy) {}
 
-PsfFormatter::~PsfFormatter(void) {}
+PsfFormatter::PsfFormatter(PsfFormatter const&) = default;
+PsfFormatter::PsfFormatter(PsfFormatter&&) = default;
+PsfFormatter& PsfFormatter::operator=(PsfFormatter const&) = default;
+PsfFormatter& PsfFormatter::operator=(PsfFormatter&&) = default;
+
+PsfFormatter::~PsfFormatter() = default;
 
 void PsfFormatter::write(dafBase::Persistable const* persistable,
                          std::shared_ptr<dafPersist::FormatterStorage> storage,

--- a/src/formatters/DecoratedImageFormatter.cc
+++ b/src/formatters/DecoratedImageFormatter.cc
@@ -104,7 +104,7 @@ DecoratedImageFormatter<ImagePixelT>::DecoratedImageFormatter(std::shared_ptr<ls
         : lsst::daf::persistence::Formatter(typeid(this)) {}
 
 template <typename ImagePixelT>
-DecoratedImageFormatter<ImagePixelT>::~DecoratedImageFormatter(void) {}
+DecoratedImageFormatter<ImagePixelT>::~DecoratedImageFormatter() = default;
 
 template <typename ImagePixelT>
 void DecoratedImageFormatter<ImagePixelT>::write(Persistable const* persistable,

--- a/src/formatters/ExposureFormatter.cc
+++ b/src/formatters/ExposureFormatter.cc
@@ -110,7 +110,7 @@ ExposureFormatter<ImagePixelT, MaskPixelT, VariancePixelT>::ExposureFormatter(
         : daf::persistence::Formatter(typeid(this)), _policy(policy) {}
 
 template <typename ImagePixelT, typename MaskPixelT, typename VariancePixelT>
-ExposureFormatter<ImagePixelT, MaskPixelT, VariancePixelT>::~ExposureFormatter(void) {}
+ExposureFormatter<ImagePixelT, MaskPixelT, VariancePixelT>::~ExposureFormatter() = default;
 
 /**
  * @internal Lookup a filter number in the database to find a filter name.

--- a/src/formatters/ImageFormatter.cc
+++ b/src/formatters/ImageFormatter.cc
@@ -110,7 +110,7 @@ ImageFormatter<ImagePixelT>::ImageFormatter(std::shared_ptr<lsst::pex::policy::P
         : lsst::daf::persistence::Formatter(typeid(this)) {}
 
 template <typename ImagePixelT>
-ImageFormatter<ImagePixelT>::~ImageFormatter(void) {}
+ImageFormatter<ImagePixelT>::~ImageFormatter() = default;
 
 namespace {
 namespace dafBase = lsst::daf::base;

--- a/src/formatters/KernelFormatter.cc
+++ b/src/formatters/KernelFormatter.cc
@@ -129,7 +129,12 @@ dafPersist::FormatterRegistration KernelFormatter::separableKernelRegistration("
 KernelFormatter::KernelFormatter(std::shared_ptr<pexPolicy::Policy> policy)
         : dafPersist::Formatter(typeid(this)), _policy(policy) {}
 
-KernelFormatter::~KernelFormatter(void) {}
+KernelFormatter::KernelFormatter(KernelFormatter const&) = default;
+KernelFormatter::KernelFormatter(KernelFormatter&&) = default;
+KernelFormatter& KernelFormatter::operator=(KernelFormatter const&) = default;
+KernelFormatter& KernelFormatter::operator=(KernelFormatter&&) = default;
+
+KernelFormatter::~KernelFormatter() = default;
 
 void KernelFormatter::write(dafBase::Persistable const* persistable,
                             std::shared_ptr<dafPersist::FormatterStorage> storage,

--- a/src/formatters/MaskFormatter.cc
+++ b/src/formatters/MaskFormatter.cc
@@ -84,7 +84,7 @@ MaskFormatter<MaskPixelT>::MaskFormatter(std::shared_ptr<lsst::pex::policy::Poli
         : lsst::daf::persistence::Formatter(typeid(this)) {}
 
 template <typename MaskPixelT>
-MaskFormatter<MaskPixelT>::~MaskFormatter(void) {}
+MaskFormatter<MaskPixelT>::~MaskFormatter() = default;
 
 template <typename MaskPixelT>
 void MaskFormatter<MaskPixelT>::write(Persistable const* persistable, std::shared_ptr<FormatterStorage> storage,

--- a/src/formatters/MaskedImageFormatter.cc
+++ b/src/formatters/MaskedImageFormatter.cc
@@ -110,7 +110,7 @@ MaskedImageFormatter<ImagePixelT, MaskPixelT, VariancePixelT>::MaskedImageFormat
         : lsst::daf::persistence::Formatter(typeid(this)) {}
 
 template <typename ImagePixelT, typename MaskPixelT, typename VariancePixelT>
-MaskedImageFormatter<ImagePixelT, MaskPixelT, VariancePixelT>::~MaskedImageFormatter(void) {}
+MaskedImageFormatter<ImagePixelT, MaskPixelT, VariancePixelT>::~MaskedImageFormatter() = default;
 
 template <typename ImagePixelT, typename MaskPixelT, typename VariancePixelT>
 void MaskedImageFormatter<ImagePixelT, MaskPixelT, VariancePixelT>::write(

--- a/src/formatters/PropertyListFormatter.cc
+++ b/src/formatters/PropertyListFormatter.cc
@@ -49,6 +49,11 @@ namespace formatters {
 lsst::daf::persistence::FormatterRegistration PropertyListFormatter::registration(
         "PropertyList", typeid(lsst::daf::base::PropertyList), createInstance);
 
+PropertyListFormatter::PropertyListFormatter(PropertyListFormatter const&) = default;
+PropertyListFormatter::PropertyListFormatter(PropertyListFormatter&&) = default;
+PropertyListFormatter& PropertyListFormatter::operator=(PropertyListFormatter const&) = default;
+PropertyListFormatter& PropertyListFormatter::operator=(PropertyListFormatter&&) = default;
+
 PropertyListFormatter::PropertyListFormatter(std::shared_ptr<lsst::pex::policy::Policy>)
         : lsst::daf::persistence::Formatter(typeid(this)) {}
 

--- a/src/formatters/TanWcsFormatter.cc
+++ b/src/formatters/TanWcsFormatter.cc
@@ -70,7 +70,12 @@ dafPersist::FormatterRegistration TanWcsFormatter::registration("TanWcs", typeid
 
 TanWcsFormatter::TanWcsFormatter(std::shared_ptr<pexPolicy::Policy>) : dafPersist::Formatter(typeid(this)) {}
 
-TanWcsFormatter::~TanWcsFormatter(void) {}
+TanWcsFormatter::TanWcsFormatter(TanWcsFormatter const&) = default;
+TanWcsFormatter::TanWcsFormatter(TanWcsFormatter&&) = default;
+TanWcsFormatter& TanWcsFormatter::operator=(TanWcsFormatter const&) = default;
+TanWcsFormatter& TanWcsFormatter::operator=(TanWcsFormatter&&) = default;
+
+TanWcsFormatter::~TanWcsFormatter() = default;
 
 void TanWcsFormatter::write(dafBase::Persistable const* persistable,
                             std::shared_ptr<dafPersist::FormatterStorage> storage,

--- a/src/formatters/WcsFormatter.cc
+++ b/src/formatters/WcsFormatter.cc
@@ -70,7 +70,12 @@ dafPersist::FormatterRegistration WcsFormatter::registration("Wcs", typeid(image
 
 WcsFormatter::WcsFormatter(std::shared_ptr<pexPolicy::Policy>) : dafPersist::Formatter(typeid(this)) {}
 
-WcsFormatter::~WcsFormatter(void) {}
+WcsFormatter::WcsFormatter(WcsFormatter const&) = default;
+WcsFormatter::WcsFormatter(WcsFormatter&&) = default;
+WcsFormatter& WcsFormatter::operator=(WcsFormatter const&) = default;
+WcsFormatter& WcsFormatter::operator=(WcsFormatter&&) = default;
+
+WcsFormatter::~WcsFormatter() = default;
 
 void WcsFormatter::write(dafBase::Persistable const* persistable,
                          std::shared_ptr<dafPersist::FormatterStorage> storage,

--- a/src/geom/AffineXYTransform.cc
+++ b/src/geom/AffineXYTransform.cc
@@ -34,6 +34,12 @@ AffineXYTransform::AffineXYTransform(AffineTransform const &affineTransform)
           _forwardAffineTransform(affineTransform),
           _reverseAffineTransform(_forwardAffineTransform.invert()) {}
 
+AffineXYTransform::AffineXYTransform(AffineXYTransform const &) = default;
+AffineXYTransform::AffineXYTransform(AffineXYTransform &&) = default;
+AffineXYTransform &AffineXYTransform::operator=(AffineXYTransform const &) = default;
+AffineXYTransform &AffineXYTransform::operator=(AffineXYTransform &&) = default;
+AffineXYTransform::~AffineXYTransform() = default;
+
 std::shared_ptr<XYTransform> AffineXYTransform::clone() const {
     return std::make_shared<AffineXYTransform>(_forwardAffineTransform);
 }

--- a/src/geom/Functor.cc
+++ b/src/geom/Functor.cc
@@ -34,6 +34,11 @@ namespace geom {
 
 Functor::Functor(std::string const& name) : daf::base::Citizen(typeid(this)), _name(name) {}
 
+Functor::Functor(Functor const &) = default;
+Functor::Functor(Functor &&) = default;
+Functor &Functor::operator=(Functor const &) = default;
+Functor &Functor::operator=(Functor &&) = default;
+
 double Functor::inverse(double y, double tol, unsigned int maxiter) const {
     // Sanity checks for tol and maxiter.
     if (tol > 1 || tol <= 0) {

--- a/src/geom/IdentityXYTransform.cc
+++ b/src/geom/IdentityXYTransform.cc
@@ -31,6 +31,12 @@ namespace geom {
 
 IdentityXYTransform::IdentityXYTransform() : XYTransform() {}
 
+IdentityXYTransform::IdentityXYTransform(IdentityXYTransform const &) = default;
+IdentityXYTransform::IdentityXYTransform(IdentityXYTransform &&) = default;
+IdentityXYTransform &IdentityXYTransform::operator=(IdentityXYTransform const &) = default;
+IdentityXYTransform &IdentityXYTransform::operator=(IdentityXYTransform &&) = default;
+IdentityXYTransform::~IdentityXYTransform() = default;
+
 std::shared_ptr<XYTransform> IdentityXYTransform::clone() const {
     return std::make_shared<IdentityXYTransform>();
 }

--- a/src/geom/InvertedXYTransform.cc
+++ b/src/geom/InvertedXYTransform.cc
@@ -32,6 +32,12 @@ namespace geom {
 InvertedXYTransform::InvertedXYTransform(std::shared_ptr<XYTransform const> base)
         : XYTransform(), _base(base) {}
 
+InvertedXYTransform::InvertedXYTransform(InvertedXYTransform const &) = default;
+InvertedXYTransform::InvertedXYTransform(InvertedXYTransform &&) = default;
+InvertedXYTransform &InvertedXYTransform::operator=(InvertedXYTransform const &) = default;
+InvertedXYTransform &InvertedXYTransform::operator=(InvertedXYTransform &&) = default;
+InvertedXYTransform::~InvertedXYTransform() = default;
+
 std::shared_ptr<XYTransform> InvertedXYTransform::clone() const {
     // deep copy
     return std::make_shared<InvertedXYTransform>(_base->clone());

--- a/src/geom/LinearFunctor.cc
+++ b/src/geom/LinearFunctor.cc
@@ -32,6 +32,11 @@ namespace geom {
 LinearFunctor::LinearFunctor(double slope, double intercept)
         : Functor("LinearFunctor"), _slope(slope), _intercept(intercept) {}
 
+LinearFunctor::LinearFunctor(LinearFunctor const &) = default;
+LinearFunctor::LinearFunctor(LinearFunctor &&) = default;
+LinearFunctor &LinearFunctor::operator=(LinearFunctor const &) = default;
+LinearFunctor &LinearFunctor::operator=(LinearFunctor &&) = default;
+
 std::shared_ptr<Functor> LinearFunctor::clone() const {
     return std::make_shared<LinearFunctor>(_slope, _intercept);
 }

--- a/src/geom/MultiXYTransform.cc
+++ b/src/geom/MultiXYTransform.cc
@@ -42,6 +42,12 @@ MultiXYTransform::MultiXYTransform(std::vector<std::shared_ptr<XYTransform const
     }
 }
 
+MultiXYTransform::MultiXYTransform(MultiXYTransform const &) = default;
+MultiXYTransform::MultiXYTransform(MultiXYTransform &&) = default;
+MultiXYTransform &MultiXYTransform::operator=(MultiXYTransform const &) = default;
+MultiXYTransform &MultiXYTransform::operator=(MultiXYTransform &&) = default;
+MultiXYTransform::~MultiXYTransform() = default;
+
 std::shared_ptr<XYTransform> MultiXYTransform::clone() const {
     return std::make_shared<MultiXYTransform>(_transformList);
 }

--- a/src/geom/RadialXYTransform.cc
+++ b/src/geom/RadialXYTransform.cc
@@ -53,6 +53,12 @@ RadialXYTransform::RadialXYTransform(std::vector<double> const &coeffs) : XYTran
     _icoeffs = polyInvert(_coeffs);
 }
 
+RadialXYTransform::RadialXYTransform(RadialXYTransform const &) = default;
+RadialXYTransform::RadialXYTransform(RadialXYTransform &&) = default;
+RadialXYTransform &RadialXYTransform::operator=(RadialXYTransform const &) = default;
+RadialXYTransform &RadialXYTransform::operator=(RadialXYTransform &&) = default;
+RadialXYTransform::~RadialXYTransform() = default;
+
 std::shared_ptr<XYTransform> RadialXYTransform::clone() const {
     return std::make_shared<RadialXYTransform>(_coeffs);
 }

--- a/src/geom/SeparableXYTransform.cc
+++ b/src/geom/SeparableXYTransform.cc
@@ -34,6 +34,11 @@ namespace geom {
 SeparableXYTransform::SeparableXYTransform(Functor const& xfunctor, Functor const& yfunctor)
         : XYTransform(), _xfunctor(xfunctor.clone()), _yfunctor(yfunctor.clone()) {}
 
+SeparableXYTransform::SeparableXYTransform(SeparableXYTransform const&) = default;
+SeparableXYTransform::SeparableXYTransform(SeparableXYTransform&&) = default;
+SeparableXYTransform& SeparableXYTransform::operator=(SeparableXYTransform const&) = default;
+SeparableXYTransform& SeparableXYTransform::operator=(SeparableXYTransform&&) = default;
+
 std::shared_ptr<XYTransform> SeparableXYTransform::clone() const {
     return std::make_shared<SeparableXYTransform>(*_xfunctor, *_yfunctor);
 }

--- a/src/geom/SpherePoint.cc
+++ b/src/geom/SpherePoint.cc
@@ -108,6 +108,8 @@ SpherePoint& SpherePoint::operator=(SpherePoint const& other) noexcept = default
 
 SpherePoint& SpherePoint::operator=(SpherePoint&& other) noexcept = default;
 
+SpherePoint::~SpherePoint() = default;
+
 Point3D SpherePoint::getVector() const noexcept {
     return Point3D(cos(_longitude) * cos(_latitude), sin(_longitude) * cos(_latitude), sin(_latitude));
 }

--- a/src/geom/XYTransform.cc
+++ b/src/geom/XYTransform.cc
@@ -31,6 +31,11 @@ namespace geom {
 
 XYTransform::XYTransform() : daf::base::Citizen(typeid(this)) {}
 
+XYTransform::XYTransform(XYTransform const &) = default;
+XYTransform::XYTransform(XYTransform &&) = default;
+XYTransform &XYTransform::operator=(XYTransform const &) = default;
+XYTransform &XYTransform::operator=(XYTransform &&) = default;
+
 AffineTransform XYTransform::linearizeForwardTransform(Point2D const &p) const {
     Point2D px = p + Extent2D(1, 0);
     Point2D py = p + Extent2D(0, 1);

--- a/src/geom/ellipses/BaseCore.cc
+++ b/src/geom/ellipses/BaseCore.cc
@@ -163,6 +163,8 @@ BaseCore& BaseCore::operator=(BaseCore const& other) {
     }
     return *this;
 }
+// Delegate to copy-constructor for backward-compatibility
+BaseCore& BaseCore::operator=(BaseCore&& other) { return *this = other; }
 
 BaseCore::Jacobian BaseCore::dAssign(BaseCore const& other) {
     if (getName() == other.getName()) {

--- a/src/geom/ellipses/Ellipse.cc
+++ b/src/geom/ellipses/Ellipse.cc
@@ -62,6 +62,9 @@ Ellipse& Ellipse::operator=(Ellipse const& other) {
     *_core = other.getCore();
     return *this;
 }
+// Delegate to copy-assignment for backwards compatibility
+Ellipse& Ellipse::operator=(Ellipse&& other) { return *this = other; }
+
 }
 }
 }

--- a/src/geom/ellipses/Separable.cc
+++ b/src/geom/ellipses/Separable.cc
@@ -68,6 +68,12 @@ Separable<Ellipticity_, Radius_>& Separable<Ellipticity_, Radius_>::operator=(
     return *this;
 }
 
+// Delegate to copy-constructor for backwards compatibility
+template <typename Ellipticity_, typename Radius_>
+Separable<Ellipticity_, Radius_>& Separable<Ellipticity_, Radius_>::operator=(
+        Separable<Ellipticity_, Radius_> && other) {
+    return *this = other;
+}
 template <typename Ellipticity_, typename Radius_>
 Separable<Ellipticity_, Radius_>::Separable(double e1, double e2, double radius, bool normalize)
         : _ellipticity(e1, e2), _radius(radius) {

--- a/src/geom/polygon/Polygon.cc
+++ b/src/geom/polygon/Polygon.cc
@@ -269,6 +269,13 @@ std::vector<std::shared_ptr<Polygon>> Polygon::Impl::symDifference(PolyT const& 
     return convertBoostPolygons(boostResult);
 }
 
+Polygon::Polygon(Polygon const&) = default;
+Polygon::Polygon(Polygon&&) = default;
+Polygon& Polygon::operator=(Polygon const&) = default;
+Polygon& Polygon::operator=(Polygon&&) = default;
+
+Polygon::~Polygon() = default;
+
 Polygon::Polygon(Polygon::Box const& box) : _impl(new Polygon::Impl(box)) {}
 
 Polygon::Polygon(std::vector<LsstPoint> const& vertices) : _impl(new Polygon::Impl(vertices)) {}

--- a/src/image/Calib.cc
+++ b/src/image/Calib.cc
@@ -146,6 +146,12 @@ void Calib::setThrowOnNegativeFlux(bool raiseException) { _throwOnNegativeFlux =
 
 bool Calib::getThrowOnNegativeFlux() { return _throwOnNegativeFlux; }
 
+Calib::Calib(Calib const&) = default;
+Calib::Calib(Calib&&) = default;
+Calib& Calib::operator=(Calib const&) = default;
+Calib& Calib::operator=(Calib&&) = default;
+Calib::~Calib() = default;
+
 namespace detail {
 int stripCalibKeywords(std::shared_ptr<lsst::daf::base::PropertySet> metadata) {
     int nstripped = 0;

--- a/src/image/CoaddInputs.cc
+++ b/src/image/CoaddInputs.cc
@@ -57,6 +57,12 @@ CoaddInputs::CoaddInputs(table::Schema const& visitSchema, table::Schema const& 
 CoaddInputs::CoaddInputs(table::ExposureCatalog const& visits_, table::ExposureCatalog const& ccds_)
         : visits(visits_), ccds(ccds_) {}
 
+CoaddInputs::CoaddInputs(CoaddInputs const&) = default;
+CoaddInputs::CoaddInputs(CoaddInputs&&) = default;
+CoaddInputs& CoaddInputs::operator=(CoaddInputs const&) = default;
+CoaddInputs& CoaddInputs::operator=(CoaddInputs&&) = default;
+CoaddInputs::~CoaddInputs() = default;
+
 bool CoaddInputs::isPersistable() const { return true; }
 
 std::string CoaddInputs::getPersistenceName() const { return "CoaddInputs"; }

--- a/src/image/DistortedTanWcs.cc
+++ b/src/image/DistortedTanWcs.cc
@@ -35,6 +35,9 @@ DistortedTanWcs::DistortedTanWcs(TanWcs const &tanWcs, Transform const &pixelsTo
     }
 }
 
+DistortedTanWcs::DistortedTanWcs(DistortedTanWcs const &) = default;
+DistortedTanWcs::DistortedTanWcs(DistortedTanWcs &&) = default;
+
 std::shared_ptr<Wcs> DistortedTanWcs::clone() const {
     return std::shared_ptr<Wcs>(new DistortedTanWcs(*this));
 }

--- a/src/image/Exposure.cc
+++ b/src/image/Exposure.cc
@@ -74,6 +74,9 @@ Exposure<ImageT, MaskT, VarianceT>::Exposure(Exposure const &src, bool const dee
         : daf::base::Citizen(typeid(this)),
           _maskedImage(src.getMaskedImage(), deep),
           _info(new ExposureInfo(*src.getInfo(), deep)) {}
+// Delegate to copy-constructor for backwards compatibility
+template <typename ImageT, typename MaskT, typename VarianceT>
+Exposure<ImageT, MaskT, VarianceT>::Exposure(Exposure &&src) : Exposure(src) {}
 
 template <typename ImageT, typename MaskT, typename VarianceT>
 Exposure<ImageT, MaskT, VarianceT>::Exposure(Exposure const &src, geom::Box2I const &bbox,
@@ -115,7 +118,7 @@ void Exposure<ImageT, MaskT, VarianceT>::_readFits(fits::Fits &fitsfile, geom::B
 }
 
 template <typename ImageT, typename MaskT, typename VarianceT>
-Exposure<ImageT, MaskT, VarianceT>::~Exposure() {}
+Exposure<ImageT, MaskT, VarianceT>::~Exposure() = default;
 
 // SET METHODS
 
@@ -131,6 +134,11 @@ void Exposure<ImageT, MaskT, VarianceT>::setXY0(geom::Point2I const &origin) {
         _info->getWcs()->shiftReferencePixel(origin.getX() - old.getX(), origin.getY() - old.getY());
     _maskedImage.setXY0(origin);
 }
+
+template <typename ImageT, typename MaskT, typename VarianceT>
+Exposure<ImageT, MaskT, VarianceT> &Exposure<ImageT, MaskT, VarianceT>::operator=(Exposure const &) = default;
+template <typename ImageT, typename MaskT, typename VarianceT>
+Exposure<ImageT, MaskT, VarianceT> &Exposure<ImageT, MaskT, VarianceT>::operator=(Exposure &&) = default;
 
 // Write FITS
 

--- a/src/image/ExposureInfo.cc
+++ b/src/image/ExposureInfo.cc
@@ -111,6 +111,9 @@ ExposureInfo::ExposureInfo(ExposureInfo const& other)
           _visitInfo(other._visitInfo),
           _transmissionCurve(other._transmissionCurve) {}
 
+// Delegate to copy-constructor for backwards compatibility
+ExposureInfo::ExposureInfo(ExposureInfo&& other) : ExposureInfo(other) {}
+
 ExposureInfo::ExposureInfo(ExposureInfo const& other, bool copyMetadata)
         : _wcs(_cloneWcs(other._wcs)),
           _psf(other._psf),
@@ -142,10 +145,12 @@ ExposureInfo& ExposureInfo::operator=(ExposureInfo const& other) {
     }
     return *this;
 }
+// Delegate to copy-assignment for backwards compatibility
+ExposureInfo& ExposureInfo::operator=(ExposureInfo&& other) { return *this = other; }
 
 void ExposureInfo::initApCorrMap() { _apCorrMap = std::make_shared<ApCorrMap>(); }
 
-ExposureInfo::~ExposureInfo() {}
+ExposureInfo::~ExposureInfo() = default;
 
 ExposureInfo::FitsWriteData ExposureInfo::_startWriteFits(afw::geom::Point2I const& xy0) const {
     FitsWriteData data;

--- a/src/image/Image.cc
+++ b/src/image/Image.cc
@@ -111,6 +111,9 @@ ImageBase<PixelT>::ImageBase(ImageBase const& rhs, bool const deep
         swap(tmp);
     }
 }
+// Delegate to copy-constructor for backwards compatibility
+template <typename PixelT>
+ImageBase<PixelT>::ImageBase(ImageBase&& rhs) : ImageBase(rhs, false) {}
 
 template <typename PixelT>
 ImageBase<PixelT>::ImageBase(ImageBase const& rhs, geom::Box2I const& bbox, ImageOrigin const origin,
@@ -148,6 +151,11 @@ ImageBase<PixelT>& ImageBase<PixelT>::operator=(ImageBase const& rhs) {
     swap(tmp);  // See Meyers, Effective C++, Item 11
 
     return *this;
+}
+// Delegate to copy-assignment for backwards compatibility
+template <typename PixelT>
+ImageBase<PixelT>& ImageBase<PixelT>::operator=(ImageBase&& rhs) {
+    return *this = rhs;
 }
 
 template <typename PixelT>
@@ -308,6 +316,9 @@ Image<PixelT>::Image(geom::Box2I const& bbox, PixelT initialValue) : ImageBase<P
 
 template <typename PixelT>
 Image<PixelT>::Image(Image const& rhs, bool const deep) : ImageBase<PixelT>(rhs, deep) {}
+// Delegate to copy-constructor for backwards compatibility
+template <typename PixelT>
+Image<PixelT>::Image(Image&& rhs) : Image(rhs, false) {}
 
 template <typename PixelT>
 Image<PixelT>::Image(Image const& rhs, geom::Box2I const& bbox, ImageOrigin const origin, bool const deep
@@ -327,6 +338,11 @@ Image<PixelT>& Image<PixelT>::operator=(Image const& rhs) {
     this->ImageBase<PixelT>::operator=(rhs);
 
     return *this;
+}
+// Delegate to copy-assignment for backwards compatibility
+template <typename PixelT>
+Image<PixelT>& Image<PixelT>::operator=(Image&& rhs) {
+    return *this = rhs;
 }
 
 #ifndef DOXYGEN  // doc for this section has been moved to header

--- a/src/image/ImagePca.cc
+++ b/src/image/ImagePca.cc
@@ -53,6 +53,15 @@ ImagePca<ImageT>::ImagePca(bool constantWeight)
           _eigenImages(ImageList()) {}
 
 template <typename ImageT>
+ImagePca<ImageT>::ImagePca(ImagePca const&) = default;
+template <typename ImageT>
+ImagePca<ImageT>::ImagePca(ImagePca&&) = default;
+template <typename ImageT>
+ImagePca<ImageT>& ImagePca<ImageT>::operator=(ImagePca const&) = default;
+template <typename ImageT>
+ImagePca<ImageT>& ImagePca<ImageT>::operator=(ImagePca&&) = default;
+
+template <typename ImageT>
 void ImagePca<ImageT>::addImage(std::shared_ptr<ImageT> img, double flux) {
     if (_imageList.empty()) {
         _dimensions = img->getDimensions();

--- a/src/image/Mask.cc
+++ b/src/image/Mask.cc
@@ -402,6 +402,12 @@ Mask<MaskPixelT>::Mask(Mask const& rhs, afwGeom::Box2I const& bbox, ImageOrigin 
 template <typename MaskPixelT>
 Mask<MaskPixelT>::Mask(Mask const& rhs, bool deep)
         : ImageBase<MaskPixelT>(rhs, deep), _maskDict(rhs._maskDict) {}
+// Delegate to copy-constructor for backwards compatibility
+template <typename MaskPixelT>
+Mask<MaskPixelT>::Mask(Mask&& rhs) : Mask(rhs, false) {}
+
+template <typename MaskPixelT>
+Mask<MaskPixelT>::~Mask() = default;
 
 template <typename MaskPixelT>
 Mask<MaskPixelT>::Mask(ndarray::Array<MaskPixelT, 2, 1> const& array, bool deep, geom::Point2I const& xy0)
@@ -426,6 +432,11 @@ Mask<MaskPixelT>& Mask<MaskPixelT>::operator=(const Mask<MaskPixelT>& rhs) {
     swap(tmp);  // See Meyers, Effective C++, Item 11
 
     return *this;
+}
+// Delegate to copy-assignment for backwards compatibility
+template <typename MaskPixelT>
+Mask<MaskPixelT>& Mask<MaskPixelT>::operator=(Mask<MaskPixelT>&& rhs) {
+    return *this = rhs;
 }
 
 template <typename MaskPixelT>

--- a/src/image/MaskedImage.cc
+++ b/src/image/MaskedImage.cc
@@ -240,6 +240,11 @@ MaskedImage<ImagePixelT, MaskPixelT, VariancePixelT>::MaskedImage(MaskedImage co
     conformSizes();
 }
 
+// Delegate to copy-constructor for backwards compatibility
+template <typename ImagePixelT, typename MaskPixelT, typename VariancePixelT>
+MaskedImage<ImagePixelT, MaskPixelT, VariancePixelT>::MaskedImage(MaskedImage&& rhs)
+        : MaskedImage(rhs, false) {}
+
 template <typename ImagePixelT, typename MaskPixelT, typename VariancePixelT>
 MaskedImage<ImagePixelT, MaskPixelT, VariancePixelT>::MaskedImage(MaskedImage const& rhs,
                                                                   const geom::Box2I& bbox,
@@ -254,11 +259,13 @@ MaskedImage<ImagePixelT, MaskPixelT, VariancePixelT>::MaskedImage(MaskedImage co
     conformSizes();
 }
 
-#if defined(DOXYGEN)
 template <typename ImagePixelT, typename MaskPixelT, typename VariancePixelT>
 MaskedImage<ImagePixelT, MaskPixelT, VariancePixelT>& MaskedImage<ImagePixelT, MaskPixelT, VariancePixelT>::
-operator=(MaskedImage const& rhs) {}
-#endif
+operator=(MaskedImage const& rhs) = default;
+
+template <typename ImagePixelT, typename MaskPixelT, typename VariancePixelT>
+MaskedImage<ImagePixelT, MaskPixelT, VariancePixelT>& MaskedImage<ImagePixelT, MaskPixelT, VariancePixelT>::
+operator=(MaskedImage&& rhs) = default;
 
 template <typename ImagePixelT, typename MaskPixelT, typename VariancePixelT>
 void MaskedImage<ImagePixelT, MaskPixelT, VariancePixelT>::swap(MaskedImage& rhs) {
@@ -268,8 +275,6 @@ void MaskedImage<ImagePixelT, MaskPixelT, VariancePixelT>::swap(MaskedImage& rhs
     _mask.swap(rhs._mask);
     _variance.swap(rhs._variance);
 }
-// Use compiler generated version of:
-//    MaskedImage<ImagePixelT, MaskPixelT> &operator=(const MaskedImage<ImagePixelT, MaskPixelT>& rhs);
 
 // Operators
 template <typename ImagePixelT, typename MaskPixelT, typename VariancePixelT>

--- a/src/image/TanWcs.cc
+++ b/src/image/TanWcs.cc
@@ -232,6 +232,8 @@ TanWcs::TanWcs(TanWcs const& rhs)
           _sipB(rhs._sipB),
           _sipAp(rhs._sipAp),
           _sipBp(rhs._sipBp) {}
+// Delegate to copy-constructor for backwards compatibility
+TanWcs::TanWcs(TanWcs&& rhs) : TanWcs(rhs) {}
 
 bool TanWcs::_isSubset(Wcs const& rhs) const {
     if (!Wcs::_isSubset(rhs)) {

--- a/src/image/Wcs.cc
+++ b/src/image/Wcs.cc
@@ -459,6 +459,11 @@ Wcs::Wcs(Wcs const& rhs)
     }
     _initWcs();
 }
+// Delegate to copy-constructor for backwards compatibility
+Wcs::Wcs(Wcs&& rhs) : Wcs(rhs) {}
+
+Wcs& Wcs::operator=(const Wcs&) = default;
+Wcs& Wcs::operator=(Wcs&&) = default;
 
 bool Wcs::operator==(Wcs const& other) const {
     if (&other == this) return true;

--- a/src/math/ChebyshevBoundedField.cc
+++ b/src/math/ChebyshevBoundedField.cc
@@ -61,6 +61,10 @@ ChebyshevBoundedField::ChebyshevBoundedField(afw::geom::Box2I const& bbox,
 ChebyshevBoundedField::ChebyshevBoundedField(afw::geom::Box2I const& bbox)
         : BoundedField(bbox), _toChebyshevRange(makeChebyshevRangeTransform(geom::Box2D(bbox))) {}
 
+ChebyshevBoundedField::ChebyshevBoundedField(ChebyshevBoundedField const &) = default;
+ChebyshevBoundedField::ChebyshevBoundedField(ChebyshevBoundedField &&) = default;
+ChebyshevBoundedField::~ChebyshevBoundedField() = default;
+
 // ------------------ fit() and helpers ---------------------------------------------------------------------
 
 namespace {

--- a/src/math/GaussianProcess.cc
+++ b/src/math/GaussianProcess.cc
@@ -1983,7 +1983,7 @@ GaussianProcessTimer &GaussianProcess<T>::getTimes() const {
 }
 
 template <typename T>
-Covariogram<T>::~Covariogram(){};
+Covariogram<T>::~Covariogram() = default;
 
 template <typename T>
 T Covariogram<T>::operator()(ndarray::Array<const T, 1, 1> const &p1,
@@ -1994,7 +1994,7 @@ T Covariogram<T>::operator()(ndarray::Array<const T, 1, 1> const &p1,
 }
 
 template <typename T>
-SquaredExpCovariogram<T>::~SquaredExpCovariogram() {}
+SquaredExpCovariogram<T>::~SquaredExpCovariogram() = default;
 
 template <typename T>
 SquaredExpCovariogram<T>::SquaredExpCovariogram() {
@@ -2019,7 +2019,7 @@ T SquaredExpCovariogram<T>::operator()(ndarray::Array<const T, 1, 1> const &p1,
 }
 
 template <typename T>
-NeuralNetCovariogram<T>::~NeuralNetCovariogram() {}
+NeuralNetCovariogram<T>::~NeuralNetCovariogram() = default;
 
 template <typename T>
 NeuralNetCovariogram<T>::NeuralNetCovariogram() {

--- a/src/math/LeastSquares.cc
+++ b/src/math/LeastSquares.cc
@@ -360,7 +360,12 @@ LeastSquares::LeastSquares(Factorization factorization, int dimension) {
     _impl->factorization = factorization;
 }
 
-LeastSquares::~LeastSquares() {}
+LeastSquares::LeastSquares(LeastSquares const &) = default;
+LeastSquares::LeastSquares(LeastSquares &&) = default;
+LeastSquares & LeastSquares::operator=(LeastSquares const &) = default;
+LeastSquares & LeastSquares::operator=(LeastSquares &&) = default;
+
+LeastSquares::~LeastSquares() = default;
 
 Eigen::MatrixXd& LeastSquares::_getDesignMatrix() { return _impl->design; }
 Eigen::VectorXd& LeastSquares::_getDataVector() { return _impl->data; }

--- a/src/math/minimize.cc
+++ b/src/math/minimize.cc
@@ -53,7 +53,11 @@ public:
                                     std::vector<double> const &measurementList,
                                     std::vector<double> const &varianceList,
                                     std::vector<double> const &xPositionList, double errorDef);
-    virtual ~MinimizerFunctionBase1(){};
+    MinimizerFunctionBase1(MinimizerFunctionBase1 const &) = default;
+    MinimizerFunctionBase1(MinimizerFunctionBase1 &&) = default;
+    MinimizerFunctionBase1 & operator=(MinimizerFunctionBase1 const &) = default;
+    MinimizerFunctionBase1 & operator=(MinimizerFunctionBase1 &&) = default;
+    virtual ~MinimizerFunctionBase1() = default;
     // Required by ROOT::Minuit2::FCNBase
     virtual double Up() const { return _errorDef; }
     virtual double operator()(const std::vector<double> &) const;
@@ -83,7 +87,11 @@ public:
                                     std::vector<double> const &varianceList,
                                     std::vector<double> const &xPositionList,
                                     std::vector<double> const &yPositionList, double errorDef);
-    virtual ~MinimizerFunctionBase2(){};
+    MinimizerFunctionBase2(MinimizerFunctionBase2 const &) = default;
+    MinimizerFunctionBase2(MinimizerFunctionBase2 &&) = default;
+    MinimizerFunctionBase2 & operator=(MinimizerFunctionBase2 const &) = default;
+    MinimizerFunctionBase2 & operator=(MinimizerFunctionBase2 &&) = default;
+    virtual ~MinimizerFunctionBase2() = default;
     // Required by ROOT::Minuit2::FCNBase
     virtual double Up() const { return _errorDef; }
     virtual double operator()(const std::vector<double> &par) const;

--- a/src/table/AmpInfo.cc
+++ b/src/table/AmpInfo.cc
@@ -70,6 +70,8 @@ static AmpInfoFitsReader const ampInfoFitsReader;
 
 AmpInfoRecord::AmpInfoRecord(std::shared_ptr<AmpInfoTable> const &table) : BaseRecord(table) {}
 
+AmpInfoRecord::~AmpInfoRecord() = default;
+
 std::shared_ptr<AmpInfoTable> AmpInfoTable::make(Schema const &schema) {
     if (!checkSchema(schema)) {
         throw LSST_EXCEPT(
@@ -82,6 +84,10 @@ std::shared_ptr<AmpInfoTable> AmpInfoTable::make(Schema const &schema) {
 AmpInfoTable::AmpInfoTable(Schema const &schema) : BaseTable(schema) {}
 
 AmpInfoTable::AmpInfoTable(AmpInfoTable const &other) : BaseTable(other) {}
+// Delegate to copy-constructor for backwards compatibility
+AmpInfoTable::AmpInfoTable(AmpInfoTable &&other) : AmpInfoTable(other) {}
+
+AmpInfoTable::~AmpInfoTable() = default;
 
 AmpInfoTable::MinimalSchema::MinimalSchema() {
     name = schema.addField<std::string>("name", "name of amplifier location in camera",

--- a/src/table/BaseColumnView.cc
+++ b/src/table/BaseColumnView.cc
@@ -147,8 +147,13 @@ BitsColumn BaseColumnView::getAllBits() const {
     return result;
 }
 
+BaseColumnView::BaseColumnView(BaseColumnView const &) = default;
+BaseColumnView::BaseColumnView(BaseColumnView &&) = default;
+BaseColumnView & BaseColumnView::operator=(BaseColumnView const &) = default;
+BaseColumnView & BaseColumnView::operator=(BaseColumnView &&) = default;
+
 // needs to be in source file so it can (implicitly) call Impl's (implicit) dtor
-BaseColumnView::~BaseColumnView() {}
+BaseColumnView::~BaseColumnView() = default;
 
 BaseColumnView::BaseColumnView(std::shared_ptr<BaseTable> const &table, int recordCount, void *buf,
                                ndarray::Manager::Ptr const &manager)

--- a/src/table/Exposure.cc
+++ b/src/table/Exposure.cc
@@ -350,6 +350,8 @@ bool ExposureRecord::contains(geom::Point2D const &point, image::Wcs const &wcs,
 
 ExposureRecord::ExposureRecord(std::shared_ptr<ExposureTable> const &table) : BaseRecord(table) {}
 
+ExposureRecord::~ExposureRecord() = default;
+
 void ExposureRecord::_assign(BaseRecord const &other) {
     try {
         ExposureRecord const &s = dynamic_cast<ExposureRecord const &>(other);
@@ -376,6 +378,10 @@ std::shared_ptr<ExposureTable> ExposureTable::make(Schema const &schema) {
 ExposureTable::ExposureTable(Schema const &schema) : BaseTable(schema) {}
 
 ExposureTable::ExposureTable(ExposureTable const &other) : BaseTable(other) {}
+// Delegate to copy-constructor for backward compatibility
+ExposureTable::ExposureTable(ExposureTable &&other) : ExposureTable(other) {}
+
+ExposureTable::~ExposureTable() = default;
 
 ExposureTable::MinimalSchema::MinimalSchema() {
     id = schema.addField<RecordId>("id", "unique ID");

--- a/src/table/Schema.cc
+++ b/src/table/Schema.cc
@@ -607,6 +607,12 @@ int const Schema::VERSION;
 Schema::Schema() : _impl(std::make_shared<Impl>()), _aliases(std::make_shared<AliasMap>()) {}
 
 Schema::Schema(Schema const &other) : _impl(other._impl), _aliases(other._aliases) {}
+// Delegate to copy constructor  for backwards compatibility
+Schema::Schema(Schema &&other) : Schema(other) {}
+
+Schema &Schema::operator=(Schema const&) = default;
+Schema &Schema::operator=(Schema&&) = default;
+Schema::~Schema() = default;
 
 Schema Schema::readFits(std::string const &filename, int hdu) {
     fits::Fits fp{filename, "r", fits::Fits::AUTO_CLOSE | fits::Fits::AUTO_CHECK};

--- a/src/table/SchemaMapper.cc
+++ b/src/table/SchemaMapper.cc
@@ -112,6 +112,8 @@ struct RemoveMinimalSchema {
 SchemaMapper::SchemaMapper() : _impl(new Impl(Schema(), Schema())) {}
 
 SchemaMapper::SchemaMapper(SchemaMapper const &other) : _impl(new Impl(*other._impl)) {}
+// Delegate to copy constructor for backwards compatibility
+SchemaMapper::SchemaMapper(SchemaMapper && other) : SchemaMapper(other) {}
 
 SchemaMapper::SchemaMapper(Schema const &input, Schema const &output) : _impl(new Impl(input, output)) {}
 
@@ -126,6 +128,10 @@ SchemaMapper &SchemaMapper::operator=(SchemaMapper const &other) {
     _impl.swap(tmp);
     return *this;
 }
+// Delegate to copy assignment for backwards compatibility
+SchemaMapper &SchemaMapper::operator=(SchemaMapper &&other) { return *this = other; }
+
+SchemaMapper::~SchemaMapper() = default;
 
 template <typename T>
 Key<T> SchemaMapper::addMapping(Key<T> const &inputKey, bool doReplace) {

--- a/src/table/Simple.cc
+++ b/src/table/Simple.cc
@@ -72,6 +72,8 @@ static SimpleFitsReader const simpleFitsReader;
 
 SimpleRecord::SimpleRecord(std::shared_ptr<SimpleTable> const& table) : BaseRecord(table) {}
 
+SimpleRecord::~SimpleRecord() = default;
+
 std::shared_ptr<SimpleTable> SimpleTable::make(Schema const& schema,
                                                std::shared_ptr<IdFactory> const& idFactory) {
     if (!checkSchema(schema)) {
@@ -86,6 +88,10 @@ SimpleTable::SimpleTable(Schema const& schema, std::shared_ptr<IdFactory> const&
 
 SimpleTable::SimpleTable(SimpleTable const& other)
         : BaseTable(other), _idFactory(other._idFactory ? other._idFactory->clone() : other._idFactory) {}
+// Delegate to copy constructor for backwards compatibility
+SimpleTable::SimpleTable(SimpleTable && other) : SimpleTable(other) {}
+
+SimpleTable::~SimpleTable() = default;
 
 SimpleTable::MinimalSchema::MinimalSchema() {
     id = schema.addField<RecordId>("id", "unique ID");

--- a/src/table/Source.cc
+++ b/src/table/Source.cc
@@ -365,6 +365,8 @@ static SourceFitsReader const sourceFitsReader;
 
 SourceRecord::SourceRecord(std::shared_ptr<SourceTable> const &table) : SimpleRecord(table) {}
 
+SourceRecord::~SourceRecord() = default;
+
 void SourceRecord::updateCoord(image::Wcs const &wcs) { setCoord(*wcs.pixelToSky(getCentroid())); }
 
 void SourceRecord::updateCoord(image::Wcs const &wcs, PointKey<double> const &key) {
@@ -392,6 +394,8 @@ SourceTable::SourceTable(Schema const &schema, std::shared_ptr<IdFactory> const 
         : SimpleTable(schema, idFactory), _slots(schema) {}
 
 SourceTable::SourceTable(SourceTable const &other) : SimpleTable(other), _slots(other._slots) {}
+// Delegate to copy constructor for backward compatibility
+SourceTable::SourceTable(SourceTable &&other) : SourceTable(other) {}
 
 void SourceTable::handleAliasChange(std::string const &alias) {
     if (alias.compare(0, 4, "slot") != 0) {

--- a/src/table/aggregates.cc
+++ b/src/table/aggregates.cc
@@ -228,6 +228,18 @@ CovarianceMatrixKey<T, N>::CovarianceMatrixKey(SubSchema const &s, NameArray con
     if (!haveCov) _cov.resize(0);
 }
 
+template <typename T, int N>
+CovarianceMatrixKey<T, N>::CovarianceMatrixKey(CovarianceMatrixKey const &) = default;
+template <typename T, int N>
+CovarianceMatrixKey<T, N>::CovarianceMatrixKey(CovarianceMatrixKey &&) = default;
+template <typename T, int N>
+CovarianceMatrixKey<T, N> & CovarianceMatrixKey<T, N>::operator=(CovarianceMatrixKey const &) = default;
+template <typename T, int N>
+CovarianceMatrixKey<T, N> & CovarianceMatrixKey<T, N>::operator=(CovarianceMatrixKey &&) = default;
+template <typename T, int N>
+CovarianceMatrixKey<T, N>::~CovarianceMatrixKey() = default;
+
+
 // these are workarounds for the fact that Eigen has different constructors for
 // dynamic-sized matrices and fixed-size matrices, but we don't want to have to
 // partial-specialize the entire template just to change one line

--- a/src/table/arrays.cc
+++ b/src/table/arrays.cc
@@ -95,6 +95,17 @@ ArrayKey<T>::ArrayKey(SubSchema const &s) : _begin(s["0"]), _size(1) {
 }
 
 template <typename T>
+ArrayKey<T>::ArrayKey(ArrayKey const &) = default;
+template <typename T>
+ArrayKey<T>::ArrayKey(ArrayKey &&) = default;
+template <typename T>
+ArrayKey<T> & ArrayKey<T>::operator=(ArrayKey const &) = default;
+template <typename T>
+ArrayKey<T> & ArrayKey<T>::operator=(ArrayKey &&) = default;
+template <typename T>
+ArrayKey<T>::~ArrayKey() = default;
+
+template <typename T>
 ndarray::Array<T const, 1, 1> ArrayKey<T>::get(BaseRecord const &record) const {
     return ndarray::external(record.getElement(_begin), ndarray::makeVector(_size), ndarray::ROW_MAJOR,
                              record.getManager());

--- a/src/table/io/FitsSchemaInputMapper.cc
+++ b/src/table/io/FitsSchemaInputMapper.cc
@@ -288,6 +288,12 @@ FitsSchemaInputMapper::FitsSchemaInputMapper(daf::base::PropertyList &metadata, 
     }
 }
 
+FitsSchemaInputMapper::FitsSchemaInputMapper(FitsSchemaInputMapper const &) = default;
+FitsSchemaInputMapper::FitsSchemaInputMapper(FitsSchemaInputMapper &&) = default;
+FitsSchemaInputMapper & FitsSchemaInputMapper::operator=(FitsSchemaInputMapper const &) = default;
+FitsSchemaInputMapper & FitsSchemaInputMapper::operator=(FitsSchemaInputMapper &&) = default;
+FitsSchemaInputMapper::~FitsSchemaInputMapper() = default;
+
 void FitsSchemaInputMapper::setArchive(std::shared_ptr<InputArchive> archive) { _impl->archive = archive; }
 
 bool FitsSchemaInputMapper::readArchive(afw::fits::Fits &fits) {

--- a/src/table/io/InputArchive.cc
+++ b/src/table/io/InputArchive.cc
@@ -166,13 +166,17 @@ InputArchive::InputArchive(BaseCatalog const& index, CatalogVector const& catalo
         : _impl(new Impl(index, catalogs)) {}
 
 InputArchive::InputArchive(InputArchive const& other) : _impl(other._impl) {}
+// Delegate to copy constructor for backwards compatibility
+InputArchive::InputArchive(InputArchive && other) : InputArchive(other) {}
 
 InputArchive& InputArchive::operator=(InputArchive const& other) {
     _impl = other._impl;
     return *this;
 }
+// Delegate to copy assignment for backwards compatibility
+InputArchive& InputArchive::operator=(InputArchive && other) { return *this = other; }
 
-InputArchive::~InputArchive() {}
+InputArchive::~InputArchive() = default;
 
 std::shared_ptr<Persistable> InputArchive::get(int id) const { return _impl->get(id, *this); }
 

--- a/src/table/io/OutputArchive.cc
+++ b/src/table/io/OutputArchive.cc
@@ -146,13 +146,17 @@ public:
 OutputArchive::OutputArchive() : _impl(new Impl()) {}
 
 OutputArchive::OutputArchive(OutputArchive const &other) : _impl(other._impl) {}
+// Delegate to copy constructor for backward compatibility
+OutputArchive::OutputArchive(OutputArchive &&other) : OutputArchive(other) {}
 
 OutputArchive &OutputArchive::operator=(OutputArchive const &other) {
     _impl = other._impl;
     return *this;
 }
+// Delegate to copy assignment for backward compatibility
+OutputArchive &OutputArchive::operator=(OutputArchive &&other) { return *this = other; }
 
-OutputArchive::~OutputArchive() {}
+OutputArchive::~OutputArchive() = default;
 
 int OutputArchive::put(Persistable const *obj, bool permissive) {
     if (!_impl.unique()) {  // copy on write


### PR DESCRIPTION
This PR changes all classes to have explicitly declared compiler-generated members, as adopted in [RFC-209](https://jira.lsstcorp.org/browse/RFC-209). I tried to make changes according to the following principles:
* Do not change current behavior, even if the old behavior is arguably wrong. For example, a class with neither copy nor move constructors defined had both explicitly defaulted, while a class with a copy constructor but no move constructor got a move constructor that delegates to the copy constructor.
* Follow the Rule of Three. In particular, I added explicit (defaulted) destructors wherever I added a copy or move constructor, and I added explicit members to classes where RFC-209 does not require them if they already had explicit destructors.
* Keep definitions locations consistent. Members were explicitly defaulted in the header file if most constructors were inline, and in the source file if most constructors were defined there.
* Use C++11 idioms. Where compiler-generated members had manually implemented defaults, I replaced them with the `default` keyword.