### PR TITLE
DM-14690: Add ability to construct centered boxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ _build.*
 *.dSYM/
 core.*
 .cache/
+.coverage
 .pytest_cache/
 .sconf_temp
 .sconsign.dblite


### PR DESCRIPTION
This PR modifies the implementation of `Exposure::getCutout` to use the `Box2I::makeCenteredBox` factory introduced by lsst/geom#4. However, as a side effect the `getCutout` method became considerably more complex (17 LLOC for input validation plus three logical processing steps); any suggestions on how to break it up would be appreciated.