### PR TITLE
DM-13396: Add more flexible mask propagation to statisticsStack.

### DIFF
--- a/include/lsst/afw/math/Stack.h
+++ b/include/lsst/afw/math/Stack.h
@@ -67,13 +67,43 @@ void statisticsStack(
                 std::vector<lsst::afw::image::VariancePixel>(0)  ///< vector containing weights
         );
 
+
+/**
+ * A function to compute some statistics of a stack of Masked Images
+ *
+ * @param[in] images    MaskedImages to process.
+ * @param[in] flags     Statistics requested.
+ * @param[in] sctrl     Control structure.
+ * @param[in] wvector   Vector of weights.
+ * @param[in] clipped   Mask to set for pixels that were clipped (NOT rejected
+ *                      due to masks).
+ * @param[in] maskMap   Vector of pairs of mask pixel values; any pixel
+ *                      on an input with any of the bits in .first will result
+ *                      in all of the bits in .second being set on the
+ *                      corresponding pixel on the output.
+ *
+ * If none of the input images are valid for some pixel,
+ * the afwMath::StatisticsControl::getNoGoodPixelsMask() bit(s) are set.
+ *
+ * All the work is done in the function computeMaskedImageStack.
+ */
+template <typename PixelT>
+std::shared_ptr<lsst::afw::image::MaskedImage<PixelT>> statisticsStack(
+        std::vector<std::shared_ptr<lsst::afw::image::MaskedImage<PixelT>>>& images,
+        Property flags,
+        StatisticsControl const& sctrl,
+        std::vector<lsst::afw::image::VariancePixel> const& wvector,
+        image::MaskPixel clipped,
+        std::vector<std::pair<image::MaskPixel, image::MaskPixel>> const & maskMap
+);
+
 /**
  * A function to compute some statistics of a stack of Masked Images
  *
  * If none of the input images are valid for some pixel,
  * the afwMath::StatisticsControl::getNoGoodPixelsMask() bit(s) are set.
  *
- * All the work is done in the function computeMaskedImageStack.
+ * Delegates to the more general version of statisticsStack taking a maskMap.
  */
 template <typename PixelT>
 std::shared_ptr<lsst::afw::image::MaskedImage<PixelT>> statisticsStack(
@@ -83,9 +113,40 @@ std::shared_ptr<lsst::afw::image::MaskedImage<PixelT>> statisticsStack(
         StatisticsControl const& sctrl = StatisticsControl(),  ///< control structure
         std::vector<lsst::afw::image::VariancePixel> const& wvector =
                 std::vector<lsst::afw::image::VariancePixel>(0),  ///< vector containing weights
-        image::MaskPixel clipped=0, ///< bitmask to set if any input was clipped
+        image::MaskPixel clipped=0, ///< bitmask to set if any input was clipped or masked
         image::MaskPixel excuse=0 ///< bitmask to excuse from marking as clipped
-        );
+);
+
+
+/**
+ * A function to compute some statistics of a stack of Masked Images
+ *
+ * @param[out] out      Output MaskedImage.
+ * @param[in] images    MaskedImages to process.
+ * @param[in] flags     Statistics requested.
+ * @param[in] sctrl     Control structure.
+ * @param[in] wvector   Vector of weights.
+ * @param[in] clipped   Mask to set for pixels that were clipped (NOT rejected
+ *                      due to masks).
+ * @param[in] maskMap   Vector of pairs of mask pixel values; any pixel
+ *                      on an input with any of the bits in .first will result
+ *                      in all of the bits in .second being set on the
+ *                      corresponding pixel on the output.
+ *
+ * If none of the input images are valid for some pixel,
+ * the afwMath::StatisticsControl::getNoGoodPixelsMask() bit(s) are set.
+ *
+ * All the work is done in the function computeMaskedImageStack.
+ */
+template <typename PixelT>
+void statisticsStack(lsst::afw::image::MaskedImage<PixelT>& out,
+                     std::vector<std::shared_ptr<lsst::afw::image::MaskedImage<PixelT>>>& images,
+                     Property flags,
+                     StatisticsControl const& sctrl,
+                     std::vector<lsst::afw::image::VariancePixel> const& wvector,
+                     image::MaskPixel clipped,
+                     std::vector<std::pair<image::MaskPixel, image::MaskPixel>> const & maskMap
+                     );
 
 /**
  * @ brief compute statistical stack of MaskedImage.  Write to output image in-situ
@@ -98,7 +159,7 @@ void statisticsStack(lsst::afw::image::MaskedImage<PixelT>& out,  ///< Output im
                      StatisticsControl const& sctrl = StatisticsControl(),  ///< control structure
                      std::vector<lsst::afw::image::VariancePixel> const& wvector =
                              std::vector<lsst::afw::image::VariancePixel>(0),  ///< vector containing weights
-                     image::MaskPixel clipped=0, ///< bitmask to set if any input was clipped
+                     image::MaskPixel clipped=0, ///< bitmask to set if any input was clipped or masked
                      image::MaskPixel excuse=0 ///< bitmask to excuse from marking as clipped
                      );
 

--- a/python/lsst/afw/math/stack.cc
+++ b/python/lsst/afw/math/stack.cc
@@ -59,6 +59,15 @@ void declareStatisticsStack(py::module &mod) {
             "wvector"_a = std::vector<lsst::afw::image::VariancePixel>(0),
             "clipped"_a=0, "excuse"_a=0);
     mod.def("statisticsStack",
+            (void (*)(lsst::afw::image::MaskedImage<PixelT> &,
+                      std::vector<std::shared_ptr<lsst::afw::image::MaskedImage<PixelT>>> &, Property,
+                      StatisticsControl const &,
+                      std::vector<lsst::afw::image::VariancePixel> const &,
+                      lsst::afw::image::MaskPixel,
+                      std::vector<std::pair<lsst::afw::image::MaskPixel, lsst::afw::image::MaskPixel>> const &
+                ))statisticsStack<PixelT>,
+            "out"_a, "images"_a, "flags"_a, "sctrl"_a, "wvector"_a, "clipped"_a, "maskMap"_a);
+    mod.def("statisticsStack",
             (std::shared_ptr<lsst::afw::image::Image<PixelT>>(*)(
                     std::vector<std::shared_ptr<lsst::afw::image::Image<PixelT>>> &, Property,
                     StatisticsControl const &,
@@ -74,6 +83,15 @@ void declareStatisticsStack(py::module &mod) {
             "images"_a, "flags"_a, "sctrl"_a = StatisticsControl(),
             "wvector"_a = std::vector<lsst::afw::image::VariancePixel>(0),
             "clipped"_a=0, "excuse"_a=0);
+    mod.def("statisticsStack",
+            (std::shared_ptr<lsst::afw::image::MaskedImage<PixelT>>(*)(
+                    std::vector<std::shared_ptr<lsst::afw::image::MaskedImage<PixelT>>> &, Property,
+                    StatisticsControl const &,
+                    std::vector<lsst::afw::image::VariancePixel> const &,
+                    lsst::afw::image::MaskPixel,
+                    std::vector<std::pair<lsst::afw::image::MaskPixel, lsst::afw::image::MaskPixel>> const &
+                ))statisticsStack<PixelT>,
+            "images"_a, "flags"_a, "sctrl"_a, "wvector"_a, "clipped"_a, "maskMap"_a);
     mod.def("statisticsStack",
             (std::shared_ptr<std::vector<PixelT>>(*)(
                     std::vector<std::shared_ptr<std::vector<PixelT>>> &, Property, StatisticsControl const &,

--- a/tests/test_stacker.py
+++ b/tests/test_stacker.py
@@ -398,6 +398,17 @@ class StackTestCase(lsst.utils.tests.TestCase):
         self.assertFloatsAlmostEqual(stack.getImage().getArray(), 0.0, atol=0.0)
         self.assertEqual(stack.getMask().get(1, 1), 0)
 
+        # Map that mask value to a different one.
+        rejected = 1 << afwImage.Mask().addMaskPlane("REJECTED")
+        maskMap = [(maskVal, rejected)]
+        images[0].getMask().set(1, 1, 0)        # only want to clip, not mask, this one
+        images[1].getMask().set(1, 2, maskVal)  # only want to mask, not clip, this one
+        stack = afwMath.statisticsStack(images, afwMath.MEANCLIP, statsCtrl, wvector=[], clipped=clipped,
+                                        maskMap=maskMap)
+        self.assertFloatsAlmostEqual(stack.getImage().getArray(), 0.0, atol=0.0)
+        self.assertEqual(stack.getMask().get(1, 1), clipped)
+        self.assertEqual(stack.getMask().get(1, 2), rejected)
+
 #################################################################
 # Test suite boiler plate
 #################################################################


### PR DESCRIPTION
Changes here were done to in a way that should guarantee ABI compatibility with w_2018_04 (when the fixed version of that comes out); I didn't want anyone working on coadds this week to have to rebuild everything (instead they'll just have to rebuild afw).  Note that this precludes some cleanups I'd have otherwise tried to do in nearby code (wow, `statisticsStack` is a mess!).