### PR TITLE
DM-13884: SpherePoint() initializes fields in the wrong order (compiler warning)

### DIFF
--- a/src/geom/SpherePoint.cc
+++ b/src/geom/SpherePoint.cc
@@ -100,7 +100,7 @@ SpherePoint::SpherePoint(Point3D const& vector) {
     }
 }
 
-SpherePoint::SpherePoint() : _latitude(nan("")), _longitude(nan("")) {}
+SpherePoint::SpherePoint() : _longitude(nan("")), _latitude(nan("")) {}
 
 SpherePoint::SpherePoint(SpherePoint const& other) noexcept = default;
 


### PR DESCRIPTION
by initializing the fields in the correct order.