### PR TITLE
DM-13655: Phase out MemoryError and TimeoutError from pex::exceptions

### DIFF
--- a/include/lsst/afw/math/ConvolveImage.h
+++ b/include/lsst/afw/math/ConvolveImage.h
@@ -186,7 +186,7 @@ inline typename OutImageT::SinglePixel convolveAtAPoint(
  * @throws lsst::pex::exceptions::InvalidParameterError if convolvedImage is not the same size as inImage
  * @throws lsst::pex::exceptions::InvalidParameterError if inImage is smaller than kernel
  *  in columns and/or rows.
- * @throws lsst::pex::exceptions::MemoryError when allocation of CPU memory fails
+ * @throws std::bad_alloc when allocation of memory fails
  */
 template <typename OutImageT, typename InImageT, typename KernelT>
 void convolve(OutImageT& convolvedImage, InImageT const& inImage, KernelT const& kernel,

--- a/include/lsst/afw/math/Random.h
+++ b/include/lsst/afw/math/Random.h
@@ -109,7 +109,7 @@ public:
      *
      * @throws lsst::pex::exceptions::InvalidParameterError
      *      Thrown if the requested algorithm is not supported.
-     * @throws lsst::pex::exceptions::MemoryError
+     * @throws std::bad_alloc
      *      Thrown if memory allocation for internal generator state fails.
      */
     explicit Random(Algorithm algorithm = MT19937, unsigned long seed = 1);
@@ -122,7 +122,7 @@ public:
      *
      * @throws lsst::pex::exceptions::InvalidParameterError
      *      Thrown if the requested algorithm is not supported.
-     * @throws lsst::pex::exceptions::MemoryError
+     * @throws std::bad_alloc
      *      Thrown if memory allocation for internal generator state fails.
      */
     explicit Random(std::string const &algorithm, unsigned long seed = 1);
@@ -139,7 +139,7 @@ public:
      *
      * @throws lsst::pex::exceptions::InvalidParameterError
      *      Thrown if the requested algorithm is not supported.
-     * @throws lsst::pex::exceptions::MemoryError
+     * @throws std::bad_alloc
      *      Thrown if memory allocation for internal generator state fails.
      */
     explicit Random(std::shared_ptr<pex::policy::Policy> const policy);
@@ -157,7 +157,7 @@ public:
      *
      * @returns  a deep copy of this random number generator
      *
-     * @throws lsst::pex::exceptions::MemoryError
+     * @throws std::bad_alloc
      *      Thrown if memory allocation for internal generator state fails.
      */
     Random deepCopy() const;

--- a/include/lsst/afw/math/detail/Convolve.h
+++ b/include/lsst/afw/math/detail/Convolve.h
@@ -62,7 +62,7 @@ namespace detail {
  * @throws lsst::pex::exceptions::InvalidParameterError if convolvedImage dimensions != inImage dimensions
  * @throws lsst::pex::exceptions::InvalidParameterError if inImage smaller than kernel in width or height
  * @throws lsst::pex::exceptions::InvalidParameterError if kernel width or height < 1
- * @throws lsst::pex::exceptions::MemoryError when allocation of CPU memory fails
+ * @throws std::bad_alloc when allocation of CPU memory fails
  */
 template <typename OutImageT, typename InImageT>
 void basicConvolve(OutImageT& convolvedImage, InImageT const& inImage, lsst::afw::math::Kernel const& kernel,
@@ -98,7 +98,7 @@ void basicConvolve(OutImageT& convolvedImage, InImageT const& inImage,
  * @throws lsst::pex::exceptions::InvalidParameterError if convolvedImage dimensions != inImage dimensions
  * @throws lsst::pex::exceptions::InvalidParameterError if inImage smaller than kernel in width or height
  * @throws lsst::pex::exceptions::InvalidParameterError if kernel width or height < 1
- * @throws lsst::pex::exceptions::MemoryError when allocation of CPU memory fails
+ * @throws std::bad_alloc when allocation of CPU memory fails
  *
  * @ingroup afw
  */
@@ -139,7 +139,7 @@ void basicConvolve(OutImageT& convolvedImage, InImageT const& inImage,
  * @throws lsst::pex::exceptions::InvalidParameterError if convolvedImage dimensions != inImage dimensions
  * @throws lsst::pex::exceptions::InvalidParameterError if inImage smaller than kernel in width or height
  * @throws lsst::pex::exceptions::InvalidParameterError if kernel width or height < 1
- * @throws lsst::pex::exceptions::MemoryError when allocation of CPU memory fails
+ * @throws std::bad_alloc when allocation of CPU memory fails
  *
  * @warning Low-level convolution function that does not set edge pixels.
  */

--- a/include/lsst/afw/math/warpExposure.h
+++ b/include/lsst/afw/math/warpExposure.h
@@ -442,7 +442,7 @@ int warpExposure(
  * by linear interpolation between those grid points. Everything else remains the same.
  *
  * @throws lsst::pex::exceptions::InvalidParameterError if destImage is srcImage
- * @throws lsst::pex::exceptions::MemoryError when allocation of CPU memory fails
+ * @throws std::bad_alloc when allocation of CPU memory fails
  *
  * @todo Should support an additional color-based position correction in the remapping
  *   (differential chromatic refraction). This can be done either object-by-object or pixel-by-pixel.

--- a/src/geom/Transform.cc
+++ b/src/geom/Transform.cc
@@ -134,21 +134,17 @@ std::shared_ptr<Transform<ToEndpoint, FromEndpoint>> Transform<FromEndpoint, ToE
 
 template <class FromEndpoint, class ToEndpoint>
 Eigen::MatrixXd Transform<FromEndpoint, ToEndpoint>::getJacobian(FromPoint const &x) const {
-    try {
-        int const nIn = _fromEndpoint.getNAxes();
-        int const nOut = _toEndpoint.getNAxes();
-        std::vector<double> const point = _fromEndpoint.dataFromPoint(x);
+    int const nIn = _fromEndpoint.getNAxes();
+    int const nOut = _toEndpoint.getNAxes();
+    std::vector<double> const point = _fromEndpoint.dataFromPoint(x);
 
-        Eigen::MatrixXd jacobian(nOut, nIn);
-        for (int i = 0; i < nOut; ++i) {
-            for (int j = 0; j < nIn; ++j) {
-                jacobian(i, j) = _frameSet->rate(point, i + 1, j + 1);
-            }
+    Eigen::MatrixXd jacobian(nOut, nIn);
+    for (int i = 0; i < nOut; ++i) {
+        for (int j = 0; j < nIn; ++j) {
+            jacobian(i, j) = _frameSet->rate(point, i + 1, j + 1);
         }
-        return jacobian;
-    } catch (std::bad_alloc const &e) {
-        std::throw_with_nested(LSST_EXCEPT(pex::exceptions::MemoryError, "Could not allocate Jacobian."));
     }
+    return jacobian;
 }
 
 template <class FromEndpoint, class ToEndpoint>

--- a/src/image/TransmissionCurve.cc
+++ b/src/image/TransmissionCurve.cc
@@ -152,10 +152,7 @@ using GslPtr = std::unique_ptr<T, void (*)(T*)>;
 template <typename T>
 GslPtr<T> makeGslPtr(T* p, void (*free)(T*)) {
     if (p == nullptr) {
-        throw LSST_EXCEPT(
-            pex::exceptions::MemoryError,
-            "Could not allocate GSL object."
-        );
+        throw std::bad_alloc();
     }
     return GslPtr<T>(p, free);
 }

--- a/src/math/Interpolate.cc
+++ b/src/math/Interpolate.cc
@@ -195,7 +195,7 @@ InterpolateGsl::InterpolateGsl(std::vector<double> const &x,   ///< the x-values
 
     _acc = ::gsl_interp_accel_alloc();
     if (!_acc) {
-        throw LSST_EXCEPT(pex::exceptions::MemoryError, "gsl_interp_accel_alloc failed");
+        throw std::bad_alloc();
     }
 
     _interp = ::gsl_interp_alloc(_interpType, _y.size());

--- a/src/math/Random.cc
+++ b/src/math/Random.cc
@@ -65,7 +65,7 @@ char const *const Random::_seedEnvVarName = "LSST_RNG_SEED";
 void Random::initialize() {
     ::gsl_rng *rng = ::gsl_rng_alloc(_gslRngTypes[_algorithm]);
     if (rng == 0) {
-        throw LSST_EXCEPT(ex::MemoryError, "gsl_rng_alloc() failed");
+        throw std::bad_alloc();
     }
     // This seed is guaranteed to be non-zero.
     // We want to give a non-zero seed to GSL to avoid it choosing its own.
@@ -118,7 +118,7 @@ Random Random::deepCopy() const {
     Random rng = *this;
     rng._rng.reset(::gsl_rng_clone(_rng.get()), ::gsl_rng_free);
     if (!rng._rng) {
-        throw LSST_EXCEPT(ex::MemoryError, "gsl_rng_clone() failed");
+        throw std::bad_alloc();
     }
     return rng;
 }


### PR DESCRIPTION
This PR removes all mention of `pex::exceptions::MemoryError` from `afw`, modifying code to throw `std::bad_alloc` instead.

This change removes error messages from the emitted exception, but there's a good chance that trying to allocate the strings for those would have triggered `bad_alloc` anyway.