### PR TITLE
DM-13847: Transform: calculate Mapping at construction time

### DIFF
--- a/include/lsst/afw/geom/Transform.h
+++ b/include/lsst/afw/geom/Transform.h
@@ -124,14 +124,14 @@ public:
      *
      * @exceptsafe Provides basic exception safety.
      */
-    bool hasForward() const { return _frameSet->hasForward(); }
+    bool hasForward() const { return _mapping->hasForward(); }
 
     /**
      * Test if this method has an inverse transform.
      *
      * @exceptsafe Provides basic exception safety.
      */
-    bool hasInverse() const { return _frameSet->hasInverse(); }
+    bool hasInverse() const { return _mapping->hasInverse(); }
 
     /**
      * Get the "from" endpoint
@@ -294,6 +294,7 @@ private:
     FromEndpoint _fromEndpoint;
     std::shared_ptr<const ast::FrameSet> _frameSet;
     ToEndpoint _toEndpoint;
+    std::shared_ptr<const ast::Mapping> _mapping;  // mapping derived from frameSet
 };
 
 /**


### PR DESCRIPTION
Much of the runtime performance degradation from SkyWcs appears to be
due to AST rebuilding the transformation every time we want to use it.
By calculating and caching the '_frameSet->getMapping' at construction
time, and using that for the coordinate transformations, we can cut
the corner and save a LOT of time.

Thanks to Russell Owen for the idea.