### PR TITLE
DM-14072: Add getCutout method to Exposure

### DIFF
--- a/include/lsst/afw/image/Exposure.h
+++ b/include/lsst/afw/image/Exposure.h
@@ -31,6 +31,8 @@
 #include "lsst/daf/base.h"
 #include "lsst/afw/image/MaskedImage.h"
 #include "lsst/afw/image/ExposureInfo.h"
+#include "lsst/geom/Extent.h"
+#include "lsst/geom/SpherePoint.h"
 
 namespace lsst {
 namespace afw {
@@ -390,6 +392,23 @@ public:
     static Exposure readFits(fits::MemFileManager& manager) {
         return Exposure<ImageT, MaskT, VarianceT>(manager);
     }
+
+    /**
+     * Return an Exposure that is a small cutout of the original.
+     *
+     * @param center desired center of cutout (in RA and Dec)
+     * @param size width and height (in that order) of cutout in pixels
+     *
+     * @return An Exposure of the requested size centered on `center` to within
+     *     half a pixel in either dimension. Pixels past the edge of the original
+     *     exposure will be zero.
+     *
+     * @throws lsst::pex::exceptions::LogicError Thrown if this Exposure does
+     *     not have a WCS.
+     * @throws lsst::pex::exceptions::InvalidParameterError Thrown if ``center``
+     *     falls outside this Exposure or if ``size`` is not a valid size.
+     */
+    Exposure getCutout(lsst::geom::SpherePoint const& center, lsst::geom::Extent2I const& size) const;
 
 private:
     LSST_PERSIST_FORMATTER(lsst::afw::formatters::ExposureFormatter<ImageT, MaskT, VarianceT>)

--- a/python/lsst/afw/image/exposure/exposure.cc
+++ b/python/lsst/afw/image/exposure/exposure.cc
@@ -138,6 +138,8 @@ PyExposure<PixelT> declareExposure(py::module &mod, const std::string &suffix) {
     cls.def_static("readFits", (ExposureT(*)(std::string const &))ExposureT::readFits);
     cls.def_static("readFits", (ExposureT(*)(fits::MemFileManager &))ExposureT::readFits);
 
+    cls.def("getCutout", &ExposureT::getCutout, "center"_a, "size"_a);
+
     return cls;
 }
 

--- a/python/lsst/afw/image/exposure/exposure.cc
+++ b/python/lsst/afw/image/exposure/exposure.cc
@@ -65,10 +65,10 @@ PyExposure<PixelT> declareExposure(py::module &mod, const std::string &suffix) {
             "wcs"_a = std::shared_ptr<geom::SkyWcs const>());
 
     /* Constructors */
-    cls.def(py::init<unsigned int, unsigned int, std::shared_ptr<geom::SkyWcs const>>(), "width"_a, "height"_a,
-            "wcs"_a = std::shared_ptr<geom::SkyWcs const>());
-    cls.def(py::init<lsst::geom::Extent2I const &, std::shared_ptr<geom::SkyWcs const>>(), "dimensions"_a = lsst::geom::Extent2I(),
-            "wcs"_a = std::shared_ptr<geom::SkyWcs const>());
+    cls.def(py::init<unsigned int, unsigned int, std::shared_ptr<geom::SkyWcs const>>(), "width"_a,
+            "height"_a, "wcs"_a = std::shared_ptr<geom::SkyWcs const>());
+    cls.def(py::init<lsst::geom::Extent2I const &, std::shared_ptr<geom::SkyWcs const>>(),
+            "dimensions"_a = lsst::geom::Extent2I(), "wcs"_a = std::shared_ptr<geom::SkyWcs const>());
     cls.def(py::init<lsst::geom::Box2I const &, std::shared_ptr<geom::SkyWcs const>>(), "bbox"_a,
             "wcs"_a = std::shared_ptr<geom::SkyWcs const>());
     cls.def(py::init<MaskedImageT &, std::shared_ptr<geom::SkyWcs const>>(), "maskedImage"_a,
@@ -83,13 +83,10 @@ PyExposure<PixelT> declareExposure(py::module &mod, const std::string &suffix) {
             "origin"_a = PARENT, "deep"_a = false);
 
     /* Members */
-    cls.def("getMaskedImage", (MaskedImageT (ExposureT::*)()) & ExposureT::getMaskedImage);
+    cls.def("getMaskedImage", (MaskedImageT(ExposureT::*)()) & ExposureT::getMaskedImage);
     cls.def("setMaskedImage", &ExposureT::setMaskedImage, "maskedImage"_a);
-    cls.def_property(
-        "maskedImage",
-        (MaskedImageT (ExposureT::*)()) & ExposureT::getMaskedImage,
-        &ExposureT::setMaskedImage
-    );
+    cls.def_property("maskedImage", (MaskedImageT(ExposureT::*)()) & ExposureT::getMaskedImage,
+                     &ExposureT::setMaskedImage);
     cls.def("getMetadata", &ExposureT::getMetadata);
     cls.def("setMetadata", &ExposureT::setMetadata, "metadata"_a);
     cls.def("getWidth", &ExposureT::getWidth);
@@ -100,41 +97,42 @@ PyExposure<PixelT> declareExposure(py::module &mod, const std::string &suffix) {
     cls.def("getXY0", &ExposureT::getXY0);
     cls.def("setXY0", &ExposureT::setXY0, "xy0"_a);
     cls.def("getBBox", &ExposureT::getBBox, "origin"_a = PARENT);
-    cls.def("getWcs", (std::shared_ptr<geom::SkyWcs> (ExposureT::*)()) & ExposureT::getWcs);
+    cls.def("getWcs", (std::shared_ptr<geom::SkyWcs>(ExposureT::*)()) & ExposureT::getWcs);
     cls.def("setWcs", &ExposureT::setWcs, "wcs"_a);
     cls.def("hasWcs", &ExposureT::hasWcs);
     cls.def("getDetector", &ExposureT::getDetector);
     cls.def("setDetector", &ExposureT::setDetector, "detector"_a);
     cls.def("getFilter", &ExposureT::getFilter);
     cls.def("setFilter", &ExposureT::setFilter, "filter"_a);
-    cls.def("getCalib", (std::shared_ptr<Calib> (ExposureT::*)()) & ExposureT::getCalib);
+    cls.def("getCalib", (std::shared_ptr<Calib>(ExposureT::*)()) & ExposureT::getCalib);
     cls.def("setCalib", &ExposureT::setCalib, "calib"_a);
-    cls.def("getPsf", (std::shared_ptr<detection::Psf> (ExposureT::*)()) & ExposureT::getPsf);
+    cls.def("getPsf", (std::shared_ptr<detection::Psf>(ExposureT::*)()) & ExposureT::getPsf);
     cls.def("setPsf", &ExposureT::setPsf, "psf"_a);
     cls.def("hasPsf", &ExposureT::hasPsf);
-    cls.def("getInfo", (std::shared_ptr<ExposureInfo> (ExposureT::*)()) & ExposureT::getInfo);
+    cls.def("getInfo", (std::shared_ptr<ExposureInfo>(ExposureT::*)()) & ExposureT::getInfo);
     cls.def("setInfo", &ExposureT::setInfo, "exposureInfo"_a);
 
     cls.def("writeFits", (void (ExposureT::*)(std::string const &) const) & ExposureT::writeFits);
     cls.def("writeFits", (void (ExposureT::*)(fits::MemFileManager &) const) & ExposureT::writeFits);
-    cls.def("writeFits", [](ExposureT & self, fits::Fits &fits) { self.writeFits(fits); });
+    cls.def("writeFits", [](ExposureT &self, fits::Fits &fits) { self.writeFits(fits); });
 
-    cls.def("writeFits", [](ExposureT & self, std::string const& filename,
-                            fits::ImageWriteOptions const& imageOptions,
-                            fits::ImageWriteOptions const& maskOptions,
-                            fits::ImageWriteOptions const& varianceOptions) {
-                                self.writeFits(filename, imageOptions, maskOptions, varianceOptions); },
+    cls.def("writeFits",
+            [](ExposureT &self, std::string const &filename, fits::ImageWriteOptions const &imageOptions,
+               fits::ImageWriteOptions const &maskOptions, fits::ImageWriteOptions const &varianceOptions) {
+                self.writeFits(filename, imageOptions, maskOptions, varianceOptions);
+            },
             "filename"_a, "imageOptions"_a, "maskOptions"_a, "varianceOptions"_a);
-    cls.def("writeFits", [](ExposureT & self, fits::MemFileManager &manager,
-                            fits::ImageWriteOptions const& imageOptions,
-                            fits::ImageWriteOptions const& maskOptions,
-                            fits::ImageWriteOptions const& varianceOptions) {
-                                self.writeFits(manager, imageOptions, maskOptions, varianceOptions); },
+    cls.def("writeFits",
+            [](ExposureT &self, fits::MemFileManager &manager, fits::ImageWriteOptions const &imageOptions,
+               fits::ImageWriteOptions const &maskOptions, fits::ImageWriteOptions const &varianceOptions) {
+                self.writeFits(manager, imageOptions, maskOptions, varianceOptions);
+            },
             "manager"_a, "imageOptions"_a, "maskOptions"_a, "varianceOptions"_a);
-    cls.def("writeFits", [](ExposureT & self, fits::Fits &fits, fits::ImageWriteOptions const& imageOptions,
-                            fits::ImageWriteOptions const& maskOptions,
-                            fits::ImageWriteOptions const& varianceOptions) {
-                                self.writeFits(fits, imageOptions, maskOptions, varianceOptions); },
+    cls.def("writeFits",
+            [](ExposureT &self, fits::Fits &fits, fits::ImageWriteOptions const &imageOptions,
+               fits::ImageWriteOptions const &maskOptions, fits::ImageWriteOptions const &varianceOptions) {
+                self.writeFits(fits, imageOptions, maskOptions, varianceOptions);
+            },
             "fits"_a, "imageOptions"_a, "maskOptions"_a, "varianceOptions"_a);
 
     cls.def_static("readFits", (ExposureT(*)(std::string const &))ExposureT::readFits);
@@ -172,7 +170,7 @@ PYBIND11_PLUGIN(exposure) {
 
     return mod.ptr();
 }
-}
-}
-}
-}  // namespace lsst::afw::image::<anonymous>
+}  // namespace
+}  // namespace image
+}  // namespace afw
+}  // namespace lsst

--- a/src/image/Exposure.cc
+++ b/src/image/Exposure.cc
@@ -22,11 +22,11 @@
  * see <http://www.lsstcorp.org/LegalNotices/>.
  */
 
+#include <memory>
 #include <stdexcept>
+#include <cstdint>
 
 #include "boost/format.hpp"
-#include <memory>
-#include <cstdint>
 #include "boost/algorithm/string/trim.hpp"
 
 #include "lsst/daf/base/PropertySet.h"


### PR DESCRIPTION
This PR adds a method, `Exposure::getCutout`, that returns a fixed-sized image centered on particular sky coordinates. To ensure the image always has the desired size, empty pixels (for coordinates near the edge of an exposure) are allowed.

Note that this implementation does not use the `Box2D` -> `Box2I` conversion suggested by @TallJimbo. That conversion prioritizes keeping particular pixels over keeping the desired size, and correctly clipping the `Box2I` back to the desired size would require complex conditions on the sky coordinates' location within a pixel.