### PR TITLE
tickets/DM-13834: Add minimum and maximum wavelength to FilterProperty.

### DIFF
--- a/include/lsst/afw/image/Filter.h
+++ b/include/lsst/afw/image/Filter.h
@@ -93,11 +93,11 @@ public:
      */
     double getLambdaEff() const { return _lambdaEff; }
     /**
-     * Return the filter's minimum wavelength (nm)
+     * Return the filter's minimum wavelength (nm) where the transmission is above 1% of the maximum.
      */
     double getLambdaMin() const { return _lambdaMin; }
     /**
-     * Return the filter's maximum wavelength (nm)
+     * Return the filter's maximum wavelength (nm) where the transmission is above 1% of the maximum.
      */
     double getLambdaMax() const { return _lambdaMax; }
     /**

--- a/include/lsst/afw/image/Filter.h
+++ b/include/lsst/afw/image/Filter.h
@@ -32,6 +32,7 @@
 #ifndef LSST_AFW_IMAGE_FILTER_H
 #define LSST_AFW_IMAGE_FILTER_H
 
+#include <cmath>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -54,8 +55,9 @@ namespace image {
  */
 class FilterProperty {
 public:
-    explicit FilterProperty(std::string const& name, double lambdaEff, bool force = false)
-            : _name(name), _lambdaEff(lambdaEff) {
+    explicit FilterProperty(std::string const& name, double lambdaEff, 
+                            double lambdaMin=NAN, double lambdaMax=NAN, bool force = false)
+            : _name(name), _lambdaEff(lambdaEff), _lambdaMin(lambdaMin), _lambdaMax(lambdaMax) {
         _insert(force);
     }
     /**
@@ -90,6 +92,14 @@ public:
      * Return the filter's effective wavelength (nm)
      */
     double getLambdaEff() const { return _lambdaEff; }
+    /**
+     * Return the filter's minimum wavelength (nm)
+     */
+    double getLambdaMin() const { return _lambdaMin; }
+    /**
+     * Return the filter's maximum wavelength (nm)
+     */
+    double getLambdaMax() const { return _lambdaMax; }
     /**
      * Return true iff two FilterProperties are identical
      *
@@ -131,6 +141,8 @@ private:
 
     std::string _name;  // name of filter
     double _lambdaEff;  // effective wavelength (nm)
+    double _lambdaMin;  // minimum wavelength (nm)
+    double _lambdaMax;  // maximum wavelength (nm)
 
     static PropertyMap* _propertyMap;  // mapping from name -> FilterProperty
 };

--- a/python/lsst/afw/image/filter.cc
+++ b/python/lsst/afw/image/filter.cc
@@ -23,6 +23,7 @@
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 
+#include <cmath>
 #include "lsst/daf/base/PropertySet.h"
 #include "lsst/pex/policy/Policy.h"
 #include "lsst/afw/image/Filter.h"
@@ -48,7 +49,8 @@ PYBIND11_PLUGIN(filter) {
     mod.def("stripFilterKeywords", &detail::stripFilterKeywords, "metadata"_a);
 
     PyFilterProperty clsFilterProperty(mod, "FilterProperty");
-    clsFilterProperty.def(py::init<std::string const &, double, bool>(), "name"_a, "lambdaEff"_a,
+    clsFilterProperty.def(py::init<std::string const &, double, double, double, bool>(),
+                          "name"_a, "lambdaEff"_a, "lambdaMin"_a = NAN, "lambdaMax"_a = NAN,
                           "force"_a = false);
     // note: metadata should be defaulted with "metadata"_a=daf::base::PropertySet()
     // but that causes an error about copying when the Python extension is imported
@@ -64,6 +66,8 @@ PYBIND11_PLUGIN(filter) {
             py::is_operator());
     clsFilterProperty.def("getName", &FilterProperty::getName);
     clsFilterProperty.def("getLambdaEff", &FilterProperty::getLambdaEff);
+    clsFilterProperty.def("getLambdaMin", &FilterProperty::getLambdaMin);
+    clsFilterProperty.def("getLambdaMax", &FilterProperty::getLambdaMax);
     clsFilterProperty.def_static("reset", &FilterProperty::reset);
     clsFilterProperty.def_static("lookup", &FilterProperty::lookup, "name"_a);
 

--- a/python/lsst/afw/image/utils.py
+++ b/python/lsst/afw/image/utils.py
@@ -26,6 +26,7 @@ __all__ = ["clipImage", "resetFilters", "defineFilter",
 
 from past.builtins import basestring
 from builtins import object
+import numpy as np
 
 import lsst.pex.policy as pexPolicy
 import lsst.afw.detection as afwDetect
@@ -60,9 +61,9 @@ def resetFilters():
     FilterProperty.reset()
 
 
-def defineFilter(name, lambdaEff, alias=[], force=False):
+def defineFilter(name, lambdaEff, lambdaMin=np.nan, lambdaMax=np.nan, alias=[], force=False):
     """Define a filter and its properties in the filter registry"""
-    prop = FilterProperty(name, lambdaEff, force)
+    prop = FilterProperty(name, lambdaEff, lambdaMin, lambdaMax, force)
     Filter.define(prop)
     if isinstance(alias, basestring):
         Filter.defineAlias(name, alias)

--- a/src/image/Filter.cc
+++ b/src/image/Filter.cc
@@ -28,6 +28,7 @@
 //         Implements looking up a filter identifier by name.
 //
 //##====----------------                                ----------------====##/
+#include <cmath>
 #include "boost/format.hpp"
 #include "boost/algorithm/string/trim.hpp"
 #include "lsst/pex/exceptions.h"
@@ -43,9 +44,15 @@ namespace image {
 FilterProperty::PropertyMap* FilterProperty::_propertyMap = NULL;
 
 FilterProperty::FilterProperty(std::string const& name, lsst::daf::base::PropertySet const& prop, bool force)
-        : _name(name), _lambdaEff(-1) {
+        : _name(name), _lambdaEff(NAN), _lambdaMin(NAN), _lambdaMax(NAN)  {
     if (prop.exists("lambdaEff")) {
         _lambdaEff = prop.getAsDouble("lambdaEff");
+    }
+    if (prop.exists("lambdaMin")) {
+        _lambdaMin = prop.getAsDouble("lambdaMin");
+    }
+    if (prop.exists("lambdaMax")) {
+        _lambdaMax = prop.getAsDouble("lambdaMax");
     }
     _insert(force);
 }
@@ -54,6 +61,12 @@ FilterProperty::FilterProperty(std::string const& name, lsst::pex::policy::Polic
         : _name(name), _lambdaEff(-1) {
     if (pol.exists("lambdaEff")) {
         _lambdaEff = pol.getDouble("lambdaEff");
+    }
+    if (pol.exists("lambdaMin")) {
+        _lambdaMin = pol.getDouble("lambdaMin");
+    }
+    if (pol.exists("lambdaMax")) {
+        _lambdaMax = pol.getDouble("lambdaMax");
     }
     _insert(force);
 }

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -297,6 +297,20 @@ class FilterTestCase(lsst.utils.tests.TestCase):
                          self.defineFilterProperty("gX", self.g_lambdaEff, force=True))
         self.assertEqual(g.getLambdaEff(), self.g_lambdaEff)
 
+    def testLambdaMinMax(self):
+        """Test additional properties for minimum and maximum wavelength for a filter."""
+        filt = afwImage.Filter("g")
+        # LambdaMin and LambdaMax are undefined for the test SDSS filter, and should return nan
+        self.assertTrue(np.isnan(filt.getFilterProperty().getLambdaMin()))
+        self.assertTrue(np.isnan(filt.getFilterProperty().getLambdaMax()))
+        lambdaEff = 476.31
+        lambdaMin = 405
+        lambdaMax = 552
+        imageUtils.defineFilter("gNew", lambdaEff, lambdaMin=lambdaMin, lambdaMax=lambdaMax)
+        filtNew = afwImage.Filter("gNew")
+        self.assertEqual(lambdaMin, filtNew.getFilterProperty().getLambdaMin())
+        self.assertEqual(lambdaMax, filtNew.getFilterProperty().getLambdaMax())
+
     def testFilterAliases(self):
         """Test that we can provide an alias for a Filter"""
         for name0 in self.aliases:

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -246,7 +246,7 @@ class FilterTestCase(lsst.utils.tests.TestCase):
                             lambdaEff in wavelengths.items() if name == "g"][0]  # for tests
 
     def defineFilterProperty(self, name, lambdaEff, force=False):
-        return afwImage.FilterProperty(name, lambdaEff, force)
+        return afwImage.FilterProperty(name, lambdaEff, force=force)
 
     def testListFilters(self):
         self.assertEqual(afwImage.Filter.getNames(), list(self.filters))
@@ -294,7 +294,7 @@ class FilterTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(f.getFilterProperty().getLambdaEff(),
                          self.g_lambdaEff)
         self.assertEqual(f.getFilterProperty(),
-                         self.defineFilterProperty("gX", self.g_lambdaEff, True))
+                         self.defineFilterProperty("gX", self.g_lambdaEff, force=True))
         self.assertEqual(g.getLambdaEff(), self.g_lambdaEff)
 
     def testFilterAliases(self):


### PR DESCRIPTION
This adds additional FilterProperties `lambdaMin` and `lambdaMax`, and should work in a backwards-compatible way. But, I am not confident working with C++, so I would appreciate an extra-careful look at my changes to make sure I haven't messed something up.