### PR TITLE
DM-10066: Provide utility function for wrapping operator<<

### DIFF
--- a/python/lsst/afw/cameraGeom/cameraPoint.cc
+++ b/python/lsst/afw/cameraGeom/cameraPoint.cc
@@ -23,6 +23,8 @@
 #include <pybind11/pybind11.h>
 //#include <pybind11/stl.h>
 
+#include "lsst/utils/python.h"
+
 #include "lsst/afw/cameraGeom/CameraPoint.h"
 
 namespace py = pybind11;
@@ -48,16 +50,8 @@ PYBIND11_PLUGIN(_cameraPoint) {
             py::is_operator());
     cls.def("__ne__", [](CameraPoint const &self, CameraPoint const &other) { return self != other; },
             py::is_operator());
-    cls.def("__str__", [](CameraPoint const &self) {
-        std::ostringstream os;
-        os << self;
-        return os.str();
-    });
-    cls.def("__repr__", [](CameraPoint &self) {
-        std::ostringstream os;
-        os << self;
-        return os.str();
-    });
+    utils::python::addOutputOp(cls, "__str__");
+    utils::python::addOutputOp(cls, "__repr__");
 
     /* Members */
     cls.def("getPoint", &CameraPoint::getPoint);

--- a/python/lsst/afw/cameraGeom/cameraSys.cc
+++ b/python/lsst/afw/cameraGeom/cameraSys.cc
@@ -25,6 +25,8 @@
 #include <pybind11/pybind11.h>
 //#include <pybind11/stl.h>
 
+#include "lsst/utils/python.h"
+
 #include "lsst/afw/cameraGeom/CameraSys.h"
 
 namespace py = pybind11;
@@ -48,20 +50,9 @@ void declareCommonSysMethods(PyClass &cls) {
             py::is_operator());
     cls.def("__ne__", [](CppClass const &self, CppClass const &other) { return self != other; },
             py::is_operator());
-    cls.def("__str__", [](CppClass const &self) {
-        std::ostringstream os;
-        os << self;
-        return os.str();
-    });
-    cls.def("__repr__", [](CppClass const &self) {
-        std::ostringstream os;
-        os << self;
-        return os.str();
-    });
-    cls.def("__hash__", [](CppClass const &self) {
-        using std::hash;
-        return hash<CppClass>()(self);
-    });
+    utils::python::addOutputOp(cls, "__str__");
+    utils::python::addOutputOp(cls, "__repr__");
+    utils::python::addHash(cls);
 
     /* Methods */
     cls.def("getSysName", &CppClass::getSysName);

--- a/python/lsst/afw/coord/weather.cc
+++ b/python/lsst/afw/coord/weather.cc
@@ -24,6 +24,8 @@
 
 #include <pybind11/pybind11.h>
 
+#include "lsst/utils/python.h"
+
 #include "lsst/afw/coord/Weather.h"
 
 namespace py = pybind11;
@@ -52,13 +54,8 @@ PYBIND11_PLUGIN(_weather) {
     cls.def("getAirPressure", &lsst::afw::coord::Weather::getAirPressure);
     cls.def("getAirTemperature", &lsst::afw::coord::Weather::getAirTemperature);
     cls.def("getHumidity", &lsst::afw::coord::Weather::getHumidity);
-    auto streamStr = [](Weather const &self) {
-        std::stringstream buffer;
-        buffer << self;
-        return buffer.str();
-    };
-    cls.def("__str__", streamStr);
-    cls.def("__repr__", streamStr);
+    utils::python::addOutputOp(cls, "__str__");
+    utils::python::addOutputOp(cls, "__repr__");
 
     return mod.ptr();
 }

--- a/python/lsst/afw/detection/peak.cc
+++ b/python/lsst/afw/detection/peak.cc
@@ -27,6 +27,8 @@
 
 //#include <pybind11/stl.h>
 
+#include "lsst/utils/python.h"
+
 #include "lsst/afw/table/BaseRecord.h"
 #include "lsst/afw/table/BaseTable.h"
 #include "lsst/afw/detection/Peak.h"
@@ -67,13 +69,8 @@ void declarePeakRecord(PyPeakRecord &cls) {
     cls.def("getF", &PeakRecord::getF);
     cls.def("getPeakValue", &PeakRecord::getPeakValue);
     cls.def("setPeakValue", &PeakRecord::setPeakValue);
-    auto streamStr = [](PeakRecord const &self) {
-        std::stringstream buffer;
-        buffer << self;
-        return buffer.str();
-    };
-    cls.def("__str__", streamStr);
-    cls.def("__repr__", streamStr);
+    utils::python::addOutputOp(cls, "__str__");
+    utils::python::addOutputOp(cls, "__repr__");
 }
 
 /**

--- a/python/lsst/afw/geom/angle/angle.cc
+++ b/python/lsst/afw/geom/angle/angle.cc
@@ -22,6 +22,8 @@
 
 #include "pybind11/pybind11.h"
 
+#include "lsst/utils/python.h"
+
 #include "lsst/afw/geom/Angle.h"
 
 namespace py = pybind11;
@@ -107,13 +109,8 @@ PYBIND11_PLUGIN(angle) {
         return py::make_tuple(clsAngle, py::make_tuple(py::cast(self.asRadians())));
     });
 
-    auto streamStr = [](Angle const& self) {
-        std::stringstream buffer;
-        buffer << self;
-        return buffer.str();
-    };
-    clsAngle.def("__str__", streamStr);
-    clsAngle.def("__repr__", streamStr);
+    utils::python::addOutputOp(clsAngle, "__str__");
+    utils::python::addOutputOp(clsAngle, "__repr__");
 
     clsAngle.def("asAngularUnits", &Angle::asAngularUnits);
     clsAngle.def("asRadians", &Angle::asRadians);

--- a/python/lsst/afw/geom/endpoint.cc
+++ b/python/lsst/afw/geom/endpoint.cc
@@ -30,6 +30,8 @@
 #include "numpy/arrayobject.h"
 #include "ndarray/pybind11.h"
 
+#include "lsst/utils/python.h"
+
 #include "lsst/afw/coord/Coord.h"
 #include "lsst/afw/geom/Point.h"
 #include "lsst/afw/geom/Endpoint.h"
@@ -52,11 +54,7 @@ repr(self) = "lsst.afw.geom." + str(self), e.g. "lsst.afw.geom.GenericEndpoint(4
 template <typename PyClass>
 void addStrAndRepr(PyClass& cls) {
     using Class = typename PyClass::type;  // C++ class associated with pybind11 wrapper class
-    cls.def("__str__", [](Class const& self) {
-        std::ostringstream os;
-        os << self;
-        return os.str();
-    });
+    utils::python::addOutputOp(cls, "__str__");
     cls.def("__repr__", [](Class const& self) {
         std::ostringstream os;
         os << "lsst.afw.geom." << self;

--- a/python/lsst/afw/geom/spherePoint/spherePoint.cc
+++ b/python/lsst/afw/geom/spherePoint/spherePoint.cc
@@ -26,6 +26,8 @@
 #include <memory>
 
 #include "lsst/utils/python.h"
+
+#include "lsst/utils/python.h"
 #include "lsst/afw/geom/Angle.h"
 #include "lsst/afw/geom/Point.h"
 #include "lsst/afw/geom/SpherePoint.h"
@@ -70,11 +72,7 @@ PYBIND11_PLUGIN(spherePoint) {
     cls.def("separation", &SpherePoint::separation, "other"_a);
     cls.def("rotated", &SpherePoint::rotated, "axis"_a, "amount"_a);
     cls.def("offset", &SpherePoint::offset, "bearing"_a, "amount"_a);
-    cls.def("__str__", [](SpherePoint const &self) {
-        std::ostringstream os;
-        os << std::fixed << self;
-        return os.str();
-    });
+    utils::python::addOutputOp(cls, "__str__");
     cls.def("__len__", [](SpherePoint const &) { return 2; });
     cls.def("__reduce__", [cls](SpherePoint const &self) {
         return py::make_tuple(cls,

--- a/python/lsst/afw/image/photoCalib.cc
+++ b/python/lsst/afw/image/photoCalib.cc
@@ -28,6 +28,8 @@
 #include "numpy/arrayobject.h"
 #include "ndarray/pybind11.h"
 
+#include "lsst/utils/python.h"
+
 #include "lsst/daf/base/PropertySet.h"
 #include "lsst/afw/math/BoundedField.h"
 #include "lsst/afw/table/io/Persistable.h"
@@ -154,11 +156,7 @@ PYBIND11_PLUGIN(photoCalib) {
     cls.def("__eq__", &PhotoCalib::operator==, py::is_operator());
     cls.def("__ne__", &PhotoCalib::operator!=, py::is_operator());
 
-    cls.def("__str__", [](PhotoCalib const &self) {
-        std::ostringstream os;
-        os << self;
-        return os.str();
-    });
+    utils::python::addOutputOp(cls, "__str__");
     cls.def("__repr__", [](PhotoCalib const &self) {
         std::ostringstream os;
         os << "PhotoCalib(" << self << ")";

--- a/python/lsst/afw/image/visitInfo.cc
+++ b/python/lsst/afw/image/visitInfo.cc
@@ -26,6 +26,8 @@
 #include <limits>
 #include <sstream>
 
+#include "lsst/utils/python.h"
+
 #include "lsst/daf/base/PropertySet.h"
 #include "lsst/afw/coord/Coord.h"
 #include "lsst/afw/coord/Observatory.h"
@@ -104,11 +106,7 @@ PYBIND11_PLUGIN(visitInfo) {
     cls.def("getLocalEra", &VisitInfo::getLocalEra);
     cls.def("getBoresightHourAngle", &VisitInfo::getBoresightHourAngle);
 
-    cls.def("__str__", [](VisitInfo const &self) {
-        std::stringstream os;
-        os << self;
-        return os.str();
-    });
+    utils::python::addOutputOp(cls, "__str__");
 
     /* Free Functions */
     mod.def("setVisitInfoMetadata", &detail::setVisitInfoMetadata, "metadata"_a, "visitInfo"_a);

--- a/python/lsst/afw/math/boundedField.cc
+++ b/python/lsst/afw/math/boundedField.cc
@@ -29,6 +29,8 @@
 #include "ndarray/pybind11.h"
 #include "ndarray/converter.h"
 
+#include "lsst/utils/python.h"
+
 #include "lsst/afw/table/io/Persistable.h"
 #include "lsst/afw/geom/Point.h"
 #include "lsst/afw/math/BoundedField.h"
@@ -91,11 +93,7 @@ PYBIND11_PLUGIN(_boundedField) {
     declareTemplates<double>(cls);
     declareTemplates<float>(cls);
 
-    cls.def("__str__", [](BoundedField const &self) {
-        std::ostringstream os;
-        os << self;
-        return os.str();
-    });
+    utils::python::addOutputOp(cls, "__str__");
     cls.def("__repr__", [](BoundedField const &self) {
         std::ostringstream os;
         os << "BoundedField(" << self << ")";

--- a/python/lsst/afw/table/schema/schema.cc
+++ b/python/lsst/afw/table/schema/schema.cc
@@ -28,6 +28,8 @@
 #include "numpy/arrayobject.h"
 #include "ndarray/pybind11.h"
 
+#include "lsst/utils/python.h"
+
 #include "lsst/afw/fits.h"
 #include "lsst/afw/table/Schema.h"
 #include "lsst/afw/table/BaseRecord.h"
@@ -60,13 +62,6 @@ using PyKey = py::class_<Key<T>, KeyBase<T>, FieldBase<T>>;
 
 template <typename T>
 using PySchemaItem = py::class_<SchemaItem<T>>;
-
-template <typename T>
-std::string streamStr(T const &self) {
-    std::ostringstream os;
-    os << self;
-    return os.str();
-}
 
 // Specializations for FieldBase
 
@@ -226,8 +221,8 @@ void declareSchemaType(py::module &mod) {
     clsField.def("getDoc", &Field<T>::getDoc);
     clsField.def("getUnits", &Field<T>::getUnits);
     clsField.def("copyRenamed", &Field<T>::copyRenamed);
-    clsField.def("__str__", &streamStr<Field<T>>);
-    clsField.def("__repr__", &streamStr<Field<T>>);
+    utils::python::addOutputOp(clsField, "__str__");
+    utils::python::addOutputOp(clsField, "__repr__");
 
     // Key
     PyKey<T> clsKey(mod, ("Key" + suffix).c_str());
@@ -239,8 +234,8 @@ void declareSchemaType(py::module &mod) {
                py::is_operator());
     clsKey.def("isValid", &Key<T>::isValid);
     clsKey.def("getOffset", &Key<T>::getOffset);
-    clsKey.def("__str__", &streamStr<Key<T>>);
-    clsKey.def("__repr__", &streamStr<Key<T>>);
+    utils::python::addOutputOp(clsKey, "__str__");
+    utils::python::addOutputOp(clsKey, "__repr__");
     // The Key methods below actually wrap templated methods on Schema and
     // SchemaMapper.  Rather than doing many-type overload resolution by
     // wrapping those methods directly, we use the visitor pattern by having
@@ -366,8 +361,8 @@ void declareSchema(py::module &mod) {
                                              std::string const &) const) &
                             Schema::join,
             "a"_a, "b"_a, "c"_a, "d"_a);
-    cls.def("__str__", &streamStr<Schema>);
-    cls.def("__repr__", &streamStr<Schema>);
+    utils::python::addOutputOp(cls, "__str__");
+    utils::python::addOutputOp(cls, "__repr__");
 }
 
 void declareSubSchema(py::module &mod) {


### PR DESCRIPTION
This PR replaces trivial pybind11 wrappers of operator<< with calls to `wrapOutputOp`, which is introduced in lsst/utils#47. Non-trivial wrappers (typically ones that add extra information to `__repr__`) are left untouched.