### PR TITLE
DM-9937: Add noexcept specifiers to applicable methods in afw

### DIFF
--- a/include/lsst/afw/cameraGeom/CameraSys.h
+++ b/include/lsst/afw/cameraGeom/CameraSys.h
@@ -47,20 +47,20 @@ public:
                              )
             : _sysName(sysName) {}
 
-    ~CameraSysPrefix() = default;
+    ~CameraSysPrefix() noexcept = default;
     CameraSysPrefix(CameraSysPrefix const &) = default;
-    CameraSysPrefix(CameraSysPrefix &&) = default;
+    CameraSysPrefix(CameraSysPrefix &&) noexcept = default;
     CameraSysPrefix &operator=(CameraSysPrefix const &) = default;
-    CameraSysPrefix &operator=(CameraSysPrefix &&) = default;
+    CameraSysPrefix &operator=(CameraSysPrefix &&) noexcept = default;
 
     /**
      * Get coordinate system name
      */
     std::string getSysName() const { return _sysName; };
 
-    bool operator==(CameraSysPrefix const &rhs) const { return _sysName == rhs.getSysName(); }
+    bool operator==(CameraSysPrefix const &rhs) const noexcept { return _sysName == rhs.getSysName(); }
 
-    bool operator!=(CameraSysPrefix const &rhs) const { return !(*this == rhs); }
+    bool operator!=(CameraSysPrefix const &rhs) const noexcept { return !(*this == rhs); }
 
     /**
      * Hash function for this object.
@@ -101,11 +101,11 @@ public:
     /// default constructor so SWIG can wrap a vector of pairs containing these
     CameraSys() : _sysName("?"), _detectorName(){};
 
-    ~CameraSys() = default;
+    ~CameraSys() noexcept = default;
     CameraSys(CameraSys const &) = default;
-    CameraSys(CameraSys &&) = default;
+    CameraSys(CameraSys &&) noexcept = default;
     CameraSys &operator=(CameraSys const &) = default;
-    CameraSys &operator=(CameraSys &&) = default;
+    CameraSys &operator=(CameraSys &&) noexcept = default;
 
     /**
      * Get coordinate system name
@@ -120,16 +120,16 @@ public:
     /**
      * Does this have a non-blank detector name?
      */
-    bool hasDetectorName() const { return !_detectorName.empty(); }
+    bool hasDetectorName() const noexcept { return !_detectorName.empty(); }
 
-    bool operator==(CameraSys const &rhs) const {
+    bool operator==(CameraSys const &rhs) const noexcept {
         return _sysName == rhs.getSysName() && _detectorName == rhs.getDetectorName();
     }
 
-    bool operator!=(CameraSys const &rhs) const { return !(*this == rhs); }
+    bool operator!=(CameraSys const &rhs) const noexcept { return !(*this == rhs); }
 
     // less-than operator required for use in std::map
-    bool operator<(CameraSys const &rhs) const {
+    bool operator<(CameraSys const &rhs) const noexcept {
         if (_sysName == rhs.getSysName()) {
             return _detectorName < rhs.getDetectorName();
         } else {

--- a/include/lsst/afw/cameraGeom/Orientation.h
+++ b/include/lsst/afw/cameraGeom/Orientation.h
@@ -65,29 +65,29 @@ public:
                                  0)  ///< roll: rotation about X'' (Y''=Y' to Z''), 3rd rotation
     );
 
-    ~Orientation();
-    Orientation(Orientation const &);
-    Orientation(Orientation &&);
-    Orientation &operator=(Orientation const &);
-    Orientation &operator=(Orientation &&);
+    ~Orientation() noexcept;
+    Orientation(Orientation const &) noexcept;
+    Orientation(Orientation &&) noexcept;
+    Orientation &operator=(Orientation const &) noexcept;
+    Orientation &operator=(Orientation &&) noexcept;
 
     /// Return focal plane position of detector reference point (mm)
-    lsst::geom::Point2D getFpPosition() const { return _fpPosition; }
+    lsst::geom::Point2D getFpPosition() const noexcept { return _fpPosition; }
 
     /// Return detector reference point (pixels)
-    lsst::geom::Point2D getReferencePoint() const { return _refPoint; }
+    lsst::geom::Point2D getReferencePoint() const noexcept { return _refPoint; }
 
     /// Return the yaw angle
-    lsst::geom::Angle getYaw() const { return _yaw; }
+    lsst::geom::Angle getYaw() const noexcept { return _yaw; }
 
     /// Return the pitch angle
-    lsst::geom::Angle getPitch() const { return _pitch; }
+    lsst::geom::Angle getPitch() const noexcept { return _pitch; }
 
     /// Return the roll angle
-    lsst::geom::Angle getRoll() const { return _roll; }
+    lsst::geom::Angle getRoll() const noexcept { return _roll; }
 
     /// Return the number of quarter turns (rounded to the closest quarter)
-    int getNQuarter() const;
+    int getNQuarter() const noexcept;
 
     /**
      * Generate a Transform from pixel to focal plane coordinates

--- a/include/lsst/afw/coord/Coord.h
+++ b/include/lsst/afw/coord/Coord.h
@@ -27,16 +27,9 @@
 /*
  * Functions to handle coordinates
  */
-#include <iostream>
-#include <limits>
-#include <map>
-#include <memory>
+#include <string>
 
-#include "lsst/base.h"
-#include "lsst/geom/Point.h"
 #include "lsst/geom/Angle.h"
-#include "lsst/afw/coord/Observatory.h"
-#include "lsst/daf/base.h"
 
 namespace lsst {
 namespace afw {

--- a/include/lsst/afw/coord/Observatory.h
+++ b/include/lsst/afw/coord/Observatory.h
@@ -59,11 +59,11 @@ public:
      */
     Observatory(std::string const& longitude, std::string const& latitude, double const elevation);
 
-    ~Observatory();
-    Observatory(Observatory const&);
-    Observatory(Observatory&&);
-    Observatory& operator=(Observatory const&);
-    Observatory& operator=(Observatory&&);
+    ~Observatory() noexcept;
+    Observatory(Observatory const&) noexcept;
+    Observatory(Observatory&&) noexcept;
+    Observatory& operator=(Observatory const&) noexcept;
+    Observatory& operator=(Observatory&&) noexcept;
 
     /// set telescope longitude
     void setLongitude(lsst::geom::Angle const longitude);
@@ -73,11 +73,11 @@ public:
     void setElevation(double const elevation);
 
     /// get telescope longitude (positive values are E of Greenwich)
-    lsst::geom::Angle getLongitude() const;
+    lsst::geom::Angle getLongitude() const noexcept;
     /// get telescope latitude
-    lsst::geom::Angle getLatitude() const;
+    lsst::geom::Angle getLatitude() const noexcept;
     /// get telescope elevation (meters above reference spheroid)
-    double getElevation() const { return _elevation; }
+    double getElevation() const noexcept { return _elevation; }
 
     /// get telescope longitude as a dd:mm:ss.s string (positive values are E of Greenwich)
     std::string getLongitudeStr() const;
@@ -86,13 +86,13 @@ public:
     /// get string representation
     std::string toString() const;
 
-    bool operator==(Observatory const& rhs) const {
+    bool operator==(Observatory const& rhs) const noexcept {
         auto deltaLongitude = (_latitude - rhs.getLatitude()).wrapCtr();
         auto deltaLatitude = (_longitude - rhs.getLongitude()).wrapCtr();
         return (deltaLongitude == 0.0 * lsst::geom::degrees) &&
                (deltaLatitude == 0.0 * lsst::geom::degrees) && ((_elevation - rhs._elevation) == 0.0);
     }
-    bool operator!=(Observatory const& rhs) const { return !(*this == rhs); }
+    bool operator!=(Observatory const& rhs) const noexcept { return !(*this == rhs); }
 
 private:
     lsst::geom::Angle _latitude;

--- a/include/lsst/afw/coord/Weather.h
+++ b/include/lsst/afw/coord/Weather.h
@@ -47,24 +47,24 @@ public:
      */
     explicit Weather(double airTemperature, double airPressure, double humidity);
 
-    ~Weather() = default;
+    ~Weather() noexcept = default;
 
-    Weather(Weather const &) = default;
-    Weather(Weather &&) = default;
-    Weather &operator=(Weather const &) = default;
-    Weather &operator=(Weather &&) = default;
+    Weather(Weather const &) noexcept = default;
+    Weather(Weather &&) noexcept = default;
+    Weather &operator=(Weather const &) noexcept = default;
+    Weather &operator=(Weather &&) noexcept = default;
 
-    bool operator==(Weather const &other) const;
-    bool operator!=(Weather const &other) const { return !(*this == other); }
+    bool operator==(Weather const &other) const noexcept;
+    bool operator!=(Weather const &other) const noexcept { return !(*this == other); }
 
     /// get outside air temperature (C)
-    double getAirTemperature() const { return _airTemperature; };
+    double getAirTemperature() const noexcept { return _airTemperature; };
 
     /// get outside air pressure (Pascal)
-    double getAirPressure() const { return _airPressure; };
+    double getAirPressure() const noexcept { return _airPressure; };
 
     /// get outside relative humidity (%)
-    double getHumidity() const { return _humidity; };
+    double getHumidity() const noexcept { return _humidity; };
 
 private:
     double _airTemperature;  ///< air temperature (C)

--- a/include/lsst/afw/detection/Footprint.h
+++ b/include/lsst/afw/detection/Footprint.h
@@ -283,7 +283,7 @@ public:
     /**
      * Report if this object is persistable
      */
-    bool isPersistable() const override { return true; }
+    bool isPersistable() const noexcept override { return true; }
 
     /**
      * Dilate the Footprint with a defined kernel

--- a/include/lsst/afw/detection/FootprintSet.h
+++ b/include/lsst/afw/detection/FootprintSet.h
@@ -137,7 +137,7 @@ public:
     FootprintSet& operator=(FootprintSet const& rhs);
     FootprintSet& operator=(FootprintSet&& rhs);
 
-    void swap(FootprintSet& rhs) {
+    void swap(FootprintSet& rhs) noexcept {
         using std::swap;  // See Meyers, Effective C++, Item 25
         swap(*_footprints, *rhs.getFootprints());
         lsst::geom::Box2I rhsRegion = rhs.getRegion();
@@ -145,7 +145,7 @@ public:
         setRegion(rhsRegion);
     }
 
-    void swapFootprintList(FootprintList& rhs) {
+    void swapFootprintList(FootprintList& rhs) noexcept {
         using std::swap;
         swap(*_footprints, rhs);
     }

--- a/include/lsst/afw/detection/GaussianPsf.h
+++ b/include/lsst/afw/detection/GaussianPsf.h
@@ -77,7 +77,7 @@ public:
     double getSigma() const { return _sigma; }
 
     /// Whether the Psf is persistable; always true.
-    virtual bool isPersistable() const { return true; }
+    virtual bool isPersistable() const noexcept override { return true; }
 
 protected:
     virtual std::string getPersistenceName() const;

--- a/include/lsst/afw/detection/Threshold.h
+++ b/include/lsst/afw/detection/Threshold.h
@@ -61,14 +61,14 @@ public:
               )
             : _value(value), _type(type), _polarity(polarity), _includeMultiplier(includeMultiplier) {}
 
-    ~Threshold() = default;
-    Threshold(Threshold const &) = default;
-    Threshold(Threshold &&) = default;
-    Threshold &operator=(Threshold const &) = default;
-    Threshold &operator=(Threshold &&) = default;
+    ~Threshold() noexcept = default;
+    Threshold(Threshold const &) noexcept = default;
+    Threshold(Threshold &&) noexcept = default;
+    Threshold &operator=(Threshold const &) noexcept = default;
+    Threshold &operator=(Threshold &&) noexcept = default;
 
     /// return type of threshold
-    ThresholdType getType() const { return _type; }
+    ThresholdType getType() const noexcept { return _type; }
 
     static ThresholdType parseTypeString(std::string const &typeStr);
     static std::string getTypeString(ThresholdType const &type);
@@ -89,15 +89,15 @@ public:
     double getValue(ImageT const &image) const;
 
     /// return Threshold's polarity
-    bool getPolarity() const { return _polarity; }
+    bool getPolarity() const noexcept { return _polarity; }
     /// set Threshold's polarity
     void setPolarity(bool const polarity  ///< desired polarity
-    ) {
+                     ) noexcept {
         _polarity = polarity;
     }
 
     /// return includeMultiplier
-    double getIncludeMultiplier() const { return _includeMultiplier; }
+    double getIncludeMultiplier() const noexcept { return _includeMultiplier; }
     /// set includeMultiplier
     void setIncludeMultiplier(double const includeMultiplier  ///< desired multiplier
     ) {

--- a/include/lsst/afw/geom/SkyWcs.h
+++ b/include/lsst/afw/geom/SkyWcs.h
@@ -263,7 +263,7 @@ public:
      */
     bool isFlipped() const;
 
-    bool isPersistable() const override { return true; }
+    bool isPersistable() const noexcept override { return true; }
 
     /**
      * Return the local linear approximation to pixelToSky at a point given in sky coordinates.

--- a/include/lsst/afw/geom/Span.h
+++ b/include/lsst/afw/geom/Span.h
@@ -62,49 +62,51 @@ public:
             : _y(y), _x0(x0), _x1(x1) {}
 
     /// Construct an empty Span with zero width at the origin.
-    Span() : _y(0), _x0(0), _x1(-1) {}
+    Span() noexcept : _y(0), _x0(0), _x1(-1) {}
 
-    Span(Span const&) = default;
-    Span(Span&&) = default;
-    Span& operator=(Span const&) = default;
-    Span& operator=(Span&&) = default;
-    ~Span() = default;
+    Span(Span const&) noexcept = default;
+    Span(Span&&) noexcept = default;
+    Span& operator=(Span const&) noexcept = default;
+    Span& operator=(Span&&) noexcept = default;
+    ~Span() noexcept = default;
 
     /// Return an iterator to the first pixel in the Span.
-    Iterator begin() const { return Iterator(lsst::geom::Point2I(_x0, _y)); }
+    Iterator begin() const noexcept { return Iterator(lsst::geom::Point2I(_x0, _y)); }
 
     /// Return an iterator to one past the last pixel in the Span.
-    Iterator end() const { return Iterator(lsst::geom::Point2I(_x1 + 1, _y)); }
+    Iterator end() const noexcept { return Iterator(lsst::geom::Point2I(_x1 + 1, _y)); }
 
-    int getX0() const { return _x0; }               ///< Return the starting x-value
-    int& getX0() { return _x0; }                    ///< Return the starting x-value
-    int getX1() const { return _x1; }               ///< Return the ending x-value
-    int& getX1() { return _x1; }                    ///< Return the ending x-value
-    int getY() const { return _y; }                 ///< Return the y-value
-    int& getY() { return _y; }                      ///< Return the y-value
-    int getWidth() const { return _x1 - _x0 + 1; }  ///< Return the number of pixels
-    int getMinX() const { return _x0; }             ///< Minimum x-value.
-    int getMaxX() const { return _x1; }             ///< Maximum x-value.
-    int getBeginX() const { return _x0; }           ///< Begin (inclusive) x-value.
-    int getEndX() const { return _x1 + 1; }         ///< End (exclusive) x-value.
-    lsst::geom::Point2I const getMin() const {
+    int getX0() const noexcept { return _x0; }               ///< Return the starting x-value
+    int& getX0() noexcept { return _x0; }                    ///< Return the starting x-value
+    int getX1() const noexcept { return _x1; }               ///< Return the ending x-value
+    int& getX1() noexcept { return _x1; }                    ///< Return the ending x-value
+    int getY() const noexcept { return _y; }                 ///< Return the y-value
+    int& getY() noexcept { return _y; }                      ///< Return the y-value
+    int getWidth() const noexcept { return _x1 - _x0 + 1; }  ///< Return the number of pixels
+    int getMinX() const noexcept { return _x0; }             ///< Minimum x-value.
+    int getMaxX() const noexcept { return _x1; }             ///< Maximum x-value.
+    int getBeginX() const noexcept { return _x0; }           ///< Begin (inclusive) x-value.
+    int getEndX() const noexcept { return _x1 + 1; }         ///< End (exclusive) x-value.
+    lsst::geom::Point2I const getMin() const noexcept {
         return lsst::geom::Point2I(_x0, _y);
     }  ///< Point corresponding to minimum x.
-    lsst::geom::Point2I const getMax() const {
+    lsst::geom::Point2I const getMax() const noexcept {
         return lsst::geom::Point2I(_x1, _y);
     }  ///< Point corresponding to maximum x.
 
-    bool contains(int x) const { return (x >= _x0) && (x <= _x1); }
-    bool contains(int x, int y) const { return (x >= _x0) && (x <= _x1) && (y == _y); }
-    bool contains(lsst::geom::Point2I const& point) const { return contains(point.getX(), point.getY()); }
+    bool contains(int x) const noexcept { return (x >= _x0) && (x <= _x1); }
+    bool contains(int x, int y) const noexcept { return (x >= _x0) && (x <= _x1) && (y == _y); }
+    bool contains(lsst::geom::Point2I const& point) const noexcept {
+        return contains(point.getX(), point.getY());
+    }
 
     /// Return true if the span contains no pixels.
-    bool isEmpty() const { return _x1 < _x0; }
+    bool isEmpty() const noexcept { return _x1 < _x0; }
 
     /// Return a string-representation of a Span
     std::string toString() const;
 
-    void shift(int dx, int dy) {
+    void shift(int dx, int dy) noexcept {
         _x0 += dx;
         _x1 += dx;
         _y += dy;
@@ -113,16 +115,16 @@ public:
     /// Stream output; delegates to toString().
     friend std::ostream& operator<<(std::ostream& os, Span const& span) { return os << span.toString(); }
 
-    bool operator==(Span const& other) const {
+    bool operator==(Span const& other) const noexcept {
         return other.getY() == getY() && other.getMinX() == getMinX() && other.getMaxX() == getMaxX();
     }
-    bool operator!=(Span const& other) const { return !(*this == other); }
+    bool operator!=(Span const& other) const noexcept { return !(*this == other); }
 
     /* Required to make Span "LessThanComparable" so they can be used
      * in sorting, binary search, etc.
      * http://www.sgi.com/tech/stl/LessThanComparable.html
      */
-    bool operator<(const Span& b) const;
+    bool operator<(const Span& b) const noexcept;
 
     friend class detection::Footprint;
 

--- a/include/lsst/afw/geom/SpanPixelIterator.h
+++ b/include/lsst/afw/geom/SpanPixelIterator.h
@@ -42,13 +42,13 @@ namespace geom {
 class SpanPixelIterator : public boost::iterator_facade<SpanPixelIterator, lsst::geom::Point2I const,
                                                         boost::random_access_traversal_tag> {
 public:
-    explicit SpanPixelIterator(lsst::geom::Point2I const& p = lsst::geom::Point2I()) : _p(p) {}
+    explicit SpanPixelIterator(lsst::geom::Point2I const& p = lsst::geom::Point2I()) noexcept : _p(p) {}
 
-    SpanPixelIterator(SpanPixelIterator const&) = default;
-    SpanPixelIterator(SpanPixelIterator&&) = default;
-    SpanPixelIterator& operator=(SpanPixelIterator const&) = default;
-    SpanPixelIterator& operator=(SpanPixelIterator&&) = default;
-    ~SpanPixelIterator() = default;
+    SpanPixelIterator(SpanPixelIterator const&) noexcept = default;
+    SpanPixelIterator(SpanPixelIterator&&) noexcept = default;
+    SpanPixelIterator& operator=(SpanPixelIterator const&) noexcept = default;
+    SpanPixelIterator& operator=(SpanPixelIterator&&) noexcept = default;
+    ~SpanPixelIterator() noexcept = default;
 
 private:
     friend class boost::iterator_core_access;

--- a/include/lsst/afw/geom/SpanSet.h
+++ b/include/lsst/afw/geom/SpanSet.h
@@ -706,7 +706,7 @@ public:
      */
     std::vector<std::shared_ptr<geom::SpanSet>> split() const;
 
-    bool isPersistable() const override { return true; }
+    bool isPersistable() const noexcept override { return true; }
 
     /**
      * Select pixels within the SpanSet which touch its edge

--- a/include/lsst/afw/geom/Transform.h
+++ b/include/lsst/afw/geom/Transform.h
@@ -262,7 +262,7 @@ public:
     std::string writeString() const;
 
     /// Whether the Transform is persistable via afw::table::io (always true).
-    bool isPersistable() const override { return true; }
+    bool isPersistable() const noexcept override { return true; }
 
 protected:
     /**

--- a/include/lsst/afw/geom/polygon/Polygon.h
+++ b/include/lsst/afw/geom/polygon/Polygon.h
@@ -98,7 +98,7 @@ public:
     //@}
 
     /// Swap two polygons
-    void swap(Polygon& other) { std::swap(this->_impl, other._impl); }
+    void swap(Polygon& other) noexcept { std::swap(this->_impl, other._impl); }
 
     /// Return number of edges
     ///

--- a/include/lsst/afw/geom/polygon/Polygon.h
+++ b/include/lsst/afw/geom/polygon/Polygon.h
@@ -248,7 +248,7 @@ public:
 
     //@{
     /// Whether Polygon is persistable which is always true
-    virtual bool isPersistable() const { return true; }
+    virtual bool isPersistable() const noexcept override { return true; }
 
 protected:
     virtual std::string getPersistenceName() const;

--- a/include/lsst/afw/image/ApCorrMap.h
+++ b/include/lsst/afw/image/ApCorrMap.h
@@ -74,7 +74,7 @@ public:
     void set(std::string const& name, std::shared_ptr<math::BoundedField> field);
 
     /// Whether the map is persistable (true IFF all contained BoundedFields are persistable).
-    virtual bool isPersistable() const;
+    virtual bool isPersistable() const noexcept override;
 
     /// Scale all fields by a constant
     ApCorrMap& operator*=(double const scale);

--- a/include/lsst/afw/image/Calib.h
+++ b/include/lsst/afw/image/Calib.h
@@ -63,10 +63,10 @@ inline double abMagErrFromFluxErr(double fluxErr, double flux) {
 }
 
 /// Compute flux in Janskys from AB magnitude
-inline double fluxFromABMag(double mag) { return std::pow(10.0, -0.4 * mag) * JanskysPerABFlux; }
+inline double fluxFromABMag(double mag) noexcept { return std::pow(10.0, -0.4 * mag) * JanskysPerABFlux; }
 
 /// Compute flux error in Janskys from AB magnitude error and AB magnitude
-inline double fluxErrFromABMagErr(double magErr, double mag) {
+inline double fluxErrFromABMagErr(double magErr, double mag) noexcept {
     return std::abs(-0.4 * magErr * fluxFromABMag(mag) * std::log(10.0));
 }
 
@@ -97,7 +97,7 @@ public:
     /**
      * ctor
      */
-    explicit Calib();
+    explicit Calib() noexcept;
     /**
      * ctor from a given fluxMagnitude zero point
      */
@@ -115,11 +115,11 @@ public:
      */
     explicit Calib(std::shared_ptr<lsst::daf::base::PropertySet const>);
 
-    Calib(Calib const&);
-    Calib(Calib&&);
-    Calib& operator=(Calib const&);
-    Calib& operator=(Calib&&);
-    virtual ~Calib();
+    Calib(Calib const&) noexcept;
+    Calib(Calib&&) noexcept;
+    Calib& operator=(Calib const&) noexcept;
+    Calib& operator=(Calib&&) noexcept;
+    virtual ~Calib() noexcept;
 
     /**
      * Set the flux of a zero-magnitude object
@@ -185,18 +185,18 @@ public:
      *
      * @param raiseException Should the exception be raised?
      */
-    static void setThrowOnNegativeFlux(bool raiseException);
+    static void setThrowOnNegativeFlux(bool raiseException) noexcept;
     /**
      * Tell me whether Calib will throw an exception if asked to convert a flux to a magnitude
      */
-    static bool getThrowOnNegativeFlux();
+    static bool getThrowOnNegativeFlux() noexcept;
     /**
      * Are two Calibs identical?
      *
      * @note Maybe this should be an approximate comparison
      */
-    bool operator==(Calib const& rhs) const;
-    bool operator!=(Calib const& rhs) const { return !(*this == rhs); }
+    bool operator==(Calib const& rhs) const noexcept;
+    bool operator!=(Calib const& rhs) const noexcept { return !(*this == rhs); }
 
     Calib& operator*=(double const scale);
     Calib& operator/=(double const scale) {

--- a/include/lsst/afw/image/Calib.h
+++ b/include/lsst/afw/image/Calib.h
@@ -204,7 +204,7 @@ public:
         return *this;
     }
 
-    bool isPersistable() const { return true; }
+    bool isPersistable() const noexcept override { return true; }
 
 protected:
     virtual std::string getPersistenceName() const;

--- a/include/lsst/afw/image/CoaddInputs.h
+++ b/include/lsst/afw/image/CoaddInputs.h
@@ -76,7 +76,7 @@ public:
      *  To avoid letting coadd provenance prevent coadd code from running, if a nested Wcs or
      *  Psf is not persistable, it will silently not be saved, instead of throwing an exception.
      */
-    virtual bool isPersistable() const;
+    virtual bool isPersistable() const noexcept override;
 
 protected:
     virtual std::string getPersistenceName() const;

--- a/include/lsst/afw/image/Color.h
+++ b/include/lsst/afw/image/Color.h
@@ -31,10 +31,10 @@ public:
     Color(Color &&) = default;
     Color &operator=(Color const &) = default;
     Color &operator=(Color &&) = default;
-    ~Color() = default;
+    ~Color() noexcept = default;
 
     /// Whether the color is the special value that indicates that it is unspecified.
-    bool isIndeterminate() const { return std::isnan(_g_r); }
+    bool isIndeterminate() const noexcept { return std::isnan(_g_r); }
 
     //@{
     /**
@@ -47,10 +47,10 @@ public:
      *  we'd have to define some kind of "color difference" matric, and it's not worthwhile doing
      *  that yet.
      */
-    bool operator==(Color const &other) const {
+    bool operator==(Color const &other) const noexcept {
         return (isIndeterminate() && other.isIndeterminate()) || other._g_r == _g_r;
     }
-    bool operator!=(Color const &other) const { return !operator==(other); }
+    bool operator!=(Color const &other) const noexcept { return !operator==(other); }
     //@}
 
     /** Return the effective wavelength for this object in the given filter

--- a/include/lsst/afw/image/Defect.h
+++ b/include/lsst/afw/image/Defect.h
@@ -43,19 +43,19 @@ public:
     explicit DefectBase(const lsst::geom::Box2I& bbox  ///< Bad pixels' bounding box
                         )
             : _bbox(bbox) {}
-    DefectBase(DefectBase const&) = default;
-    DefectBase(DefectBase&&) = default;
-    DefectBase& operator=(DefectBase const&) = default;
-    DefectBase& operator=(DefectBase&&) = default;
-    virtual ~DefectBase() = default;
+    DefectBase(DefectBase const&) noexcept = default;
+    DefectBase(DefectBase&&) noexcept = default;
+    DefectBase& operator=(DefectBase const&) noexcept = default;
+    DefectBase& operator=(DefectBase&&) noexcept = default;
+    virtual ~DefectBase() noexcept = default;
 
-    lsst::geom::Box2I const& getBBox() const { return _bbox; }  ///< Return the Defect's bounding box
-    int getX0() const { return _bbox.getMinX(); }               ///< Return the Defect's left column
-    int getX1() const { return _bbox.getMaxX(); }               ///< Return the Defect's right column
-    int getY0() const { return _bbox.getMinY(); }               ///< Return the Defect's bottom row
-    int getY1() const { return _bbox.getMaxY(); }               ///< Return the Defect's top row
+    lsst::geom::Box2I const& getBBox() const noexcept { return _bbox; }  ///< Return the Defect's bounding box
+    int getX0() const noexcept { return _bbox.getMinX(); }               ///< Return the Defect's left column
+    int getX1() const noexcept { return _bbox.getMaxX(); }               ///< Return the Defect's right column
+    int getY0() const noexcept { return _bbox.getMinY(); }               ///< Return the Defect's bottom row
+    int getY1() const noexcept { return _bbox.getMaxY(); }               ///< Return the Defect's top row
 
-    void clip(lsst::geom::Box2I const& bbox) { _bbox.clip(bbox); }
+    void clip(lsst::geom::Box2I const& bbox) noexcept { _bbox.clip(bbox); }
 
     /**
      * Offset a Defect by `(dx, dy)`

--- a/include/lsst/afw/image/Filter.h
+++ b/include/lsst/afw/image/Filter.h
@@ -79,38 +79,38 @@ public:
                             bool force = false);
 
     FilterProperty(FilterProperty const&) = default;
-    FilterProperty(FilterProperty&&) = default;
+    FilterProperty(FilterProperty&&) noexcept = default;
     FilterProperty& operator=(FilterProperty const&) = default;
-    FilterProperty& operator=(FilterProperty&&) = default;
-    ~FilterProperty() = default;
+    FilterProperty& operator=(FilterProperty&&) noexcept = default;
+    ~FilterProperty() noexcept = default;
 
     /**
      * Return a filter's name
      */
-    std::string const& getName() const { return _name; }
+    std::string const& getName() const noexcept { return _name; }
     /**
      * Return the filter's effective wavelength (nm)
      */
-    double getLambdaEff() const { return _lambdaEff; }
+    double getLambdaEff() const noexcept { return _lambdaEff; }
     /**
      * Return the filter's minimum wavelength (nm) where the transmission is above 1% of the maximum.
      */
-    double getLambdaMin() const { return _lambdaMin; }
+    double getLambdaMin() const noexcept { return _lambdaMin; }
     /**
      * Return the filter's maximum wavelength (nm) where the transmission is above 1% of the maximum.
      */
-    double getLambdaMax() const { return _lambdaMax; }
+    double getLambdaMax() const noexcept { return _lambdaMax; }
     /**
      * Return true iff two FilterProperties are identical
      *
      * @param rhs Object to compare with this
      */
-    bool operator==(FilterProperty const& rhs) const;
+    bool operator==(FilterProperty const& rhs) const noexcept;
     /**
      * Return true iff rhs != this
      */
     bool operator!=(FilterProperty const& rhs  ///< Object to compare with this
-                    ) const {
+                    ) const noexcept {
         return !(*this == rhs);
     }
     /**
@@ -177,25 +177,25 @@ public:
     explicit Filter(std::shared_ptr<lsst::daf::base::PropertySet const> metadata, bool const force = false);
 
     Filter(Filter const&) = default;
-    Filter(Filter&&) = default;
+    Filter(Filter&&) noexcept = default;
     Filter& operator=(Filter const&) = default;
-    Filter& operator=(Filter&&) = default;
-    ~Filter() = default;
+    Filter& operator=(Filter&&) noexcept = default;
+    ~Filter() noexcept = default;
 
     /**
      * Are two filters identical?
      */
-    bool operator==(Filter const& rhs) const;
-    bool operator!=(Filter const& rhs) const { return !(*this == rhs); }
+    bool operator==(Filter const& rhs) const noexcept;
+    bool operator!=(Filter const& rhs) const noexcept { return !(*this == rhs); }
 
     /**
      * Return a Filter's integral id
      */
-    int getId() const { return _id; }
+    int getId() const noexcept { return _id; }
     /**
      * Return a Filter's name
      */
-    std::string const& getName() const { return _name; }
+    std::string const& getName() const noexcept { return _name; }
     /**
      * Return a filter's canonical name
      *

--- a/include/lsst/afw/image/PhotoCalib.h
+++ b/include/lsst/afw/image/PhotoCalib.h
@@ -396,7 +396,7 @@ public:
     /// @copydoc operator==
     bool operator!=(PhotoCalib const &rhs) const { return !(*this == rhs); }
 
-    bool isPersistable() const { return true; }
+    bool isPersistable() const noexcept override { return true; }
 
     friend std::ostream &operator<<(std::ostream &os, PhotoCalib const &photoCalib);
 

--- a/include/lsst/afw/image/VisitInfo.h
+++ b/include/lsst/afw/image/VisitInfo.h
@@ -164,7 +164,7 @@ public:
     /// get basic weather information
     coord::Weather getWeather() const { return _weather; }
 
-    bool isPersistable() const { return true; }
+    bool isPersistable() const noexcept override { return true; }
 
     // get the local sidereal time on the meridian (equivalent, but not equal, to Local Mean Sidereal Time)
     lsst::geom::Angle getLocalEra() const;

--- a/include/lsst/afw/math/ChebyshevBoundedField.h
+++ b/include/lsst/afw/math/ChebyshevBoundedField.h
@@ -202,7 +202,7 @@ public:
     virtual double mean() const;
 
     /// ChebyshevBoundedField is always persistable.
-    virtual bool isPersistable() const { return true; }
+    virtual bool isPersistable() const noexcept override { return true; }
 
     /// @copydoc BoundedField::operator*
     virtual std::shared_ptr<BoundedField> operator*(double const scale) const;

--- a/include/lsst/afw/math/Function.h
+++ b/include/lsst/afw/math/Function.h
@@ -49,6 +49,14 @@ namespace math {
 
 using boost::serialization::make_nvp;
 
+/** Test that a Function's return value is nothrow-castable to T
+ *
+ * std::complex is an example of a numeric type that does not satisfy
+ * this requirement.
+ */
+template <typename T>
+bool constexpr IS_NOTHROW_INIT = noexcept(static_cast<T>(1.0));
+
 /**
  * Basic Function class.
  *
@@ -102,14 +110,14 @@ public:
     Function& operator=(Function const&) = default;
     Function& operator=(Function&&) = default;
 
-    virtual ~Function() = default;
+    virtual ~Function() noexcept = default;
 
     /**
      * Return the number of function parameters
      *
      * @returns the number of function parameters
      */
-    unsigned int getNParameters() const { return _params.size(); }
+    unsigned int getNParameters() const noexcept { return _params.size(); }
 
     /**
      * Get one function parameter without range checking
@@ -126,7 +134,7 @@ public:
      *
      * @returns the function parameters as a vector
      */
-    std::vector<double> const& getParameters() const { return _params; }
+    std::vector<double> const& getParameters() const noexcept { return _params; }
 
     /**
      * Is the function a linear combination of its parameters?
@@ -135,7 +143,7 @@ public:
      *
      * @warning: subclasses must override if true.
      */
-    virtual bool isLinearCombination() const { return false; }
+    virtual bool isLinearCombination() const noexcept { return false; }
 
     /**
      * Set one function parameter without range checking
@@ -227,7 +235,7 @@ public:
     Function1& operator=(Function1 const&) = default;
     Function1& operator=(Function1&&) = default;
 
-    virtual ~Function1() = default;
+    virtual ~Function1() noexcept = default;
 
     /**
      * Return a pointer to a deep copy of this function
@@ -293,7 +301,7 @@ public:
     Function2& operator=(Function2 const&) = default;
     Function2& operator=(Function2&&) = default;
 
-    virtual ~Function2() = default;
+    virtual ~Function2() noexcept = default;
 
     /**
      * Return a pointer to a deep copy of this function
@@ -373,14 +381,14 @@ public:
     BasePolynomialFunction2& operator=(BasePolynomialFunction2 const&) = default;
     BasePolynomialFunction2& operator=(BasePolynomialFunction2&&) = default;
 
-    virtual ~BasePolynomialFunction2() = default;
+    virtual ~BasePolynomialFunction2() noexcept = default;
 
     /**
      * Get the polynomial order
      */
-    int getOrder() const { return _order; }
+    int getOrder() const noexcept { return _order; }
 
-    virtual bool isLinearCombination() const { return true; }
+    virtual bool isLinearCombination() const noexcept { return true; }
 
     /**
      * Compute number of parameters from polynomial order.
@@ -475,7 +483,7 @@ public:
     }
 
 private:
-    ReturnT operator()(double) const { return static_cast<ReturnT>(0); }
+    ReturnT operator()(double) const noexcept(IS_NOTHROW_INIT<ReturnT>) { return static_cast<ReturnT>(0); }
 
 private:
     friend class boost::serialization::access;
@@ -497,7 +505,9 @@ public:
     }
 
 private:
-    ReturnT operator()(double, double) const { return static_cast<ReturnT>(0); }
+    ReturnT operator()(double, double) const noexcept(IS_NOTHROW_INIT<ReturnT>) {
+        return static_cast<ReturnT>(0);
+    }
 
 private:
     friend class boost::serialization::access;

--- a/include/lsst/afw/math/FunctionLibrary.h
+++ b/include/lsst/afw/math/FunctionLibrary.h
@@ -266,7 +266,7 @@ public:
         return os.str();
     }
 
-    virtual bool isPersistable() const { return true; }
+    virtual bool isPersistable() const noexcept override { return true; }
 
 protected:
     virtual std::string getPersistenceName() const;
@@ -379,7 +379,7 @@ public:
         return os.str();
     }
 
-    virtual bool isPersistable() const { return true; }
+    virtual bool isPersistable() const noexcept override { return true; }
 
 protected:
     virtual std::string getPersistenceName() const;
@@ -594,7 +594,7 @@ public:
         return os.str();
     }
 
-    virtual bool isPersistable() const { return true; }
+    virtual bool isPersistable() const noexcept override { return true; }
 
 protected:
     virtual std::string getPersistenceName() const;
@@ -929,7 +929,7 @@ public:
         return os.str();
     }
 
-    virtual bool isPersistable() const { return true; }
+    virtual bool isPersistable() const noexcept override { return true; }
 
 protected:
     virtual std::string getPersistenceName() const;

--- a/include/lsst/afw/math/FunctionLibrary.h
+++ b/include/lsst/afw/math/FunctionLibrary.h
@@ -54,7 +54,7 @@ template <typename ReturnT>
 class IntegerDeltaFunction1 : public Function1<ReturnT> {
 public:
     /**
-     * Construct an integer delta function with specified xo, yo
+     * Construct an integer delta function with specified xo
      */
     explicit IntegerDeltaFunction1(double xo) : Function1<ReturnT>(0), _xo(xo) {}
 
@@ -62,13 +62,15 @@ public:
     IntegerDeltaFunction1(IntegerDeltaFunction1&&) = default;
     IntegerDeltaFunction1& operator=(IntegerDeltaFunction1 const&) = default;
     IntegerDeltaFunction1& operator=(IntegerDeltaFunction1&&) = default;
-    virtual ~IntegerDeltaFunction1() = default;
+    virtual ~IntegerDeltaFunction1() noexcept = default;
 
     virtual std::shared_ptr<Function1<ReturnT>> clone() const {
         return std::shared_ptr<Function1<ReturnT>>(new IntegerDeltaFunction1(_xo));
     }
 
-    virtual ReturnT operator()(double x) const { return static_cast<ReturnT>(x == _xo); }
+    virtual ReturnT operator()(double x) const noexcept(IS_NOTHROW_INIT<ReturnT>) {
+        return static_cast<ReturnT>(x == _xo);
+    }
 
     virtual std::string toString(std::string const& prefix = "") const {
         std::ostringstream os;
@@ -115,13 +117,13 @@ public:
     IntegerDeltaFunction2(IntegerDeltaFunction2&&) = default;
     IntegerDeltaFunction2& operator=(IntegerDeltaFunction2 const&) = default;
     IntegerDeltaFunction2& operator=(IntegerDeltaFunction2&&) = default;
-    virtual ~IntegerDeltaFunction2() = default;
+    virtual ~IntegerDeltaFunction2() noexcept = default;
 
     virtual std::shared_ptr<Function2<ReturnT>> clone() const {
         return std::shared_ptr<Function2<ReturnT>>(new IntegerDeltaFunction2(_xo, _yo));
     }
 
-    virtual ReturnT operator()(double x, double y) const {
+    virtual ReturnT operator()(double x, double y) const noexcept(IS_NOTHROW_INIT<ReturnT>) {
         return static_cast<ReturnT>((x == _xo) && (y == _yo));
     }
 
@@ -174,13 +176,13 @@ public:
     GaussianFunction1(GaussianFunction1&&) = default;
     GaussianFunction1& operator=(GaussianFunction1 const&) = default;
     GaussianFunction1& operator=(GaussianFunction1&&) = default;
-    virtual ~GaussianFunction1() = default;
+    virtual ~GaussianFunction1() noexcept = default;
 
     virtual std::shared_ptr<Function1<ReturnT>> clone() const {
         return std::shared_ptr<Function1<ReturnT>>(new GaussianFunction1(this->_params[0]));
     }
 
-    virtual ReturnT operator()(double x) const {
+    virtual ReturnT operator()(double x) const noexcept(IS_NOTHROW_INIT<ReturnT>) {
         return static_cast<ReturnT>((_multFac / this->_params[0]) *
                                     std::exp(-(x * x) / (2.0 * this->_params[0] * this->_params[0])));
     }
@@ -241,14 +243,14 @@ public:
     GaussianFunction2(GaussianFunction2&&) = default;
     GaussianFunction2& operator=(GaussianFunction2 const&) = default;
     GaussianFunction2& operator=(GaussianFunction2&&) = default;
-    virtual ~GaussianFunction2() = default;
+    virtual ~GaussianFunction2() noexcept = default;
 
     virtual std::shared_ptr<Function2<ReturnT>> clone() const {
         return std::shared_ptr<Function2<ReturnT>>(
                 new GaussianFunction2(this->_params[0], this->_params[1], this->_params[2]));
     }
 
-    virtual ReturnT operator()(double x, double y) const {
+    virtual ReturnT operator()(double x, double y) const noexcept(IS_NOTHROW_INIT<ReturnT>) {
         if (_angle != this->_params[2]) {
             _updateCache();
         }
@@ -291,7 +293,7 @@ private:
      * The overhead is small, but the function is typically evaulated more often
      * than its parameters are changed.
      */
-    void _updateCache() const {
+    void _updateCache() const noexcept {
         _angle = this->_params[2];
         _sinAngle = std::sin(_angle);
         _cosAngle = std::cos(_angle);
@@ -355,14 +357,14 @@ public:
     DoubleGaussianFunction2(DoubleGaussianFunction2&&) = default;
     DoubleGaussianFunction2& operator=(DoubleGaussianFunction2 const&) = default;
     DoubleGaussianFunction2& operator=(DoubleGaussianFunction2&&) = default;
-    virtual ~DoubleGaussianFunction2() = default;
+    virtual ~DoubleGaussianFunction2() noexcept = default;
 
     virtual std::shared_ptr<Function2<ReturnT>> clone() const {
         return std::shared_ptr<Function2<ReturnT>>(
                 new DoubleGaussianFunction2(this->_params[0], this->_params[1], this->_params[2]));
     }
 
-    virtual ReturnT operator()(double x, double y) const {
+    virtual ReturnT operator()(double x, double y) const noexcept(IS_NOTHROW_INIT<ReturnT>) {
         double radSq = (x * x) + (y * y);
         double sigma1Sq = this->_params[0] * this->_params[0];
         double sigma2Sq = this->_params[1] * this->_params[1];
@@ -438,15 +440,15 @@ public:
     PolynomialFunction1(PolynomialFunction1&&) = default;
     PolynomialFunction1& operator=(PolynomialFunction1 const&) = default;
     PolynomialFunction1& operator=(PolynomialFunction1&&) = default;
-    virtual ~PolynomialFunction1() = default;
+    virtual ~PolynomialFunction1() noexcept = default;
 
     virtual std::shared_ptr<Function1<ReturnT>> clone() const {
         return std::shared_ptr<Function1<ReturnT>>(new PolynomialFunction1(this->_params));
     }
 
-    virtual bool isLinearCombination() const { return true; };
+    virtual bool isLinearCombination() const noexcept { return true; };
 
-    virtual ReturnT operator()(double x) const {
+    virtual ReturnT operator()(double x) const noexcept(IS_NOTHROW_INIT<ReturnT>) {
         int const order = static_cast<int>(this->_params.size()) - 1;
         double retVal = this->_params[order];
         for (int ii = order - 1; ii >= 0; --ii) {
@@ -458,7 +460,7 @@ public:
     /**
      * Get the polynomial order
      */
-    unsigned int getOrder() const { return this->getNParameters() - 1; };
+    unsigned int getOrder() const noexcept { return this->getNParameters() - 1; };
 
     virtual std::string toString(std::string const& prefix) const {
         std::ostringstream os;
@@ -525,13 +527,13 @@ public:
     PolynomialFunction2(PolynomialFunction2&&) = default;
     PolynomialFunction2& operator=(PolynomialFunction2 const&) = default;
     PolynomialFunction2& operator=(PolynomialFunction2&&) = default;
-    virtual ~PolynomialFunction2() = default;
+    virtual ~PolynomialFunction2() noexcept = default;
 
     virtual std::shared_ptr<Function2<ReturnT>> clone() const {
         return std::shared_ptr<Function2<ReturnT>>(new PolynomialFunction2(this->_params));
     }
 
-    virtual ReturnT operator()(double x, double y) const {
+    virtual ReturnT operator()(double x, double y) const noexcept(IS_NOTHROW_INIT<ReturnT>) {
         /* Solve as follows:
         - f(x,y) = Cx0 + Cx1 x + Cx2 x^2 + Cx3 x^3 + ...
         where:
@@ -671,7 +673,7 @@ public:
     Chebyshev1Function1(Chebyshev1Function1&&) = default;
     Chebyshev1Function1& operator=(Chebyshev1Function1 const&) = default;
     Chebyshev1Function1& operator=(Chebyshev1Function1&&) = default;
-    virtual ~Chebyshev1Function1() = default;
+    virtual ~Chebyshev1Function1() noexcept = default;
 
     virtual std::shared_ptr<Function1<ReturnT>> clone() const {
         return std::shared_ptr<Function1<ReturnT>>(new Chebyshev1Function1(this->_params, _minX, _maxX));
@@ -680,19 +682,19 @@ public:
     /**
      * Get minimum allowed x
      */
-    double getMinX() const { return _minX; };
+    double getMinX() const noexcept { return _minX; };
 
     /**
      * Get maximum allowed x
      */
-    double getMaxX() const { return _maxX; };
+    double getMaxX() const noexcept { return _maxX; };
 
     /**
      * Get the polynomial order
      */
-    unsigned int getOrder() const { return this->getNParameters() - 1; };
+    unsigned int getOrder() const noexcept { return this->getNParameters() - 1; };
 
-    virtual bool isLinearCombination() const { return true; };
+    virtual bool isLinearCombination() const noexcept { return true; };
 
     virtual ReturnT operator()(double x) const {
         double xPrime = (x + _offset) * _scale;
@@ -826,7 +828,7 @@ public:
     Chebyshev1Function2(Chebyshev1Function2&&) = default;
     Chebyshev1Function2& operator=(Chebyshev1Function2 const&) = default;
     Chebyshev1Function2& operator=(Chebyshev1Function2&&) = default;
-    virtual ~Chebyshev1Function2() = default;
+    virtual ~Chebyshev1Function2() noexcept = default;
 
     virtual std::shared_ptr<Function2<ReturnT>> clone() const {
         return std::shared_ptr<Function2<ReturnT>>(
@@ -836,7 +838,7 @@ public:
     /**
      * Get x,y range
      */
-    lsst::geom::Box2D getXYRange() const {
+    lsst::geom::Box2D getXYRange() const noexcept {
         return lsst::geom::Box2D(lsst::geom::Point2D(_minX, _minY), lsst::geom::Point2D(_maxX, _maxY));
     };
 
@@ -1025,13 +1027,13 @@ public:
     LanczosFunction1(LanczosFunction1&&) = default;
     LanczosFunction1& operator=(LanczosFunction1 const&) = default;
     LanczosFunction1& operator=(LanczosFunction1&&) = default;
-    virtual ~LanczosFunction1() = default;
+    virtual ~LanczosFunction1() noexcept = default;
 
     virtual std::shared_ptr<Function1<ReturnT>> clone() const {
         return std::shared_ptr<Function1<ReturnT>>(new LanczosFunction1(this->getOrder(), this->_params[0]));
     }
 
-    virtual ReturnT operator()(double x) const {
+    virtual ReturnT operator()(double x) const noexcept(IS_NOTHROW_INIT<ReturnT>) {
         double xArg1 = (x - this->_params[0]) * lsst::geom::PI;
         double xArg2 = xArg1 * _invN;
         if (std::fabs(xArg1) > 1.0e-5) {
@@ -1044,7 +1046,7 @@ public:
     /**
      * Get the order of the Lanczos function
      */
-    unsigned int getOrder() const { return static_cast<unsigned int>(0.5 + (1.0 / _invN)); };
+    unsigned int getOrder() const noexcept { return static_cast<unsigned int>(0.5 + (1.0 / _invN)); };
 
     virtual std::string toString(std::string const& prefix) const {
         std::ostringstream os;
@@ -1100,14 +1102,14 @@ public:
     LanczosFunction2(LanczosFunction2&&) = default;
     LanczosFunction2& operator=(LanczosFunction2 const&) = default;
     LanczosFunction2& operator=(LanczosFunction2&&) = default;
-    virtual ~LanczosFunction2() = default;
+    virtual ~LanczosFunction2() noexcept = default;
 
     virtual std::shared_ptr<Function2<ReturnT>> clone() const {
         return std::shared_ptr<Function2<ReturnT>>(
                 new LanczosFunction2(this->getOrder(), this->_params[0], this->_params[1]));
     }
 
-    virtual ReturnT operator()(double x, double y) const {
+    virtual ReturnT operator()(double x, double y) const noexcept(IS_NOTHROW_INIT<ReturnT>) {
         double xArg1 = (x - this->_params[0]) * lsst::geom::PI;
         double xArg2 = xArg1 * _invN;
         double xFunc = 1;
@@ -1126,7 +1128,7 @@ public:
     /**
      * Get the order of Lanczos function
      */
-    unsigned int getOrder() const { return static_cast<unsigned int>(0.5 + (1.0 / _invN)); };
+    unsigned int getOrder() const noexcept { return static_cast<unsigned int>(0.5 + (1.0 / _invN)); };
 
     virtual std::string toString(std::string const& prefix) const {
         std::ostringstream os;

--- a/include/lsst/afw/math/Kernel.h
+++ b/include/lsst/afw/math/Kernel.h
@@ -555,7 +555,7 @@ public:
 
     virtual Pixel getSum() const { return _sum; }
 
-    virtual bool isPersistable() const { return true; }
+    virtual bool isPersistable() const noexcept override { return true; }
 
     class Factory;
 
@@ -676,7 +676,7 @@ public:
 
     virtual std::string toString(std::string const &prefix = "") const;
 
-    virtual bool isPersistable() const { return true; }
+    virtual bool isPersistable() const noexcept override { return true; }
 
     class Factory;
 
@@ -738,7 +738,7 @@ public:
 
     virtual std::string toString(std::string const &prefix = "") const;
 
-    virtual bool isPersistable() const { return true; }
+    virtual bool isPersistable() const noexcept override { return true; }
 
     class Factory;
 
@@ -891,7 +891,7 @@ public:
 
     virtual std::string toString(std::string const &prefix = "") const;
 
-    virtual bool isPersistable() const { return true; }
+    virtual bool isPersistable() const noexcept override { return true; }
 
     class Factory;
 

--- a/include/lsst/afw/math/Statistics.h
+++ b/include/lsst/afw/math/Statistics.h
@@ -130,14 +130,14 @@ public:
     void setMaskPropagationThreshold(int bit, double threshold);
     //@}
 
-    double getNumSigmaClip() const { return _numSigmaClip; }
-    int getNumIter() const { return _numIter; }
-    int getAndMask() const { return _andMask; }
-    int getNoGoodPixelsMask() const { return _noGoodPixelsMask; }
-    bool getNanSafe() const { return _isNanSafe; }
-    bool getWeighted() const { return _useWeights == WEIGHTS_TRUE ? true : false; }
-    bool getWeightedIsSet() const { return _useWeights != WEIGHTS_NONE ? true : false; }
-    bool getCalcErrorFromInputVariance() const { return _calcErrorFromInputVariance; }
+    double getNumSigmaClip() const noexcept { return _numSigmaClip; }
+    int getNumIter() const noexcept { return _numIter; }
+    int getAndMask() const noexcept { return _andMask; }
+    int getNoGoodPixelsMask() const noexcept { return _noGoodPixelsMask; }
+    bool getNanSafe() const noexcept { return _isNanSafe; }
+    bool getWeighted() const noexcept { return _useWeights == WEIGHTS_TRUE ? true : false; }
+    bool getWeightedIsSet() const noexcept { return _useWeights != WEIGHTS_NONE ? true : false; }
+    bool getCalcErrorFromInputVariance() const noexcept { return _calcErrorFromInputVariance; }
 
     void setNumSigmaClip(double numSigmaClip) {
         assert(numSigmaClip > 0);
@@ -149,9 +149,9 @@ public:
     }
     void setAndMask(int andMask) { _andMask = andMask; }
     void setNoGoodPixelsMask(int noGoodPixelsMask) { _noGoodPixelsMask = noGoodPixelsMask; }
-    void setNanSafe(bool isNanSafe) { _isNanSafe = isNanSafe; }
-    void setWeighted(bool useWeights) { _useWeights = useWeights ? WEIGHTS_TRUE : WEIGHTS_FALSE; }
-    void setCalcErrorFromInputVariance(bool calcErrorFromInputVariance) {
+    void setNanSafe(bool isNanSafe) noexcept { _isNanSafe = isNanSafe; }
+    void setWeighted(bool useWeights) noexcept { _useWeights = useWeights ? WEIGHTS_TRUE : WEIGHTS_FALSE; }
+    void setCalcErrorFromInputVariance(bool calcErrorFromInputVariance) noexcept {
         _calcErrorFromInputVariance = calcErrorFromInputVariance;
     }
 
@@ -249,7 +249,7 @@ public:
     Statistics(Statistics &&) = default;
     Statistics &operator=(Statistics const &) = default;
     Statistics &operator=(Statistics &&) = default;
-    ~Statistics() = default;
+    ~Statistics() noexcept = default;
 
     /** Return the value and error in the specified statistic (e.g. MEAN)
      *
@@ -280,7 +280,7 @@ public:
      *             asked for one property in the constructor, that property is returned
      */
     double getValue(Property const prop = NOTHING) const;
-    lsst::afw::image::MaskPixel getOrMask() const { return _allPixelOrMask; }
+    lsst::afw::image::MaskPixel getOrMask() const noexcept { return _allPixelOrMask; }
 
 private:
     long _flags;  // The desired calculation
@@ -329,7 +329,7 @@ public:
 
 private:
     friend class boost::iterator_core_access;
-    void increment() { ; }  // never actually advance the iterator
+    void increment() noexcept { ; }  // never actually advance the iterator
 };
 /**
  * @brief A Mask wrapper to provide an infinite_iterator for Mask::row_begin().  This allows a fake
@@ -339,8 +339,8 @@ template <typename ValueT>
 class MaskImposter {
 public:
     typedef infinite_iterator<ValueT> x_iterator;
-    explicit MaskImposter(ValueT val = 0) { _val[0] = val; }
-    x_iterator row_begin(int) const { return x_iterator(_val); }
+    explicit MaskImposter(ValueT val = 0) noexcept { _val[0] = val; }
+    x_iterator row_begin(int) const noexcept { return x_iterator(_val); }
 
 private:
     ValueT _val[1];
@@ -446,13 +446,15 @@ public:
     explicit ImageImposter(ImageImposter<ValueT> const &img) : _v(img._getVector()) {}
 
     // The methods we'll use in Statistics
-    x_iterator row_begin(int) const { return _v.begin(); }
-    x_iterator row_end(int) const { return _v.end(); }
-    int getWidth() const { return _v.size(); }
-    int getHeight() const { return 1; }
-    lsst::geom::Extent2I getDimensions() const { return lsst::geom::Extent2I(getWidth(), getHeight()); }
+    x_iterator row_begin(int) const noexcept { return _v.begin(); }
+    x_iterator row_end(int) const noexcept { return _v.end(); }
+    int getWidth() const noexcept { return _v.size(); }
+    int getHeight() const noexcept { return 1; }
+    lsst::geom::Extent2I getDimensions() const noexcept {
+        return lsst::geom::Extent2I(getWidth(), getHeight());
+    }
 
-    bool empty() const { return _v.empty(); }
+    bool empty() const noexcept { return _v.empty(); }
 
 private:
     std::vector<ValueT> const &_v;                                // a private reference to the data

--- a/include/lsst/afw/math/TransformBoundedField.h
+++ b/include/lsst/afw/math/TransformBoundedField.h
@@ -70,7 +70,7 @@ public:
     using BoundedField::evaluate;
 
     /// TransformBoundedField is always persistable.
-    bool isPersistable() const override { return true; }
+    bool isPersistable() const noexcept override { return true; }
 
     /// @copydoc BoundedField::operator*
     std::shared_ptr<BoundedField> operator*(double const scale) const override;

--- a/include/lsst/afw/table/Catalog.h
+++ b/include/lsst/afw/table/Catalog.h
@@ -552,7 +552,7 @@ public:
     }
 
     /// Shallow swap of two catalogs.
-    void swap(CatalogT& other) {
+    void swap(CatalogT& other) noexcept {
         _table.swap(other._table);
         _internal.swap(other._internal);
     }

--- a/include/lsst/afw/table/Field.h
+++ b/include/lsst/afw/table/Field.h
@@ -62,19 +62,19 @@ struct Field : public FieldBase<T> {
             : FieldBase<T>(size), _name(name), _doc(doc), _units() {}
 
     Field(Field const&) = default;
-    Field(Field&&) = default;
+    Field(Field&&) noexcept = default;
     Field& operator=(Field const&) = default;
-    Field& operator=(Field&&) = default;
-    ~Field() = default;
+    Field& operator=(Field&&) noexcept = default;
+    ~Field() noexcept = default;
 
     /// Return the name of the field.
-    std::string const& getName() const { return _name; }
+    std::string const& getName() const noexcept { return _name; }
 
     /// Return the documentation for the field.
-    std::string const& getDoc() const { return _doc; }
+    std::string const& getDoc() const noexcept { return _doc; }
 
     /// Return the units for the field.
-    std::string const& getUnits() const { return _units; }
+    std::string const& getUnits() const noexcept { return _units; }
 
     /// Stringification.
     inline friend std::ostream& operator<<(std::ostream& os, Field<T> const& field) {

--- a/include/lsst/afw/table/FieldBase.h
+++ b/include/lsst/afw/table/FieldBase.h
@@ -47,7 +47,7 @@ struct FieldBase {
     typedef T Element;                ///< the type of subfields (the same as the type itself for scalars)
 
     /// Return the number of subfield elements (always one for scalars).
-    int getElementCount() const { return 1; }
+    int getElementCount() const noexcept { return 1; }
 
     /// Return a string description of the field type.
     static std::string getTypeString();
@@ -60,15 +60,15 @@ struct FieldBase {
         throw LSST_EXCEPT(lsst::pex::exceptions::LogicError,
                           "Constructor disabled (this Field type is not sized).");
     }
-    FieldBase(FieldBase const &) = default;
-    FieldBase(FieldBase &&) = default;
-    FieldBase &operator=(FieldBase const &) = default;
-    FieldBase &operator=(FieldBase &&) = default;
-    ~FieldBase() = default;
+    FieldBase(FieldBase const &) noexcept = default;
+    FieldBase(FieldBase &&) noexcept = default;
+    FieldBase &operator=(FieldBase const &) noexcept = default;
+    FieldBase &operator=(FieldBase &&) noexcept = default;
+    ~FieldBase() noexcept = default;
 
 protected:
     /// Needed to allow Keys to be default-constructed.
-    static FieldBase makeDefault() { return FieldBase(); }
+    static FieldBase makeDefault() noexcept { return FieldBase(); }
 
     /// Defines how Fields are printed.
     void stream(std::ostream &os) const {}
@@ -126,29 +126,29 @@ struct FieldBase<Array<U> > {
                               "A non-negative size must be provided when constructing an array field.");
     }
 
-    FieldBase(FieldBase const &) = default;
-    FieldBase(FieldBase &&) = default;
-    FieldBase &operator=(FieldBase const &) = default;
-    FieldBase &operator=(FieldBase &&) = default;
-    ~FieldBase() = default;
+    FieldBase(FieldBase const &) noexcept = default;
+    FieldBase(FieldBase &&) noexcept = default;
+    FieldBase &operator=(FieldBase const &) noexcept = default;
+    FieldBase &operator=(FieldBase &&) noexcept = default;
+    ~FieldBase() noexcept = default;
 
     /// Return a string description of the field type.
     static std::string getTypeString();
 
     /// Return the number of subfield elements (equal to the size of the array),
     /// or 0 for a variable-length array.
-    int getElementCount() const { return _size; }
+    int getElementCount() const noexcept { return _size; }
 
     /// Return the size of the array (equal to the number of subfield elements),
     /// or 0 for a variable-length array.
-    int getSize() const { return _size; }
+    int getSize() const noexcept { return _size; }
 
     /// Return true if the field is variable-length (each record can have a different size array).
-    bool isVariableLength() const { return _size == 0; }
+    bool isVariableLength() const noexcept { return _size == 0; }
 
 protected:
     /// Needed to allow Keys to be default-constructed.
-    static FieldBase makeDefault() { return FieldBase(0); }
+    static FieldBase makeDefault() noexcept { return FieldBase(0); }
 
     /// Defines how Fields are printed.
     void stream(std::ostream &os) const { os << ", size=" << _size; }
@@ -247,29 +247,29 @@ struct FieldBase<std::string> {
      */
     FieldBase(int size = -1);
 
-    FieldBase(FieldBase const &) = default;
-    FieldBase(FieldBase &&) = default;
-    FieldBase &operator=(FieldBase const &) = default;
-    FieldBase &operator=(FieldBase &&) = default;
-    ~FieldBase() = default;
+    FieldBase(FieldBase const &) noexcept = default;
+    FieldBase(FieldBase &&) noexcept = default;
+    FieldBase &operator=(FieldBase const &) noexcept = default;
+    FieldBase &operator=(FieldBase &&) noexcept = default;
+    ~FieldBase() noexcept = default;
 
     /// Return a string description of the field type.
     static std::string getTypeString();
 
     /// @brief Return the number of subfield elements (equal to the size of the string,
     ///        including a null terminator), or 0 for a variable-length string.
-    int getElementCount() const { return _size; }
+    int getElementCount() const noexcept { return _size; }
 
     /// @brief Return the maximum length of the string, including a null terminator
     ///        (equal to the number of subfield elements), or 0 for a variable-length string.
-    int getSize() const { return _size; }
+    int getSize() const noexcept { return _size; }
 
     /// Return true if the field is variable-length (each record can have a different size array).
-    bool isVariableLength() const { return _size == 0; }
+    bool isVariableLength() const noexcept { return _size == 0; }
 
 protected:
     /// Needed to allow Keys to be default-constructed.
-    static FieldBase makeDefault() { return FieldBase(0); }
+    static FieldBase makeDefault() noexcept { return FieldBase(0); }
 
     /// Defines how Fields are printed.
     void stream(std::ostream &os) const { os << ", size=" << _size; }

--- a/include/lsst/afw/table/FunctorKey.h
+++ b/include/lsst/afw/table/FunctorKey.h
@@ -44,7 +44,7 @@ public:
 
     virtual T get(BaseRecord const& record) const = 0;
 
-    virtual ~OutputFunctorKey() = default;
+    virtual ~OutputFunctorKey() noexcept = default;
 };
 
 /**
@@ -61,7 +61,7 @@ public:
 
     virtual void set(BaseRecord& record, T const& value) const = 0;
 
-    virtual ~InputFunctorKey() = default;
+    virtual ~InputFunctorKey() noexcept = default;
 };
 
 /**
@@ -92,7 +92,7 @@ class ReferenceFunctorKey {
 public:
     virtual T getReference(BaseRecord& record) const = 0;
 
-    virtual ~ReferenceFunctorKey() = default;
+    virtual ~ReferenceFunctorKey() noexcept = default;
 };
 
 /**
@@ -110,7 +110,7 @@ class ConstReferenceFunctorKey {
 public:
     virtual T getConstReference(BaseRecord const& record) const = 0;
 
-    virtual ~ConstReferenceFunctorKey() = default;
+    virtual ~ConstReferenceFunctorKey() noexcept = default;
 };
 }  // namespace table
 }  // namespace afw

--- a/include/lsst/afw/table/Key.h
+++ b/include/lsst/afw/table/Key.h
@@ -61,22 +61,22 @@ public:
      *  the two keys will be equal).
      */
     template <typename OtherT>
-    bool operator==(Key<OtherT> const& other) const {
+    bool operator==(Key<OtherT> const& other) const noexcept {
         return false;
     }
     template <typename OtherT>
-    bool operator!=(Key<OtherT> const& other) const {
+    bool operator!=(Key<OtherT> const& other) const noexcept {
         return true;
     }
 
-    bool operator==(Key const& other) const {
+    bool operator==(Key const& other) const noexcept {
         return _offset == other._offset && this->getElementCount() == other.getElementCount();
     }
-    bool operator!=(Key const& other) const { return !this->operator==(other); }
+    bool operator!=(Key const& other) const noexcept { return !this->operator==(other); }
     //@}
 
     /// Return the offset (in bytes) of this field within a record.
-    int getOffset() const { return _offset; }
+    int getOffset() const noexcept { return _offset; }
 
     /**
      *  Return true if the key was initialized to valid offset.
@@ -86,20 +86,20 @@ public:
      *
      *  A key that is default constructed will always be invalid.
      */
-    bool isValid() const { return _offset >= 0; }
+    bool isValid() const noexcept { return _offset >= 0; }
 
     /**
      *  Default construct a field.
      *
      *  The new field will be invalid until a valid Key is assigned to it.
      */
-    Key() : FieldBase<T>(FieldBase<T>::makeDefault()), _offset(-1) {}
+    Key() noexcept : FieldBase<T>(FieldBase<T>::makeDefault()), _offset(-1) {}
 
-    Key(Key const&) = default;
-    Key(Key&&) = default;
-    Key& operator=(Key const&) = default;
-    Key& operator=(Key&&) = default;
-    ~Key() = default;
+    Key(Key const&) noexcept = default;
+    Key(Key&&) noexcept = default;
+    Key& operator=(Key const&) noexcept = default;
+    Key& operator=(Key&&) noexcept = default;
+    ~Key() noexcept = default;
 
     /// Stringification.
     inline friend std::ostream& operator<<(std::ostream& os, Key<T> const& key) {
@@ -111,7 +111,8 @@ private:
     friend class detail::Access;
     friend class BaseRecord;
 
-    explicit Key(int offset, FieldBase<T> const& fb = FieldBase<T>()) : FieldBase<T>(fb), _offset(offset) {}
+    explicit Key(int offset, FieldBase<T> const& fb = FieldBase<T>()) noexcept
+            : FieldBase<T>(fb), _offset(offset) {}
 
     int _offset;
 };

--- a/include/lsst/afw/table/aggregates.h
+++ b/include/lsst/afw/table/aggregates.h
@@ -59,16 +59,16 @@ public:
                               std::string const& unit);
 
     /// Default constructor; instance will not be usable unless subsequently assigned to.
-    PointKey() : _x(), _y() {}
+    PointKey() noexcept : _x(), _y() {}
 
     /// Construct from a pair of Keys
-    PointKey(Key<T> const& x, Key<T> const& y) : _x(x), _y(y) {}
+    PointKey(Key<T> const& x, Key<T> const& y) noexcept : _x(x), _y(y) {}
 
-    PointKey(PointKey const&) = default;
-    PointKey(PointKey&&) = default;
-    PointKey& operator=(PointKey const&) = default;
-    PointKey& operator=(PointKey&&) = default;
-    virtual ~PointKey() = default;
+    PointKey(PointKey const&) noexcept = default;
+    PointKey(PointKey&&) noexcept = default;
+    PointKey& operator=(PointKey const&) noexcept = default;
+    PointKey& operator=(PointKey&&) noexcept = default;
+    virtual ~PointKey() noexcept = default;
 
     /**
      *  Construct from a subschema, assuming x and y subfields
@@ -88,18 +88,18 @@ public:
 
     //@{
     /// Compare the FunctorKey for equality with another, using the underlying x and y Keys
-    bool operator==(PointKey<T> const& other) const { return _x == other._x && _y == other._y; }
-    bool operator!=(PointKey<T> const& other) const { return !(*this == other); }
+    bool operator==(PointKey<T> const& other) const noexcept { return _x == other._x && _y == other._y; }
+    bool operator!=(PointKey<T> const& other) const noexcept { return !(*this == other); }
     //@}
 
     /// Return True if both the x and y Keys are valid.
-    bool isValid() const { return _x.isValid() && _y.isValid(); }
+    bool isValid() const noexcept { return _x.isValid() && _y.isValid(); }
 
     /// Return the underlying x Key
-    Key<T> getX() const { return _x; }
+    Key<T> getX() const noexcept { return _x; }
 
     /// Return the underlying y Key
-    Key<T> getY() const { return _y; }
+    Key<T> getY() const noexcept { return _y; }
 
 private:
     Key<T> _x;
@@ -137,10 +137,10 @@ public:
                             std::string const& unit);
 
     /// Default constructor; instance will not be usable unless subsequently assigned to.
-    BoxKey() = default;
+    BoxKey() noexcept = default;
 
     /// Construct from a pair of PointKeys
-    BoxKey(PointKey<Element> const& min, PointKey<Element> const& max) : _min(min), _max(max) {}
+    BoxKey(PointKey<Element> const& min, PointKey<Element> const& max) noexcept : _min(min), _max(max) {}
 
     /**
      *  Construct from a subschema, assuming _min_x, _max_x, _min_y, _max_y subfields
@@ -152,11 +152,11 @@ public:
      */
     BoxKey(SubSchema const& s) : _min(s["min"]), _max(s["max"]) {}
 
-    BoxKey(BoxKey const&) = default;
-    BoxKey(BoxKey&&) = default;
-    BoxKey& operator=(BoxKey const&) = default;
-    BoxKey& operator=(BoxKey&&) = default;
-    virtual ~BoxKey() = default;
+    BoxKey(BoxKey const&) noexcept = default;
+    BoxKey(BoxKey&&) noexcept = default;
+    BoxKey& operator=(BoxKey const&) noexcept = default;
+    BoxKey& operator=(BoxKey&&) noexcept = default;
+    virtual ~BoxKey() noexcept = default;
 
     /// Get a Point from the given record
     virtual Box get(BaseRecord const& record) const;
@@ -166,18 +166,18 @@ public:
 
     //@{
     /// Compare the FunctorKey for equality with another, using the underlying x and y Keys
-    bool operator==(BoxKey const& other) const { return _min == other._min && _max == other._max; }
-    bool operator!=(BoxKey const& other) const { return !(*this == other); }
+    bool operator==(BoxKey const& other) const noexcept { return _min == other._min && _max == other._max; }
+    bool operator!=(BoxKey const& other) const noexcept { return !(*this == other); }
     //@}
 
     /// Return True if both the min and max PointKeys are valid.
-    bool isValid() const { return _min.isValid() && _max.isValid(); }
+    bool isValid() const noexcept { return _min.isValid() && _max.isValid(); }
 
     /// Return the underlying min PointKey
-    PointKey<Element> getMin() const { return _min; }
+    PointKey<Element> getMin() const noexcept { return _min; }
 
     /// Return the underlying max PointKey
-    PointKey<Element> getMax() const { return _max; }
+    PointKey<Element> getMax() const noexcept { return _max; }
 
 private:
     PointKey<Element> _min;
@@ -206,10 +206,11 @@ public:
     static CoordKey addFields(afw::table::Schema& schema, std::string const& name, std::string const& doc);
 
     /// Default constructor; instance will not be usable unless subsequently assigned to.
-    CoordKey() : _ra(), _dec() {}
+    CoordKey() noexcept : _ra(), _dec() {}
 
     /// Construct from a pair of Keys
-    CoordKey(Key<lsst::geom::Angle> const& ra, Key<lsst::geom::Angle> const& dec) : _ra(ra), _dec(dec) {}
+    CoordKey(Key<lsst::geom::Angle> const& ra, Key<lsst::geom::Angle> const& dec) noexcept
+            : _ra(ra), _dec(dec) {}
 
     /**
      *  Construct from a subschema, assuming ra and dec subfields.
@@ -221,11 +222,11 @@ public:
      */
     CoordKey(SubSchema const& s) : _ra(s["ra"]), _dec(s["dec"]) {}
 
-    CoordKey(CoordKey const&) = default;
-    CoordKey(CoordKey&&) = default;
-    CoordKey& operator=(CoordKey const&) = default;
-    CoordKey& operator=(CoordKey&&) = default;
-    virtual ~CoordKey() = default;
+    CoordKey(CoordKey const&) noexcept = default;
+    CoordKey(CoordKey&&) noexcept = default;
+    CoordKey& operator=(CoordKey const&) noexcept = default;
+    CoordKey& operator=(CoordKey&&) noexcept = default;
+    virtual ~CoordKey() noexcept = default;
 
     /// Get an lsst::geom::SpherePoint from the given record
     virtual lsst::geom::SpherePoint get(BaseRecord const& record) const;
@@ -235,16 +236,16 @@ public:
 
     //@{
     /// Compare CoordKeys for equality using the constituent `ra` and `dec` Keys
-    bool operator==(CoordKey const& other) const { return _ra == other._ra && _dec == other._dec; }
-    bool operator!=(CoordKey const& other) const { return !(*this == other); }
+    bool operator==(CoordKey const& other) const noexcept { return _ra == other._ra && _dec == other._dec; }
+    bool operator!=(CoordKey const& other) const noexcept { return !(*this == other); }
     //@}
 
-    bool isValid() const { return _ra.isValid() && _dec.isValid(); }
+    bool isValid() const noexcept { return _ra.isValid() && _dec.isValid(); }
 
     //@{
     /// Return a constituent Key
-    Key<lsst::geom::Angle> getRa() const { return _ra; }
-    Key<lsst::geom::Angle> getDec() const { return _dec; }
+    Key<lsst::geom::Angle> getRa() const noexcept { return _ra; }
+    Key<lsst::geom::Angle> getDec() const noexcept { return _dec; }
     //@}
 
 private:
@@ -281,10 +282,10 @@ public:
                                    CoordinateType coordType = CoordinateType::PIXEL);
 
     /// Default constructor; instance will not be usable unless subsequently assigned to.
-    QuadrupoleKey() : _ixx(), _iyy(), _ixy() {}
+    QuadrupoleKey() noexcept : _ixx(), _iyy(), _ixy() {}
 
     /// Construct from individual Keys
-    QuadrupoleKey(Key<double> const& ixx, Key<double> const& iyy, Key<double> const& ixy)
+    QuadrupoleKey(Key<double> const& ixx, Key<double> const& iyy, Key<double> const& ixy) noexcept
             : _ixx(ixx), _iyy(iyy), _ixy(ixy) {}
 
     /**
@@ -297,11 +298,11 @@ public:
      */
     QuadrupoleKey(SubSchema const& s) : _ixx(s["xx"]), _iyy(s["yy"]), _ixy(s["xy"]) {}
 
-    QuadrupoleKey(QuadrupoleKey const&) = default;
-    QuadrupoleKey(QuadrupoleKey&&) = default;
-    QuadrupoleKey& operator=(QuadrupoleKey const&) = default;
-    QuadrupoleKey& operator=(QuadrupoleKey&&) = default;
-    virtual ~QuadrupoleKey() = default;
+    QuadrupoleKey(QuadrupoleKey const&) noexcept = default;
+    QuadrupoleKey(QuadrupoleKey&&) noexcept = default;
+    QuadrupoleKey& operator=(QuadrupoleKey const&) noexcept = default;
+    QuadrupoleKey& operator=(QuadrupoleKey&&) noexcept = default;
+    virtual ~QuadrupoleKey() noexcept = default;
 
     /// Get a Quadrupole from the given record
     virtual geom::ellipses::Quadrupole get(BaseRecord const& record) const;
@@ -311,20 +312,20 @@ public:
 
     //@{
     /// Compare the FunctorKey for equality with another, using the underlying Ixx, Iyy, Ixy Keys
-    bool operator==(QuadrupoleKey const& other) const {
+    bool operator==(QuadrupoleKey const& other) const noexcept {
         return _ixx == other._ixx && _iyy == other._iyy && _ixy == other._ixy;
     }
-    bool operator!=(QuadrupoleKey const& other) const { return !(*this == other); }
+    bool operator!=(QuadrupoleKey const& other) const noexcept { return !(*this == other); }
     //@}
 
     /// Return True if all the constituent Keys are valid.
-    bool isValid() const { return _ixx.isValid() && _iyy.isValid() && _ixy.isValid(); }
+    bool isValid() const noexcept { return _ixx.isValid() && _iyy.isValid() && _ixy.isValid(); }
 
     //@{
     /// Return a constituent Key
-    Key<double> getIxx() const { return _ixx; }
-    Key<double> getIyy() const { return _iyy; }
-    Key<double> getIxy() const { return _ixy; }
+    Key<double> getIxx() const noexcept { return _ixx; }
+    Key<double> getIyy() const noexcept { return _iyy; }
+    Key<double> getIxy() const noexcept { return _ixy; }
     //@}
 
 private:
@@ -352,10 +353,10 @@ public:
                                 std::string const& unit);
 
     /// Default constructor; instance will not be usable unless subsequently assigned to.
-    EllipseKey() : _qKey(), _pKey() {}
+    EllipseKey() noexcept : _qKey(), _pKey() {}
 
     /// Construct from individual Keys
-    EllipseKey(QuadrupoleKey const& qKey, PointKey<double> const& pKey) : _qKey(qKey), _pKey(pKey) {}
+    EllipseKey(QuadrupoleKey const& qKey, PointKey<double> const& pKey) noexcept : _qKey(qKey), _pKey(pKey) {}
 
     /**
      *  Construct from a subschema, assuming (xx, yy, xy, x, y) subfields
@@ -367,11 +368,11 @@ public:
      */
     EllipseKey(SubSchema const& s) : _qKey(s), _pKey(s) {}
 
-    EllipseKey(EllipseKey const&) = default;
-    EllipseKey(EllipseKey&&) = default;
-    EllipseKey& operator=(EllipseKey const&) = default;
-    EllipseKey& operator=(EllipseKey&&) = default;
-    virtual ~EllipseKey() = default;
+    EllipseKey(EllipseKey const&) noexcept = default;
+    EllipseKey(EllipseKey&&) noexcept = default;
+    EllipseKey& operator=(EllipseKey const&) noexcept = default;
+    EllipseKey& operator=(EllipseKey&&) noexcept = default;
+    virtual ~EllipseKey() noexcept = default;
 
     /// Get an Ellipse from the given record
     virtual geom::ellipses::Ellipse get(BaseRecord const& record) const;
@@ -381,17 +382,19 @@ public:
 
     //@{
     /// Compare the FunctorKey for equality with another, using the underlying Ixx, Iyy, Ixy Keys
-    bool operator==(EllipseKey const& other) const { return _qKey == other._qKey && _pKey == other._pKey; }
-    bool operator!=(EllipseKey const& other) const { return !(*this == other); }
+    bool operator==(EllipseKey const& other) const noexcept {
+        return _qKey == other._qKey && _pKey == other._pKey;
+    }
+    bool operator!=(EllipseKey const& other) const noexcept { return !(*this == other); }
     //@}
 
     /// Return True if all the constituent Keys are valid.
-    bool isValid() const { return _qKey.isValid() && _pKey.isValid(); }
+    bool isValid() const noexcept { return _qKey.isValid() && _pKey.isValid(); }
 
     //@{
     /// Return constituent FunctorKeys
-    QuadrupoleKey getCore() const { return _qKey; }
-    PointKey<double> getCenter() const { return _pKey; }
+    QuadrupoleKey getCore() const noexcept { return _qKey; }
+    PointKey<double> getCenter() const noexcept { return _pKey; }
     //@}
 
 private:
@@ -480,7 +483,7 @@ public:
     CovarianceMatrixKey(CovarianceMatrixKey&&);
     CovarianceMatrixKey& operator=(CovarianceMatrixKey const&);
     CovarianceMatrixKey& operator=(CovarianceMatrixKey&&);
-    virtual ~CovarianceMatrixKey();
+    virtual ~CovarianceMatrixKey() noexcept;
 
     /// Get a covariance matrix from the given record
     virtual Eigen::Matrix<T, N, N> get(BaseRecord const& record) const;
@@ -500,12 +503,12 @@ public:
      *  Note that if the only one or more off-diagonal keys are invalid, we assume that means those terms
      *  are zero, not that the whole FunctorKey is invalid.
      */
-    bool isValid() const;
+    bool isValid() const noexcept;
 
     //@{
     /// Compare the FunctorKey for equality with another, using its constituent Keys
-    bool operator==(CovarianceMatrixKey const& other) const;
-    bool operator!=(CovarianceMatrixKey const& other) const { return !(*this == other); }
+    bool operator==(CovarianceMatrixKey const& other) const noexcept;
+    bool operator!=(CovarianceMatrixKey const& other) const noexcept { return !(*this == other); }
     //@}
 
 private:

--- a/include/lsst/afw/table/arrays.h
+++ b/include/lsst/afw/table/arrays.h
@@ -73,7 +73,7 @@ public:
                               std::string const& unit, int size);
 
     /// Default constructor; instance will not be usable unless subsequently assigned to.
-    ArrayKey() noexcept : _begin() {}
+    ArrayKey() noexcept : _begin(), _size(0) {}
 
     /// Construct from a vector of scalar Keys
     explicit ArrayKey(std::vector<Key<T> > const& keys);
@@ -100,7 +100,7 @@ public:
     ArrayKey(ArrayKey&&) noexcept;
     ArrayKey& operator=(ArrayKey const&) noexcept;
     ArrayKey& operator=(ArrayKey&&) noexcept;
-    ~ArrayKey() noexcept;
+    virtual ~ArrayKey() noexcept;
 
     /// Return the number of elements in the array.
     int getSize() const noexcept { return _size; }

--- a/include/lsst/afw/table/arrays.h
+++ b/include/lsst/afw/table/arrays.h
@@ -73,7 +73,7 @@ public:
                               std::string const& unit, int size);
 
     /// Default constructor; instance will not be usable unless subsequently assigned to.
-    ArrayKey() : _begin() {}
+    ArrayKey() noexcept : _begin() {}
 
     /// Construct from a vector of scalar Keys
     explicit ArrayKey(std::vector<Key<T> > const& keys);
@@ -84,7 +84,7 @@ public:
      *  Key< Array<T> > is now deprecated in favor of ArrayKey; this factory function is intended to
      *  aid in the transition.
      */
-    explicit ArrayKey(Key<Array<T> > const& other);
+    explicit ArrayKey(Key<Array<T> > const& other) noexcept;
 
     /**
      *  Construct from a subschema, assuming *_0, *_1, *_2, etc. subfields
@@ -96,14 +96,14 @@ public:
      */
     ArrayKey(SubSchema const& s);
 
-    ArrayKey(ArrayKey const&);
-    ArrayKey(ArrayKey&&);
-    ArrayKey& operator=(ArrayKey const&);
-    ArrayKey& operator=(ArrayKey&&);
-    ~ArrayKey();
+    ArrayKey(ArrayKey const&) noexcept;
+    ArrayKey(ArrayKey&&) noexcept;
+    ArrayKey& operator=(ArrayKey const&) noexcept;
+    ArrayKey& operator=(ArrayKey&&) noexcept;
+    ~ArrayKey() noexcept;
 
     /// Return the number of elements in the array.
-    int getSize() const { return _size; }
+    int getSize() const noexcept { return _size; }
 
     /// Get an array from the given record
     virtual ndarray::Array<T const, 1, 1> get(BaseRecord const& record) const;
@@ -119,12 +119,14 @@ public:
 
     //@{
     /// Compare the FunctorKey for equality with another, using the underlying scalar Keys
-    bool operator==(ArrayKey<T> const& other) const { return other._begin == _begin && other._size == _size; }
-    bool operator!=(ArrayKey<T> const& other) const { return !operator==(other); }
+    bool operator==(ArrayKey<T> const& other) const noexcept {
+        return other._begin == _begin && other._size == _size;
+    }
+    bool operator!=(ArrayKey<T> const& other) const noexcept { return !operator==(other); }
     //@}
 
     /// Return True if the FunctorKey contains valid scalar keys.
-    bool isValid() const { return _begin.isValid(); }
+    bool isValid() const noexcept { return _begin.isValid(); }
 
     /// Return a scalar Key for an element of the array
     Key<T> operator[](int i) const;
@@ -133,7 +135,7 @@ public:
     ArrayKey slice(int begin, int end) const;
 
 private:
-    ArrayKey(Key<T> const& begin, int size) : _begin(begin), _size(size) {}
+    ArrayKey(Key<T> const& begin, int size) noexcept : _begin(begin), _size(size) {}
 
     Key<T> _begin;
     int _size;

--- a/include/lsst/afw/table/io/Persistable.h
+++ b/include/lsst/afw/table/io/Persistable.h
@@ -99,9 +99,9 @@ public:
     void writeFits(fits::Fits& fitsfile) const;
 
     /// Return true if this particular object can be persisted using afw::table::io.
-    virtual bool isPersistable() const { return false; }
+    virtual bool isPersistable() const noexcept { return false; }
 
-    virtual ~Persistable() = default;
+    virtual ~Persistable() noexcept = default;
 
 protected:
     // convenient for derived classes not in afw::table::io
@@ -133,13 +133,13 @@ protected:
      */
     virtual void write(OutputArchiveHandle& handle) const;
 
-    Persistable() = default;
+    Persistable() noexcept = default;
 
-    Persistable(Persistable const& other) = default;
-    Persistable(Persistable&& other) = default;
+    Persistable(Persistable const& other) noexcept = default;
+    Persistable(Persistable&& other) noexcept = default;
 
-    Persistable& operator=(Persistable const& other) = default;
-    Persistable& operator=(Persistable&& other) = default;
+    Persistable& operator=(Persistable const& other) noexcept = default;
+    Persistable& operator=(Persistable&& other) noexcept = default;
 
 private:
     friend class io::OutputArchive;
@@ -246,7 +246,7 @@ public:
      */
     static PersistableFactory const& lookup(std::string const& name, std::string const& module = "");
 
-    virtual ~PersistableFactory() = default;
+    virtual ~PersistableFactory() noexcept = default;
 
     // No copying
     PersistableFactory(const PersistableFactory&) = delete;

--- a/src/cameraGeom/Orientation.cc
+++ b/src/cameraGeom/Orientation.cc
@@ -47,13 +47,42 @@ Orientation::Orientation(lsst::geom::Point2D const fpPosition, lsst::geom::Point
             cosYaw * cosRoll + sinYaw * sinPitch * sinRoll;
 }
 
-Orientation::~Orientation() = default;
-Orientation::Orientation(Orientation const &) = default;
-Orientation::Orientation(Orientation &&) = default;
-Orientation &Orientation::operator=(Orientation const &) = default;
-Orientation &Orientation::operator=(Orientation &&) = default;
+Orientation::~Orientation() noexcept = default;
+// Can't combine noexcept and =default until Eigen::Matrix supports noexcept
+Orientation::Orientation(Orientation const &other) noexcept
+        : _fpPosition(other._fpPosition),
+          _refPoint(other._refPoint),
+          _yaw(other._yaw),
+          _pitch(other._pitch),
+          _roll(other._roll),
+          _rotMat(other._rotMat) {}
+Orientation::Orientation(Orientation &&other) noexcept
+        : _fpPosition(std::move(other._fpPosition)),
+          _refPoint(std::move(other._refPoint)),
+          _yaw(std::move(other._yaw)),
+          _pitch(std::move(other._pitch)),
+          _roll(std::move(other._roll)),
+          _rotMat(std::move(other._rotMat)) {}
+Orientation &Orientation::operator=(Orientation const &other) noexcept {
+    _fpPosition = other._fpPosition;
+    _refPoint = other._refPoint;
+    _yaw = other._yaw;
+    _pitch = other._pitch;
+    _roll = other._roll;
+    _rotMat = other._rotMat;
+    return *this;
+}
+Orientation &Orientation::operator=(Orientation &&other) noexcept {
+    _fpPosition = std::move(other._fpPosition);
+    _refPoint = std::move(other._refPoint);
+    _yaw = std::move(other._yaw);
+    _pitch = std::move(other._pitch);
+    _roll = std::move(other._roll);
+    _rotMat = std::move(other._rotMat);
+    return *this;
+}
 
-int Orientation::getNQuarter() const {
+int Orientation::getNQuarter() const noexcept {
     float yawDeg = _yaw.asDegrees();
     while (yawDeg < 0.) {
         yawDeg += 360.;

--- a/src/coord/Observatory.cc
+++ b/src/coord/Observatory.cc
@@ -44,16 +44,16 @@ Observatory::Observatory(std::string const& longitude, std::string const& latitu
           _longitude(dmsStringToAngle(longitude)),
           _elevation(elevation) {}
 
-Observatory::~Observatory() = default;
+Observatory::~Observatory() noexcept = default;
 
-Observatory::Observatory(Observatory const&) = default;
-Observatory::Observatory(Observatory&&) = default;
-Observatory& Observatory::operator=(Observatory const&) = default;
-Observatory& Observatory::operator=(Observatory&&) = default;
+Observatory::Observatory(Observatory const&) noexcept = default;
+Observatory::Observatory(Observatory&&) noexcept = default;
+Observatory& Observatory::operator=(Observatory const&) noexcept = default;
+Observatory& Observatory::operator=(Observatory&&) noexcept = default;
 
-lsst::geom::Angle Observatory::getLongitude() const { return _longitude; }
+lsst::geom::Angle Observatory::getLongitude() const noexcept { return _longitude; }
 
-lsst::geom::Angle Observatory::getLatitude() const { return _latitude; }
+lsst::geom::Angle Observatory::getLatitude() const noexcept { return _latitude; }
 
 void Observatory::setLatitude(lsst::geom::Angle const latitude) { _latitude = latitude; }
 

--- a/src/coord/Weather.cc
+++ b/src/coord/Weather.cc
@@ -36,7 +36,7 @@ Weather::Weather(double airTemperature, double airPressure, double humidity)
     validate();
 }
 
-bool Weather::operator==(Weather const& other) const {
+bool Weather::operator==(Weather const& other) const noexcept {
     return (_airTemperature == other.getAirTemperature() && _airPressure == other.getAirPressure() &&
             _humidity == other.getHumidity());
 }

--- a/src/geom/Span.cc
+++ b/src/geom/Span.cc
@@ -29,7 +29,7 @@ namespace lsst {
 namespace afw {
 namespace geom {
 
-bool Span::operator<(const Span& b) const {
+bool Span::operator<(const Span& b) const noexcept {
     if (_y < b._y) return true;
     if (_y > b._y) return false;
     // y equal; check x0...

--- a/src/image/ApCorrMap.cc
+++ b/src/image/ApCorrMap.cc
@@ -110,7 +110,7 @@ ApCorrMapFactory registration(getApCorrMapPersistenceName());
 
 }  // namespace
 
-bool ApCorrMap::isPersistable() const {
+bool ApCorrMap::isPersistable() const noexcept {
     for (Iterator i = begin(); i != end(); ++i) {
         if (!i->second->isPersistable()) return false;
     }

--- a/src/image/Calib.cc
+++ b/src/image/Calib.cc
@@ -97,7 +97,7 @@ ndarray::Array<T, 1> fluxErrFromABMagErr(ndarray::Array<T const, 1> const& magEr
     return out;
 }
 
-Calib::Calib() : _fluxMag0(0.0), _fluxMag0Sigma(0.0) {}
+Calib::Calib() noexcept : _fluxMag0(0.0), _fluxMag0Sigma(0.0) {}
 Calib::Calib(double fluxMag0) : _fluxMag0(fluxMag0), _fluxMag0Sigma(0.0) {}
 Calib::Calib(std::vector<std::shared_ptr<Calib const>> const& calibs) : _fluxMag0(0.0), _fluxMag0Sigma(0.0) {
     if (calibs.empty()) {
@@ -141,15 +141,15 @@ Calib::Calib(std::shared_ptr<lsst::daf::base::PropertySet const> metadata) {
     _fluxMag0Sigma = fluxMag0Sigma;
 }
 bool Calib::_throwOnNegativeFlux = true;
-void Calib::setThrowOnNegativeFlux(bool raiseException) { _throwOnNegativeFlux = raiseException; }
+void Calib::setThrowOnNegativeFlux(bool raiseException) noexcept { _throwOnNegativeFlux = raiseException; }
 
-bool Calib::getThrowOnNegativeFlux() { return _throwOnNegativeFlux; }
+bool Calib::getThrowOnNegativeFlux() noexcept { return _throwOnNegativeFlux; }
 
-Calib::Calib(Calib const&) = default;
-Calib::Calib(Calib&&) = default;
-Calib& Calib::operator=(Calib const&) = default;
-Calib& Calib::operator=(Calib&&) = default;
-Calib::~Calib() = default;
+Calib::Calib(Calib const&) noexcept = default;
+Calib::Calib(Calib&&) noexcept = default;
+Calib& Calib::operator=(Calib const&) noexcept = default;
+Calib& Calib::operator=(Calib&&) noexcept = default;
+Calib::~Calib() noexcept = default;
 
 namespace detail {
 int stripCalibKeywords(std::shared_ptr<lsst::daf::base::PropertySet> metadata) {
@@ -171,7 +171,7 @@ int stripCalibKeywords(std::shared_ptr<lsst::daf::base::PropertySet> metadata) {
 }
 }  // namespace detail
 
-bool Calib::operator==(Calib const& rhs) const {
+bool Calib::operator==(Calib const& rhs) const noexcept {
     return _fluxMag0 == rhs._fluxMag0 && _fluxMag0Sigma == rhs._fluxMag0Sigma;
 }
 

--- a/src/image/CoaddInputs.cc
+++ b/src/image/CoaddInputs.cc
@@ -63,7 +63,7 @@ CoaddInputs& CoaddInputs::operator=(CoaddInputs const&) = default;
 CoaddInputs& CoaddInputs::operator=(CoaddInputs&&) = default;
 CoaddInputs::~CoaddInputs() = default;
 
-bool CoaddInputs::isPersistable() const { return true; }
+bool CoaddInputs::isPersistable() const noexcept { return true; }
 
 std::string CoaddInputs::getPersistenceName() const { return "CoaddInputs"; }
 

--- a/src/image/Filter.cc
+++ b/src/image/Filter.cc
@@ -92,7 +92,9 @@ void FilterProperty::_insert(bool force) {
     _propertyMap->insert(std::make_pair(getName(), *this));
 }
 
-bool FilterProperty::operator==(FilterProperty const& rhs) const { return (_lambdaEff == rhs._lambdaEff); }
+bool FilterProperty::operator==(FilterProperty const& rhs) const noexcept {
+    return (_lambdaEff == rhs._lambdaEff);
+}
 
 void FilterProperty::_initRegistry() {
     if (_propertyMap) {
@@ -177,7 +179,7 @@ std::vector<std::string> Filter::getNames() {
     return names;
 }
 
-bool Filter::operator==(Filter const& rhs) const { return _id != UNKNOWN && _id == rhs._id; }
+bool Filter::operator==(Filter const& rhs) const noexcept { return _id != UNKNOWN && _id == rhs._id; }
 
 void Filter::_initRegistry() {
     _id0 = UNKNOWN;

--- a/src/image/TransmissionCurve.cc
+++ b/src/image/TransmissionCurve.cc
@@ -71,7 +71,7 @@ public:
         out.deep() = 1.0;
     }
 
-    bool isPersistable() const override { return true; }
+    bool isPersistable() const noexcept override { return true; }
 
 protected:
     // transforming an IdentityTransmissionCurve is a no-op
@@ -322,7 +322,7 @@ public:
         }
     }
 
-    bool isPersistable() const override { return true; }
+    bool isPersistable() const noexcept override { return true; }
 
 protected:
     std::shared_ptr<TransmissionCurve const> _transformedByImpl(
@@ -452,7 +452,7 @@ public:
         out.deep() *= tmp;
     }
 
-    bool isPersistable() const override { return _a->isPersistable() && _b->isPersistable(); }
+    bool isPersistable() const noexcept override { return _a->isPersistable() && _b->isPersistable(); }
 
 protected:
     std::string getPersistenceName() const override { return NAME; }
@@ -535,7 +535,9 @@ public:
         return _nested->sampleAt(_transform->applyInverse(position), wavelengths, out);
     }
 
-    bool isPersistable() const override { return _nested->isPersistable() && _transform->isPersistable(); }
+    bool isPersistable() const noexcept override {
+        return _nested->isPersistable() && _transform->isPersistable();
+    }
 
 protected:
     // transforming a TransformedTransmissionCurve composes the transforms

--- a/src/table/aggregates.cc
+++ b/src/table/aggregates.cc
@@ -235,7 +235,7 @@ CovarianceMatrixKey<T, N> &CovarianceMatrixKey<T, N>::operator=(CovarianceMatrix
 template <typename T, int N>
 CovarianceMatrixKey<T, N> &CovarianceMatrixKey<T, N>::operator=(CovarianceMatrixKey &&) = default;
 template <typename T, int N>
-CovarianceMatrixKey<T, N>::~CovarianceMatrixKey() = default;
+CovarianceMatrixKey<T, N>::~CovarianceMatrixKey() noexcept = default;
 
 // these are workarounds for the fact that Eigen has different constructors for
 // dynamic-sized matrices and fixed-size matrices, but we don't want to have to
@@ -291,7 +291,7 @@ void CovarianceMatrixKey<T, N>::set(BaseRecord &record, Eigen::Matrix<T, N, N> c
 }
 
 template <typename T, int N>
-bool CovarianceMatrixKey<T, N>::isValid() const {
+bool CovarianceMatrixKey<T, N>::isValid() const noexcept {
     int const n = _sigma.size();
     if (n < 1) return false;
     for (int i = 0; i < n; ++i) {
@@ -301,7 +301,7 @@ bool CovarianceMatrixKey<T, N>::isValid() const {
 }
 
 template <typename T, int N>
-bool CovarianceMatrixKey<T, N>::operator==(CovarianceMatrixKey const &other) const {
+bool CovarianceMatrixKey<T, N>::operator==(CovarianceMatrixKey const &other) const noexcept {
     if (_sigma.size() != other._sigma.size()) {
         return false;
     }

--- a/src/table/arrays.cc
+++ b/src/table/arrays.cc
@@ -75,7 +75,7 @@ ArrayKey<T>::ArrayKey(std::vector<Key<T> > const &keys) : _begin(), _size(keys.s
 }
 
 template <typename T>
-ArrayKey<T>::ArrayKey(Key<Array<T> > const &other) : _begin(other[0]), _size(other.getSize()) {}
+ArrayKey<T>::ArrayKey(Key<Array<T> > const &other) noexcept : _begin(other[0]), _size(other.getSize()) {}
 
 template <typename T>
 ArrayKey<T>::ArrayKey(SubSchema const &s) : _begin(s["0"]), _size(1) {
@@ -95,15 +95,15 @@ ArrayKey<T>::ArrayKey(SubSchema const &s) : _begin(s["0"]), _size(1) {
 }
 
 template <typename T>
-ArrayKey<T>::ArrayKey(ArrayKey const &) = default;
+ArrayKey<T>::ArrayKey(ArrayKey const &) noexcept = default;
 template <typename T>
-ArrayKey<T>::ArrayKey(ArrayKey &&) = default;
+ArrayKey<T>::ArrayKey(ArrayKey &&) noexcept = default;
 template <typename T>
-ArrayKey<T> &ArrayKey<T>::operator=(ArrayKey const &) = default;
+ArrayKey<T> &ArrayKey<T>::operator=(ArrayKey const &) noexcept = default;
 template <typename T>
-ArrayKey<T> &ArrayKey<T>::operator=(ArrayKey &&) = default;
+ArrayKey<T> &ArrayKey<T>::operator=(ArrayKey &&) noexcept = default;
 template <typename T>
-ArrayKey<T>::~ArrayKey() = default;
+ArrayKey<T>::~ArrayKey() noexcept = default;
 
 template <typename T>
 ndarray::Array<T const, 1, 1> ArrayKey<T>::get(BaseRecord const &record) const {

--- a/tests/testTableArchivesLib.cc
+++ b/tests/testTableArchivesLib.cc
@@ -47,7 +47,7 @@ public:
         throw LSST_EXCEPT(lsst::pex::exceptions::LogicError, "Not Implemented");
     }
 
-    virtual bool isPersistable() const { return true; }
+    virtual bool isPersistable() const noexcept { return true; }
 
     double getValue() const { return _x; }
 

--- a/tests/test_tableArchives.cc
+++ b/tests/test_tableArchives.cc
@@ -71,7 +71,7 @@ public:
 
     ExampleA(int v1, double v2, ndarray::Array<float, 1, 1> const &v3) : var1(v1), var2(v2), var3(v3) {}
 
-    virtual bool isPersistable() const { return true; }
+    virtual bool isPersistable() const noexcept { return true; }
 
     virtual std::string getPersistenceName() const { return "ExampleA"; }
 
@@ -126,7 +126,7 @@ public:
 
     ExampleB(int v1, std::vector<double> const &v2) : var1(v1), var2(v2) {}
 
-    virtual bool isPersistable() const { return true; }
+    virtual bool isPersistable() const noexcept { return true; }
 
     virtual std::string getPersistenceName() const { return "ExampleB"; }
 
@@ -203,7 +203,7 @@ public:
              std::shared_ptr<Comparable> v3 = std::shared_ptr<Comparable>())
             : var1(v1), var2(v2), var3(v3) {}
 
-    virtual bool isPersistable() const { return true; }
+    virtual bool isPersistable() const noexcept { return true; }
 
     virtual std::string getPersistenceName() const { return "ExampleC"; }
 
@@ -261,7 +261,7 @@ public:
 
     virtual void stream(std::ostream &os) const { os << "ExampleD()"; }
 
-    virtual bool isPersistable() const { return true; }
+    virtual bool isPersistable() const noexcept { return true; }
 
     virtual std::string getPersistenceName() const { return "ExampleD"; }
 


### PR DESCRIPTION
This PR adds `noexcept` specifiers to several key types in `lsst::afw`. I have omitted these specifiers in a couple of key cases:
- any method that directly or indirectly uses dynamic memory allocation, or where it might be reasonable to want that in the future.  This includes methods that return `vector` or `string` by value.
- any method that could in principle take an invalid input (e.g., anything that takes an index) has been left potentially throwing
- some classes have implementations that I wasn't able to analyze (e.g., `ImageBase` and classes that compose it or its subclasses); to be on the safe side, I left these classes untouched even when a method "obviously shouldn't" throw

I was a bit surprised to conclude that `afw::table::FieldBase<T>` and `KeyBase<T>` are unconditionally nothrow-constructible and nothrow-copyable; please confirm that neither they nor any reasonable subclass can ever have a constructor failure for any `T`.