### PR TITLE
DM-14840 Make mask transparency and color "sticky" in display_firefly

### DIFF
--- a/python/lsst/afw/display/interface.py
+++ b/python/lsst/afw/display/interface.py
@@ -396,7 +396,7 @@ class Display:
         if isinstance(transparency, dict):
             assert name is None
             for k, v in transparency.items():
-                self.setMaskTransparency(k, v)
+                self.setMaskTransparency(v, k)
             return
 
         if transparency is not None and (transparency < 0 or transparency > 100):


### PR DESCRIPTION
This PR is a very small bug fix for `afwDisplay.setDefaultMaskTransparency` to swap the order of arguments when these are a dictionary, that are provided to `setMaskTransparency`.