### PR TITLE
DM-14814: Change invalid pixel handling by Exposure::getCutout

### DIFF
--- a/include/lsst/afw/image/Exposure.h
+++ b/include/lsst/afw/image/Exposure.h
@@ -214,14 +214,12 @@ public:
      *       references to images (just as the copy constructor does).
      *       This is an intrinsic flaw in Image's design.
      */
-    Exposure subset(lsst::geom::Box2I const & bbox, ImageOrigin origin=PARENT) const {
+    Exposure subset(lsst::geom::Box2I const& bbox, ImageOrigin origin = PARENT) const {
         return Exposure(*this, bbox, origin, false);
     }
 
     /// Return a subimage corresponding to the given box (interpreted as PARENT coordinates).
-    Exposure operator[](lsst::geom::Box2I const & bbox) const {
-        return subset(bbox);
-    }
+    Exposure operator[](lsst::geom::Box2I const& bbox) const { return subset(bbox); }
 
     /** Destructor
      */

--- a/include/lsst/afw/image/Exposure.h
+++ b/include/lsst/afw/image/Exposure.h
@@ -421,7 +421,8 @@ public:
      *
      * @return An Exposure of the requested size centered on `center` to within
      *     half a pixel in either dimension. Pixels past the edge of the original
-     *     exposure will be zero.
+     *     exposure will equal @ref math::edgePixel(image::detail::MaskedImage_tag)
+     *     "math::edgePixel<MaskedImageT>".
      *
      * @throws lsst::pex::exceptions::LogicError Thrown if this Exposure does
      *     not have a WCS.

--- a/include/lsst/afw/math/ConvolveImage.h
+++ b/include/lsst/afw/math/ConvolveImage.h
@@ -228,7 +228,10 @@ typename ImageT::SinglePixel edgePixel(lsst::afw::image::detail::Image_tag
  * The components are:
  * - %image = quiet_NaN if that exists for the pixel type, else 0
  * - mask = NO_DATA bit set
- * - variance = infinity
+ * - variance = infinity if that exists for the pixel type, else 0
+ *
+ * @throws lsst::pex::exceptions::LogicError Thrown if the global
+ *     mask plane dictionary does not have a NO_DATA bit.
  */
 template <typename MaskedImageT>
 typename MaskedImageT::SinglePixel edgePixel(
@@ -238,10 +241,14 @@ typename MaskedImageT::SinglePixel edgePixel(
     typedef typename MaskedImageT::Image::Pixel ImagePixelT;
     typedef typename MaskedImageT::Variance::Pixel VariancePixelT;
 
-    return typename MaskedImageT::SinglePixel(
-            std::numeric_limits<ImagePixelT>::has_quiet_NaN ? std::numeric_limits<ImagePixelT>::quiet_NaN()
-                                                            : 0,
-            MaskedImageT::Mask::getPlaneBitMask("NO_DATA"), std::numeric_limits<VariancePixelT>::infinity());
+    auto imagePixel = std::numeric_limits<ImagePixelT>::has_quiet_NaN
+                              ? std::numeric_limits<ImagePixelT>::quiet_NaN()
+                              : 0;
+    auto maskPixel = MaskedImageT::Mask::getPlaneBitMask("NO_DATA");
+    auto variancePixel = std::numeric_limits<VariancePixelT>::has_infinity
+                                 ? std::numeric_limits<VariancePixelT>::infinity()
+                                 : 0;
+    return typename MaskedImageT::SinglePixel(imagePixel, maskPixel, variancePixel);
 }
 
 /*

--- a/src/image/Exposure.cc
+++ b/src/image/Exposure.cc
@@ -38,6 +38,7 @@
 #include "lsst/afw/image/Exposure.h"
 #include "lsst/afw/detection/Psf.h"
 #include "lsst/afw/image/Calib.h"
+#include "lsst/afw/math/ConvolveImage.h"
 #include "lsst/afw/cameraGeom/Detector.h"
 #include "lsst/afw/fits.h"
 
@@ -243,6 +244,8 @@ Exposure<ImageT, MaskT, VarianceT> Exposure<ImageT, MaskT, VarianceT>::getCutout
     // cutout must have independent ExposureInfo
     auto copyInfo = std::make_shared<ExposureInfo>(*getInfo());
     MaskedImageT blank(bbox);  // Can't initialize Exposure with a temporary
+    blank = math::edgePixel<MaskedImageT>(
+            typename image::detail::image_traits<MaskedImageT>::image_category());
     Exposure cutout(blank, copyInfo);
 
     _copyCommonPixels(cutout, *this);


### PR DESCRIPTION
This PR changes the behavior of `Exposure::getCutout` when creating cutouts that extend off the edge of the original exposure. Previously, the off-edge pixels were left blank; the new behavior is to set them to `math::edgePixel`. Note that this means `getCutout` now throws an exception if the `NO_DATA` flag has been deleted from the global mask plane dictionary.