### PR TITLE
DM-9933: Add C++11 inheritance safeguards to afw

### DIFF
--- a/include/lsst/afw/cameraGeom/CameraSys.h
+++ b/include/lsst/afw/cameraGeom/CameraSys.h
@@ -41,7 +41,7 @@ namespace cameraGeom {
  * This is Jim Bosch's clever idea for simplifying Detector.convert;
  * CameraSys is always complete and CameraSysPrefix is not.
  */
-class CameraSysPrefix {
+class CameraSysPrefix final {
 public:
     explicit CameraSysPrefix(std::string const &sysName  ///< coordinate system name
                              )
@@ -80,7 +80,7 @@ private:
 /**
  * Camera coordinate system; used as a key in in TransformMap
  */
-class CameraSys {
+class CameraSys final {
 public:
     /**
      * Construct a CameraSys from a sysName and a detectorName

--- a/include/lsst/afw/cameraGeom/Detector.h
+++ b/include/lsst/afw/cameraGeom/Detector.h
@@ -61,7 +61,7 @@ enum DetectorType {
  * @note code definitions use lsst::afw::table:: instead of table:: because the latter confused swig
  * when I tried it. This is a known issue: ticket #2461.
  */
-class Detector {
+class Detector final {
 public:
     typedef ndarray::Array<float const, 2> CrosstalkMatrix;
 

--- a/include/lsst/afw/cameraGeom/Orientation.h
+++ b/include/lsst/afw/cameraGeom/Orientation.h
@@ -49,7 +49,7 @@ namespace cameraGeom {
  * This means that the default-constructed Orientation is not a unity transform,
  * but instead includes a 1/2 pixel shift.
  */
-class Orientation {
+class Orientation final {
 public:
     explicit Orientation(lsst::geom::Point2D const fpPosition = lsst::geom::Point2D(0, 0),
                          ///< Focal plane position of detector reference point (mm)

--- a/include/lsst/afw/coord/Observatory.h
+++ b/include/lsst/afw/coord/Observatory.h
@@ -38,7 +38,7 @@ namespace coord {
 /**
  * Hold the location of an observatory
  */
-class Observatory {
+class Observatory final {
 public:
     /**
      * Construct an Observatory with longitude and latitude specified as lsst::geom::Angle

--- a/include/lsst/afw/coord/Weather.h
+++ b/include/lsst/afw/coord/Weather.h
@@ -35,7 +35,7 @@ namespace coord {
  *
  * Weather is immutable.
  */
-class Weather {
+class Weather final {
 public:
     /**
      * Construct a Weather

--- a/include/lsst/afw/detection/Footprint.h
+++ b/include/lsst/afw/detection/Footprint.h
@@ -107,7 +107,7 @@ public:
     Footprint &operator=(Footprint const &other) = default;
     Footprint &operator=(Footprint &&) = default;
 
-    virtual ~Footprint() = default;
+    ~Footprint() override = default;
 
     /** Indicates if this object is a HeavyFootprint
      */

--- a/include/lsst/afw/detection/FootprintMerge.h
+++ b/include/lsst/afw/detection/FootprintMerge.h
@@ -53,7 +53,7 @@ class FootprintMerge;
  *  are operating on smallish number of objects, such as at the tract level.
  *
  */
-class FootprintMergeList {
+class FootprintMergeList final {
 public:
     /**
      *  Initialize the merge with a custom initial peak schema

--- a/include/lsst/afw/detection/GaussianPsf.h
+++ b/include/lsst/afw/detection/GaussianPsf.h
@@ -58,17 +58,17 @@ public:
      */
     GaussianPsf(lsst::geom::Extent2I const& dimensions, double sigma);
 
-    ~GaussianPsf();
+    ~GaussianPsf() override;
     GaussianPsf(GaussianPsf const&);
     GaussianPsf(GaussianPsf&&);
     GaussianPsf& operator=(GaussianPsf const&) = delete;
     GaussianPsf& operator=(GaussianPsf&&) = delete;
 
     /// Polymorphic deep copy; should usually be unnecessary because Psfs are immutable.
-    virtual std::shared_ptr<afw::detection::Psf> clone() const;
+    std::shared_ptr<afw::detection::Psf> clone() const override;
 
     /// Return a clone with specified kernel dimensions
-    virtual std::shared_ptr<afw::detection::Psf> resized(int width, int height) const;
+    std::shared_ptr<afw::detection::Psf> resized(int width, int height) const override;
 
     /// Return the dimensions of the images returned by computeImage()
     lsst::geom::Extent2I getDimensions() const { return _dimensions; }
@@ -77,14 +77,14 @@ public:
     double getSigma() const { return _sigma; }
 
     /// Whether the Psf is persistable; always true.
-    virtual bool isPersistable() const noexcept override { return true; }
+    bool isPersistable() const noexcept override { return true; }
 
 protected:
-    virtual std::string getPersistenceName() const;
+    std::string getPersistenceName() const override;
 
-    virtual std::string getPythonModule() const;
+    std::string getPythonModule() const override;
 
-    virtual void write(OutputArchiveHandle& handle) const;
+    void write(OutputArchiveHandle& handle) const override;
 
 private:
 #if 0  // We could reimplement this more efficiently than what's in the base class,
@@ -95,17 +95,17 @@ private:
     ) const;
 #endif
 
-    virtual std::shared_ptr<Image> doComputeKernelImage(lsst::geom::Point2D const& position,
-                                                        image::Color const& color) const;
+    std::shared_ptr<Image> doComputeKernelImage(lsst::geom::Point2D const& position,
+                                                image::Color const& color) const override;
 
-    virtual double doComputeApertureFlux(double radius, lsst::geom::Point2D const& position,
-                                         image::Color const& color) const;
+    double doComputeApertureFlux(double radius, lsst::geom::Point2D const& position,
+                                 image::Color const& color) const override;
 
-    virtual geom::ellipses::Quadrupole doComputeShape(lsst::geom::Point2D const& position,
-                                                      image::Color const& color) const;
+    geom::ellipses::Quadrupole doComputeShape(lsst::geom::Point2D const& position,
+                                              image::Color const& color) const override;
 
-    virtual lsst::geom::Box2I doComputeBBox(lsst::geom::Point2D const& position,
-                                            image::Color const& color) const;
+    lsst::geom::Box2I doComputeBBox(lsst::geom::Point2D const& position,
+                                    image::Color const& color) const override;
 
     lsst::geom::Extent2I _dimensions;
     double _sigma;

--- a/include/lsst/afw/detection/HeavyFootprint.h
+++ b/include/lsst/afw/detection/HeavyFootprint.h
@@ -79,7 +79,7 @@ public:
      * with the assignment operator
      */
     HeavyFootprint() = default;
-    ~HeavyFootprint() = default;
+    ~HeavyFootprint() override = default;
 
     HeavyFootprint(HeavyFootprint const& other) = default;
     HeavyFootprint(HeavyFootprint&& other) = default;
@@ -90,7 +90,7 @@ public:
     /**
      * Is this a HeavyFootprint (yes!)
      */
-    virtual bool isHeavy() const { return true; }
+    bool isHeavy() const override { return true; }
 
     /**
      * Replace all the pixels in the image with the values in the HeavyFootprint.
@@ -130,9 +130,9 @@ public:
 protected:
     class Factory;  // factory class used for persistence, public only so we can instantiate it in .cc file
 
-    virtual std::string getPersistenceName() const;
+    std::string getPersistenceName() const override;
 
-    virtual void write(OutputArchiveHandle& handle) const;
+    void write(OutputArchiveHandle& handle) const override;
 
 private:
     ndarray::Array<ImagePixelT, 1, 1> _image;

--- a/include/lsst/afw/detection/Peak.h
+++ b/include/lsst/afw/detection/Peak.h
@@ -46,7 +46,7 @@ public:
     typedef afw::table::CatalogT<PeakRecord> Catalog;
     typedef afw::table::CatalogT<PeakRecord const> ConstCatalog;
 
-    virtual ~PeakRecord() = default;
+    ~PeakRecord() override = default;
     PeakRecord(PeakRecord const&) = delete;
     PeakRecord(PeakRecord&&) = delete;
     PeakRecord& operator=(PeakRecord const&) = delete;
@@ -96,7 +96,7 @@ public:
     typedef afw::table::CatalogT<Record> Catalog;
     typedef afw::table::CatalogT<Record const> ConstCatalog;
 
-    virtual ~PeakTable();
+    ~PeakTable() override;
     PeakTable& operator=(PeakTable const&) = delete;
     PeakTable& operator=(PeakTable&&) = delete;
 

--- a/include/lsst/afw/detection/Psf.h
+++ b/include/lsst/afw/detection/Psf.h
@@ -100,7 +100,7 @@ public:
     Psf& operator=(Psf&&) = delete;
 
     Psf(Psf&&);
-    virtual ~Psf();
+    ~Psf() override;
 
     /**
      *  Polymorphic deep-copy.

--- a/include/lsst/afw/detection/PsfFormatter.h
+++ b/include/lsst/afw/detection/PsfFormatter.h
@@ -22,24 +22,23 @@ class PsfFormatter : public lsst::daf::persistence::Formatter {
 public:
     /** Minimal destructor.
      */
-    virtual ~PsfFormatter();
+    ~PsfFormatter() override;
 
     PsfFormatter(PsfFormatter const&);
     PsfFormatter(PsfFormatter&&);
     PsfFormatter& operator=(PsfFormatter const&);
     PsfFormatter& operator=(PsfFormatter&&);
 
-    virtual void write(lsst::daf::base::Persistable const* persistable,
-                       std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
-                       std::shared_ptr<lsst::daf::base::PropertySet> additionalData);
+    void write(lsst::daf::base::Persistable const* persistable,
+               std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
+               std::shared_ptr<lsst::daf::base::PropertySet> additionalData) override;
 
-    virtual lsst::daf::base::Persistable* read(
-            std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
-            std::shared_ptr<lsst::daf::base::PropertySet> additionalData);
+    lsst::daf::base::Persistable* read(std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
+                                       std::shared_ptr<lsst::daf::base::PropertySet> additionalData) override;
 
-    virtual void update(lsst::daf::base::Persistable* persistable,
-                        std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
-                        std::shared_ptr<lsst::daf::base::PropertySet> additionalData);
+    void update(lsst::daf::base::Persistable* persistable,
+                std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
+                std::shared_ptr<lsst::daf::base::PropertySet> additionalData) override;
 
     /** Serialize a Psf to a Boost archive.  Handles text or XML
      * archives, input or output.

--- a/include/lsst/afw/detection/Threshold.h
+++ b/include/lsst/afw/detection/Threshold.h
@@ -40,7 +40,7 @@ namespace detection {
  * Note that the constructor is not declared explicit, so you may pass a bare
  * threshold, and it'll be interpreted as a VALUE.
  */
-class Threshold {
+class Threshold final {
 public:
     /// Types of threshold:
     enum ThresholdType {

--- a/include/lsst/afw/fitsCompression.h
+++ b/include/lsst/afw/fitsCompression.h
@@ -116,7 +116,7 @@ public:
                   const_cast<typename std::remove_const<T>::type*>(reinterpret_cast<T const*>(_pixels)));
     }
 
-    virtual ~PixelArray() {}
+    ~PixelArray() override {}
 
     void const* getData() const override { return _pixels; }
 

--- a/include/lsst/afw/formatters/DecoratedImageFormatter.h
+++ b/include/lsst/afw/formatters/DecoratedImageFormatter.h
@@ -43,22 +43,21 @@ namespace formatters {
 template <typename ImagePixelT>
 class DecoratedImageFormatter : public lsst::daf::persistence::Formatter {
 public:
-    virtual ~DecoratedImageFormatter();
+    ~DecoratedImageFormatter() override;
 
     DecoratedImageFormatter(DecoratedImageFormatter const&) = default;
     DecoratedImageFormatter(DecoratedImageFormatter&&) = default;
     DecoratedImageFormatter& operator=(DecoratedImageFormatter const&) = default;
     DecoratedImageFormatter& operator=(DecoratedImageFormatter&&) = default;
 
-    virtual void write(lsst::daf::base::Persistable const* persistable,
-                       std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
-                       std::shared_ptr<lsst::daf::base::PropertySet> additionalData);
-    virtual lsst::daf::base::Persistable* read(
-            std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
-            std::shared_ptr<lsst::daf::base::PropertySet> additionalData);
-    virtual void update(lsst::daf::base::Persistable* persistable,
-                        std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
-                        std::shared_ptr<lsst::daf::base::PropertySet> additionalData);
+    void write(lsst::daf::base::Persistable const* persistable,
+               std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
+               std::shared_ptr<lsst::daf::base::PropertySet> additionalData) override;
+    lsst::daf::base::Persistable* read(std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
+                                       std::shared_ptr<lsst::daf::base::PropertySet> additionalData) override;
+    void update(lsst::daf::base::Persistable* persistable,
+                std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
+                std::shared_ptr<lsst::daf::base::PropertySet> additionalData) override;
 
     static std::shared_ptr<lsst::daf::persistence::Formatter> createInstance(
             std::shared_ptr<lsst::pex::policy::Policy> policy);

--- a/include/lsst/afw/formatters/ExposureFormatter.h
+++ b/include/lsst/afw/formatters/ExposureFormatter.h
@@ -43,22 +43,21 @@ namespace formatters {
 template <typename ImagePixelT, typename MaskPixelT, typename VariancePixelT>
 class ExposureFormatter : public lsst::daf::persistence::Formatter {
 public:
-    virtual ~ExposureFormatter();
+    ~ExposureFormatter() override;
 
     ExposureFormatter(ExposureFormatter const&) = default;
     ExposureFormatter(ExposureFormatter&&) = default;
     ExposureFormatter& operator=(ExposureFormatter const&) = default;
     ExposureFormatter& operator=(ExposureFormatter&&) = default;
 
-    virtual void write(lsst::daf::base::Persistable const* persistable,
-                       std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
-                       std::shared_ptr<lsst::daf::base::PropertySet> additionalData);
-    virtual lsst::daf::base::Persistable* read(
-            std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
-            std::shared_ptr<lsst::daf::base::PropertySet> additionalData);
-    virtual void update(lsst::daf::base::Persistable* persistable,
-                        std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
-                        std::shared_ptr<lsst::daf::base::PropertySet> additionalData);
+    void write(lsst::daf::base::Persistable const* persistable,
+               std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
+               std::shared_ptr<lsst::daf::base::PropertySet> additionalData) override;
+    lsst::daf::base::Persistable* read(std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
+                                       std::shared_ptr<lsst::daf::base::PropertySet> additionalData) override;
+    void update(lsst::daf::base::Persistable* persistable,
+                std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
+                std::shared_ptr<lsst::daf::base::PropertySet> additionalData) override;
 
     static std::shared_ptr<lsst::daf::persistence::Formatter> createInstance(
             std::shared_ptr<lsst::pex::policy::Policy> policy);

--- a/include/lsst/afw/formatters/ImageFormatter.h
+++ b/include/lsst/afw/formatters/ImageFormatter.h
@@ -43,22 +43,21 @@ namespace formatters {
 template <typename ImagePixelT>
 class ImageFormatter : public lsst::daf::persistence::Formatter {
 public:
-    virtual ~ImageFormatter();
+    ~ImageFormatter() override;
 
     ImageFormatter(ImageFormatter const&) = default;
     ImageFormatter(ImageFormatter&&) = default;
     ImageFormatter& operator=(ImageFormatter const&) = default;
     ImageFormatter& operator=(ImageFormatter&&) = default;
 
-    virtual void write(lsst::daf::base::Persistable const* persistable,
-                       std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
-                       std::shared_ptr<lsst::daf::base::PropertySet> additionalData);
-    virtual lsst::daf::base::Persistable* read(
-            std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
-            std::shared_ptr<lsst::daf::base::PropertySet> additionalData);
-    virtual void update(lsst::daf::base::Persistable* persistable,
-                        std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
-                        std::shared_ptr<lsst::daf::base::PropertySet> additionalData);
+    void write(lsst::daf::base::Persistable const* persistable,
+               std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
+               std::shared_ptr<lsst::daf::base::PropertySet> additionalData) override;
+    lsst::daf::base::Persistable* read(std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
+                                       std::shared_ptr<lsst::daf::base::PropertySet> additionalData) override;
+    void update(lsst::daf::base::Persistable* persistable,
+                std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
+                std::shared_ptr<lsst::daf::base::PropertySet> additionalData) override;
 
     static std::shared_ptr<lsst::daf::persistence::Formatter> createInstance(
             std::shared_ptr<lsst::pex::policy::Policy> policy);

--- a/include/lsst/afw/formatters/KernelFormatter.h
+++ b/include/lsst/afw/formatters/KernelFormatter.h
@@ -46,24 +46,23 @@ class KernelFormatter : public lsst::daf::persistence::Formatter {
 public:
     /** Minimal destructor.
      */
-    virtual ~KernelFormatter();
+    ~KernelFormatter() override;
 
     KernelFormatter(KernelFormatter const&);
     KernelFormatter(KernelFormatter&&);
     KernelFormatter& operator=(KernelFormatter const&);
     KernelFormatter& operator=(KernelFormatter&&);
 
-    virtual void write(lsst::daf::base::Persistable const* persistable,
-                       std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
-                       std::shared_ptr<lsst::daf::base::PropertySet> additionalData);
+    void write(lsst::daf::base::Persistable const* persistable,
+               std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
+               std::shared_ptr<lsst::daf::base::PropertySet> additionalData) override;
 
-    virtual lsst::daf::base::Persistable* read(
-            std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
-            std::shared_ptr<lsst::daf::base::PropertySet> additionalData);
+    lsst::daf::base::Persistable* read(std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
+                                       std::shared_ptr<lsst::daf::base::PropertySet> additionalData) override;
 
-    virtual void update(lsst::daf::base::Persistable* persistable,
-                        std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
-                        std::shared_ptr<lsst::daf::base::PropertySet> additionalData);
+    void update(lsst::daf::base::Persistable* persistable,
+                std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
+                std::shared_ptr<lsst::daf::base::PropertySet> additionalData) override;
 
     /** Serialize a Kernel to a Boost archive.  Handles text or XML
      * archives, input or output.

--- a/include/lsst/afw/formatters/MaskFormatter.h
+++ b/include/lsst/afw/formatters/MaskFormatter.h
@@ -43,22 +43,21 @@ namespace formatters {
 template <typename MaskPixelT>
 class MaskFormatter : public lsst::daf::persistence::Formatter {
 public:
-    virtual ~MaskFormatter();
+    ~MaskFormatter() override;
 
     MaskFormatter(MaskFormatter const&) = default;
     MaskFormatter(MaskFormatter&&) = default;
     MaskFormatter& operator=(MaskFormatter const&) = default;
     MaskFormatter& operator=(MaskFormatter&&) = default;
 
-    virtual void write(lsst::daf::base::Persistable const* persistable,
-                       std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
-                       std::shared_ptr<lsst::daf::base::PropertySet> additionalData);
-    virtual lsst::daf::base::Persistable* read(
-            std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
-            std::shared_ptr<lsst::daf::base::PropertySet> additionalData);
-    virtual void update(lsst::daf::base::Persistable* persistable,
-                        std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
-                        std::shared_ptr<lsst::daf::base::PropertySet> additionalData);
+    void write(lsst::daf::base::Persistable const* persistable,
+               std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
+               std::shared_ptr<lsst::daf::base::PropertySet> additionalData) override;
+    lsst::daf::base::Persistable* read(std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
+                                       std::shared_ptr<lsst::daf::base::PropertySet> additionalData) override;
+    void update(lsst::daf::base::Persistable* persistable,
+                std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
+                std::shared_ptr<lsst::daf::base::PropertySet> additionalData) override;
 
     static std::shared_ptr<lsst::daf::persistence::Formatter> createInstance(
             std::shared_ptr<lsst::pex::policy::Policy> policy);

--- a/include/lsst/afw/formatters/MaskedImageFormatter.h
+++ b/include/lsst/afw/formatters/MaskedImageFormatter.h
@@ -43,22 +43,21 @@ namespace formatters {
 template <typename ImagePixelT, typename MaskPixelT, typename VariancePixelT>
 class MaskedImageFormatter : public lsst::daf::persistence::Formatter {
 public:
-    virtual ~MaskedImageFormatter();
+    ~MaskedImageFormatter() override;
 
     MaskedImageFormatter(MaskedImageFormatter const&) = default;
     MaskedImageFormatter(MaskedImageFormatter&&) = default;
     MaskedImageFormatter& operator=(MaskedImageFormatter const&) = default;
     MaskedImageFormatter& operator=(MaskedImageFormatter&&) = default;
 
-    virtual void write(lsst::daf::base::Persistable const* persistable,
-                       std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
-                       std::shared_ptr<lsst::daf::base::PropertySet> additionalData);
-    virtual lsst::daf::base::Persistable* read(
-            std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
-            std::shared_ptr<lsst::daf::base::PropertySet> additionalData);
-    virtual void update(lsst::daf::base::Persistable* persistable,
-                        std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
-                        std::shared_ptr<lsst::daf::base::PropertySet> additionalData);
+    void write(lsst::daf::base::Persistable const* persistable,
+               std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
+               std::shared_ptr<lsst::daf::base::PropertySet> additionalData) override;
+    lsst::daf::base::Persistable* read(std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
+                                       std::shared_ptr<lsst::daf::base::PropertySet> additionalData) override;
+    void update(lsst::daf::base::Persistable* persistable,
+                std::shared_ptr<lsst::daf::persistence::FormatterStorage> storage,
+                std::shared_ptr<lsst::daf::base::PropertySet> additionalData) override;
 
     static std::shared_ptr<lsst::daf::persistence::Formatter> createInstance(
             std::shared_ptr<lsst::pex::policy::Policy> policy);

--- a/include/lsst/afw/formatters/PropertyListFormatter.h
+++ b/include/lsst/afw/formatters/PropertyListFormatter.h
@@ -38,23 +38,23 @@ namespace formatters {
  */
 class PropertyListFormatter : public daf::persistence::Formatter {
 public:
-    virtual ~PropertyListFormatter() = default;
+    ~PropertyListFormatter() override = default;
 
     PropertyListFormatter(PropertyListFormatter const&);
     PropertyListFormatter(PropertyListFormatter&&);
     PropertyListFormatter& operator=(PropertyListFormatter const&);
     PropertyListFormatter& operator=(PropertyListFormatter&&);
 
-    virtual void write(daf::base::Persistable const* persistable,
-                       std::shared_ptr<daf::persistence::FormatterStorage> storage,
-                       std::shared_ptr<daf::base::PropertySet> additionalData);
+    void write(daf::base::Persistable const* persistable,
+               std::shared_ptr<daf::persistence::FormatterStorage> storage,
+               std::shared_ptr<daf::base::PropertySet> additionalData) override;
 
-    virtual daf::base::Persistable* read(std::shared_ptr<daf::persistence::FormatterStorage> storage,
-                                         std::shared_ptr<daf::base::PropertySet> additionalData);
+    daf::base::Persistable* read(std::shared_ptr<daf::persistence::FormatterStorage> storage,
+                                 std::shared_ptr<daf::base::PropertySet> additionalData) override;
 
-    virtual void update(daf::base::Persistable* persistable,
-                        std::shared_ptr<daf::persistence::FormatterStorage> storage,
-                        std::shared_ptr<daf::base::PropertySet> additionalData);
+    void update(daf::base::Persistable* persistable,
+                std::shared_ptr<daf::persistence::FormatterStorage> storage,
+                std::shared_ptr<daf::base::PropertySet> additionalData) override;
 
     static std::shared_ptr<daf::persistence::Formatter> createInstance(
             std::shared_ptr<pex::policy::Policy> policy);

--- a/include/lsst/afw/geom/Endpoint.h
+++ b/include/lsst/afw/geom/Endpoint.h
@@ -202,9 +202,9 @@ public:
     BaseVectorEndpoint &operator=(BaseVectorEndpoint const &) = delete;
     BaseVectorEndpoint &operator=(BaseVectorEndpoint &&) = delete;
 
-    virtual ~BaseVectorEndpoint() = default;
+    ~BaseVectorEndpoint() override = default;
 
-    virtual int getNPoints(Array const &arr) const override;
+    int getNPoints(Array const &arr) const override;
 
 protected:
     /**
@@ -239,17 +239,17 @@ public:
      */
     explicit GenericEndpoint(int nAxes) : BaseEndpoint(nAxes){};
 
-    virtual ~GenericEndpoint() = default;
+    ~GenericEndpoint() override = default;
 
-    virtual int getNPoints(Array const &arr) const override { return arr.getSize<1>(); }
+    int getNPoints(Array const &arr) const override { return arr.getSize<1>(); }
 
-    virtual std::vector<double> dataFromPoint(Point const &point) const override;
+    std::vector<double> dataFromPoint(Point const &point) const override;
 
-    virtual ndarray::Array<double, 2, 2> dataFromArray(Array const &arr) const override;
+    ndarray::Array<double, 2, 2> dataFromArray(Array const &arr) const override;
 
-    virtual Point pointFromData(std::vector<double> const &data) const override;
+    Point pointFromData(std::vector<double> const &data) const override;
 
-    virtual Array arrayFromData(ndarray::Array<double, 2, 2> const &data) const override;
+    Array arrayFromData(ndarray::Array<double, 2, 2> const &data) const override;
 
     /// Get the class name prefix, e.g. "Point2" for "Point2Endpoint"
     static std::string getClassPrefix() { return "Generic"; };
@@ -282,15 +282,15 @@ public:
      */
     explicit Point2Endpoint(int nAxes);
 
-    virtual ~Point2Endpoint() = default;
+    ~Point2Endpoint() override = default;
 
-    virtual std::vector<double> dataFromPoint(Point const &point) const override;
+    std::vector<double> dataFromPoint(Point const &point) const override;
 
-    virtual ndarray::Array<double, 2, 2> dataFromArray(Array const &arr) const override;
+    ndarray::Array<double, 2, 2> dataFromArray(Array const &arr) const override;
 
-    virtual Point pointFromData(std::vector<double> const &data) const override;
+    Point pointFromData(std::vector<double> const &data) const override;
 
-    virtual Array arrayFromData(ndarray::Array<double, 2, 2> const &data) const override;
+    Array arrayFromData(ndarray::Array<double, 2, 2> const &data) const override;
 
     /**
      * Check that framePtr points to a Frame, not a subclass
@@ -301,7 +301,7 @@ public:
      * in any case. A CmpFrame could be cartesian, but we play it safe and reject these
      * (however, a cartesian CmpFrame ought to simplify to a Frame).
      */
-    virtual void normalizeFrame(std::shared_ptr<ast::Frame> framePtr) const override;
+    void normalizeFrame(std::shared_ptr<ast::Frame> framePtr) const override;
 
     /// Get the class name prefix, e.g. "Point2" for "Point2Endpoint"
     static std::string getClassPrefix() { return "Point2"; };
@@ -336,21 +336,21 @@ public:
      */
     explicit SpherePointEndpoint(int nAxes);
 
-    virtual ~SpherePointEndpoint() = default;
+    ~SpherePointEndpoint() override = default;
 
-    virtual std::vector<double> dataFromPoint(Point const &point) const override;
+    std::vector<double> dataFromPoint(Point const &point) const override;
 
-    virtual ndarray::Array<double, 2, 2> dataFromArray(Array const &arr) const override;
+    ndarray::Array<double, 2, 2> dataFromArray(Array const &arr) const override;
 
-    virtual Point pointFromData(std::vector<double> const &data) const override;
+    Point pointFromData(std::vector<double> const &data) const override;
 
-    virtual Array arrayFromData(ndarray::Array<double, 2, 2> const &data) const override;
+    Array arrayFromData(ndarray::Array<double, 2, 2> const &data) const override;
 
     /// Create a Frame that can be used with this end point in a Transform
-    virtual std::shared_ptr<ast::Frame> makeFrame() const override;
+    std::shared_ptr<ast::Frame> makeFrame() const override;
 
     /// Check that framePtr points to a SkyFrame and set longitude axis to 0, latitude to 1
-    virtual void normalizeFrame(std::shared_ptr<ast::Frame> framePtr) const override;
+    void normalizeFrame(std::shared_ptr<ast::Frame> framePtr) const override;
 
     /// Get the class name prefix, e.g. "Point2" for "Point2Endpoint"
     static std::string getClassPrefix() { return "SpherePoint"; };

--- a/include/lsst/afw/geom/SipApproximation.h
+++ b/include/lsst/afw/geom/SipApproximation.h
@@ -91,7 +91,7 @@ namespace lsst { namespace afw { namespace geom {
  *  exact mapping from pixels to Intermediate World Coordinates with a SIP
  *  distortion.
  */
-class SipApproximation {
+class SipApproximation final {
 public:
 
     /**

--- a/include/lsst/afw/geom/SkyWcs.h
+++ b/include/lsst/afw/geom/SkyWcs.h
@@ -118,7 +118,7 @@ public:
     SkyWcs(SkyWcs &&) = default;
     SkyWcs &operator=(SkyWcs const &) = delete;
     SkyWcs &operator=(SkyWcs &&) = delete;
-    ~SkyWcs() = default;
+    ~SkyWcs() override = default;
 
     /**
      * Equality is based on the string representations being equal

--- a/include/lsst/afw/geom/Span.h
+++ b/include/lsst/afw/geom/Span.h
@@ -51,7 +51,7 @@ namespace geom {
 /**
  * A range of pixels within one row of an Image
  */
-class Span {
+class Span final {
 public:
     /// An iterator over points in the Span.
     typedef SpanPixelIterator Iterator;

--- a/include/lsst/afw/geom/SpanSet.h
+++ b/include/lsst/afw/geom/SpanSet.h
@@ -162,7 +162,7 @@ public:
     // Explicitly delete copy and move constructors
     SpanSet(SpanSet const &other) = delete;
     SpanSet(SpanSet &&other) = delete;
-    ~SpanSet() = default;
+    ~SpanSet() override = default;
 
     SpanSet &operator=(SpanSet const &) = default;
     // Delegate to copy-assignment for backwards compatibility

--- a/include/lsst/afw/geom/SpanSetFunctorGetters.h
+++ b/include/lsst/afw/geom/SpanSetFunctorGetters.h
@@ -85,7 +85,7 @@ void variadicIncrementPosition(T& first, Args&... x) {
  */
 
 template <typename T>
-class IterGetter {
+class IterGetter final {
     /* Getter class to manage retrieving values from a generic iterator
        !!! be careful !!! Because there is no way to easily check bounds
        for a generic iterator, it is possible to pass an iterator too
@@ -124,7 +124,7 @@ private:
 };
 
 template <typename T>
-class ConstantGetter {
+class ConstantGetter final {
     // Getter class which takes in a constant value, and simply returns that value
     // for each iteration
 public:
@@ -152,7 +152,7 @@ private:
 };
 
 template <typename T, int N, int C>
-class ImageNdGetter {
+class ImageNdGetter final {
     // Getter class to manage iterating though an ndarray which is interpreted as a 2D image
 public:
     using Reference = typename ndarray::Array<T, N, C>::Reference::Reference;
@@ -192,7 +192,7 @@ private:
 };
 
 template <typename T, int inA, int inC>
-class FlatNdGetter {
+class FlatNdGetter final {
     // Getter class to manage iterating though an ndarray which is interpreted as a 1D image
 public:
     using Reference = typename ndarray::Array<T, inA, inC>::Reference;

--- a/include/lsst/afw/geom/Transform.h
+++ b/include/lsst/afw/geom/Transform.h
@@ -79,7 +79,7 @@ public:
     Transform(Transform &&) = default;
     Transform &operator=(Transform const &) = delete;
     Transform &operator=(Transform &&) = delete;
-    ~Transform() = default;
+    ~Transform() override = default;
 
     /**
      * Construct a Transform from a deep copy of an ast::Mapping

--- a/include/lsst/afw/geom/ellipses/Axes.h
+++ b/include/lsst/afw/geom/ellipses/Axes.h
@@ -61,17 +61,17 @@ public:
     std::shared_ptr<Axes> clone() const { return std::static_pointer_cast<Axes>(_clone()); }
 
     /// Return a string that identifies this parametrization.
-    virtual std::string getName() const;
+    std::string getName() const override;
 
     /**
      *  @brief Put the parameters into a "standard form", if possible, and throw InvalidParameterError
      *         if they cannot be normalized.
      */
-    virtual void normalize();
+    void normalize() override;
 
-    virtual void readParameters(double const* iter);
+    void readParameters(double const* iter) override;
 
-    virtual void writeParameters(double* iter) const;
+    void writeParameters(double* iter) const override;
 
     /// Standard assignment.
     Axes& operator=(Axes const& other) {
@@ -102,7 +102,7 @@ public:
     Axes(Axes const& other) : _vector(other._vector) {}
     // Delegate to copy-constructor for backwards compatibility
     Axes(Axes&& other) : Axes(other) {}
-    ~Axes() = default;
+    ~Axes() override = default;
 
     /// Converting copy constructor.
     Axes(BaseCore const& other) { *this = other; }
@@ -114,19 +114,19 @@ public:
     Axes(BaseCore::Convolution const& convolution) { convolution.apply(*this); }
 
 protected:
-    virtual std::shared_ptr<BaseCore> _clone() const { return std::make_shared<Axes>(*this); }
+    std::shared_ptr<BaseCore> _clone() const override { return std::make_shared<Axes>(*this); }
 
-    virtual void _assignToQuadrupole(double& ixx, double& iyy, double& ixy) const;
-    virtual void _assignFromQuadrupole(double ixx, double iyy, double ixy);
+    void _assignToQuadrupole(double& ixx, double& iyy, double& ixy) const override;
+    void _assignFromQuadrupole(double ixx, double iyy, double ixy) override;
 
-    virtual void _assignToAxes(double& a, double& b, double& theta) const;
-    virtual void _assignFromAxes(double a, double b, double theta);
+    void _assignToAxes(double& a, double& b, double& theta) const override;
+    void _assignFromAxes(double a, double b, double theta) override;
 
-    virtual Jacobian _dAssignToQuadrupole(double& ixx, double& iyy, double& ixy) const;
-    virtual Jacobian _dAssignFromQuadrupole(double ixx, double iyy, double ixy);
+    Jacobian _dAssignToQuadrupole(double& ixx, double& iyy, double& ixy) const override;
+    Jacobian _dAssignFromQuadrupole(double ixx, double iyy, double ixy) override;
 
-    virtual Jacobian _dAssignToAxes(double& a, double& b, double& theta) const;
-    virtual Jacobian _dAssignFromAxes(double a, double b, double theta);
+    Jacobian _dAssignToAxes(double& a, double& b, double& theta) const override;
+    Jacobian _dAssignFromAxes(double a, double b, double theta) override;
 
 private:
     static Registrar<Axes> registrar;

--- a/include/lsst/afw/geom/ellipses/Convolution.h
+++ b/include/lsst/afw/geom/ellipses/Convolution.h
@@ -43,7 +43,7 @@ namespace ellipses {
 /**
  *  A temporary-only expression object for ellipse core convolution.
  */
-class BaseCore::Convolution {
+class BaseCore::Convolution final {
 public:
     /// Matrix type for derivative with respect to input ellipse parameters.
     typedef Eigen::Matrix3d DerivativeMatrix;
@@ -69,7 +69,7 @@ public:
 /**
  *  A temporary-only expression object for ellipse convolution.
  */
-class Ellipse::Convolution {
+class Ellipse::Convolution final {
 public:
     /// Matrix type for derivative with respect to input ellipse parameters.
     typedef Eigen::Matrix<double, 5, 5> DerivativeMatrix;

--- a/include/lsst/afw/geom/ellipses/GridTransform.h
+++ b/include/lsst/afw/geom/ellipses/GridTransform.h
@@ -45,7 +45,7 @@ namespace ellipses {
  *  @brief A temporary-only expression object representing an lsst::geom::LinearTransform that
  *         maps the ellipse core to a unit circle.
  */
-class BaseCore::GridTransform {
+class BaseCore::GridTransform final {
 public:
     /// Matrix type for derivative with respect to ellipse parameters.
     typedef Eigen::Matrix<double, 4, 3> DerivativeMatrix;
@@ -84,7 +84,7 @@ private:
  *  @brief A temporary-only expression object representing an lsst::geom::AffineTransform that
  *         maps the Ellipse to a unit circle at the origin.
  */
-class Ellipse::GridTransform {
+class Ellipse::GridTransform final {
 public:
     /// Matrix type for derivative with respect to input ellipse parameters.
     typedef Eigen::Matrix<double, 6, 5> DerivativeMatrix;

--- a/include/lsst/afw/geom/ellipses/Parametric.h
+++ b/include/lsst/afw/geom/ellipses/Parametric.h
@@ -36,7 +36,7 @@ namespace ellipses {
  *  @brief A functor that returns points on the boundary of the ellipse as a function
  *         of a parameter that runs between 0 and 2 pi (but is not angle).
  */
-class Parametric {
+class Parametric final {
 public:
     Parametric(Ellipse const& ellipse);
 

--- a/include/lsst/afw/geom/ellipses/PixelRegion.h
+++ b/include/lsst/afw/geom/ellipses/PixelRegion.h
@@ -35,7 +35,7 @@ namespace afw {
 namespace geom {
 namespace ellipses {
 
-class PixelRegion {
+class PixelRegion final {
 public:
     class Iterator;
 

--- a/include/lsst/afw/geom/ellipses/Quadrupole.h
+++ b/include/lsst/afw/geom/ellipses/Quadrupole.h
@@ -64,17 +64,17 @@ public:
     std::shared_ptr<Quadrupole> clone() const { return std::static_pointer_cast<Quadrupole>(_clone()); }
 
     /// Return a string that identifies this parametrization.
-    virtual std::string getName() const;
+    std::string getName() const override;
 
     /**
      *  @brief Put the parameters into a "standard form", and throw InvalidParameterError
      *         if they cannot be normalized.
      */
-    virtual void normalize();
+    void normalize() override;
 
-    virtual void readParameters(double const* iter);
+    void readParameters(double const* iter) override;
 
-    virtual void writeParameters(double* iter) const;
+    void writeParameters(double* iter) const override;
 
     /// Return a 2x2 symmetric matrix of the parameters.
     Matrix const& getMatrix() const { return _matrix; }
@@ -112,7 +112,7 @@ public:
     // Delegate to copy-constructor for backwards compatibility
     Quadrupole(Quadrupole&& other) : Quadrupole(other) {}
 
-    ~Quadrupole() = default;
+    ~Quadrupole() override = default;
 
     /// Converting copy constructor.
     Quadrupole(BaseCore const& other) { *this = other; }
@@ -124,19 +124,19 @@ public:
     Quadrupole(BaseCore::Convolution const& convolution) { convolution.apply(*this); }
 
 protected:
-    virtual std::shared_ptr<BaseCore> _clone() const { return std::make_shared<Quadrupole>(*this); }
+    std::shared_ptr<BaseCore> _clone() const override { return std::make_shared<Quadrupole>(*this); }
 
-    virtual void _assignToQuadrupole(double& ixx, double& iyy, double& ixy) const;
-    virtual void _assignFromQuadrupole(double ixx, double iyy, double ixy);
+    void _assignToQuadrupole(double& ixx, double& iyy, double& ixy) const override;
+    void _assignFromQuadrupole(double ixx, double iyy, double ixy) override;
 
-    virtual void _assignToAxes(double& a, double& b, double& theta) const;
-    virtual void _assignFromAxes(double a, double b, double theta);
+    void _assignToAxes(double& a, double& b, double& theta) const override;
+    void _assignFromAxes(double a, double b, double theta) override;
 
-    virtual Jacobian _dAssignToQuadrupole(double& ixx, double& iyy, double& ixy) const;
-    virtual Jacobian _dAssignFromQuadrupole(double ixx, double iyy, double ixy);
+    Jacobian _dAssignToQuadrupole(double& ixx, double& iyy, double& ixy) const override;
+    Jacobian _dAssignFromQuadrupole(double ixx, double iyy, double ixy) override;
 
-    virtual Jacobian _dAssignToAxes(double& a, double& b, double& theta) const;
-    virtual Jacobian _dAssignFromAxes(double a, double b, double theta);
+    Jacobian _dAssignToAxes(double& a, double& b, double& theta) const override;
+    Jacobian _dAssignFromAxes(double a, double b, double theta) override;
 
 private:
     static Registrar<Quadrupole> registrar;

--- a/include/lsst/afw/geom/ellipses/Separable.h
+++ b/include/lsst/afw/geom/ellipses/Separable.h
@@ -72,17 +72,17 @@ public:
     std::shared_ptr<Separable> clone() const { return std::static_pointer_cast<Separable>(_clone()); }
 
     /// Return a string that identifies this parametrization.
-    virtual std::string getName() const;
+    std::string getName() const override;
 
     /**
      *  @brief Put the parameters into a "standard form", and throw InvalidParameterError
      *         if they cannot be normalized.
      */
-    virtual void normalize();
+    void normalize() override;
 
-    virtual void readParameters(double const* iter);
+    void readParameters(double const* iter) override;
 
-    virtual void writeParameters(double* iter) const;
+    void writeParameters(double* iter) const override;
 
     /// Standard assignment.
     Separable& operator=(Separable const& other);
@@ -113,7 +113,7 @@ public:
     // Delegate to copy-constructor for backwards compatibility
     Separable(Separable&& other) : Separable(other) {}
 
-    ~Separable() = default;
+    ~Separable() override = default;
 
     /// Converting copy constructor.
     Separable(BaseCore const& other) { *this = other; }
@@ -125,19 +125,19 @@ public:
     Separable(BaseCore::Convolution const& convolution) { convolution.apply(*this); }
 
 protected:
-    virtual std::shared_ptr<BaseCore> _clone() const { return std::make_shared<Separable>(*this); }
+    std::shared_ptr<BaseCore> _clone() const override { return std::make_shared<Separable>(*this); }
 
-    virtual void _assignToQuadrupole(double& ixx, double& iyy, double& ixy) const;
-    virtual void _assignFromQuadrupole(double ixx, double iyy, double ixy);
+    void _assignToQuadrupole(double& ixx, double& iyy, double& ixy) const override;
+    void _assignFromQuadrupole(double ixx, double iyy, double ixy) override;
 
-    virtual void _assignToAxes(double& a, double& b, double& theta) const;
-    virtual void _assignFromAxes(double a, double b, double theta);
+    void _assignToAxes(double& a, double& b, double& theta) const override;
+    void _assignFromAxes(double a, double b, double theta) override;
 
-    virtual Jacobian _dAssignToQuadrupole(double& ixx, double& iyy, double& ixy) const;
-    virtual Jacobian _dAssignFromQuadrupole(double ixx, double iyy, double ixy);
+    Jacobian _dAssignToQuadrupole(double& ixx, double& iyy, double& ixy) const override;
+    Jacobian _dAssignFromQuadrupole(double ixx, double iyy, double ixy) override;
 
-    virtual Jacobian _dAssignToAxes(double& a, double& b, double& theta) const;
-    virtual Jacobian _dAssignFromAxes(double a, double b, double theta);
+    Jacobian _dAssignToAxes(double& a, double& b, double& theta) const override;
+    Jacobian _dAssignFromAxes(double a, double b, double theta) override;
 
 private:
     static BaseCore::Registrar<Separable> registrar;

--- a/include/lsst/afw/geom/ellipses/Transformer.h
+++ b/include/lsst/afw/geom/ellipses/Transformer.h
@@ -46,7 +46,7 @@ namespace ellipses {
  *  in-place and new-object transformations, derivatives of the transformations,
  *  and implicit conversion to a shared_ptr to a new transformed core.
  */
-class BaseCore::Transformer {
+class BaseCore::Transformer final {
 public:
     /// Matrix type for derivative with respect to input ellipse parameters.
     typedef Eigen::Matrix3d DerivativeMatrix;
@@ -83,7 +83,7 @@ public:
  *  in-place and new-object transformations, derivatives of the transformations, and implicit
  *  conversion to an auto_ptr to a new transformed ellipse.
  */
-class Ellipse::Transformer {
+class Ellipse::Transformer final {
 public:
     /// Matrix type for derivative with respect to input ellipse parameters.
     typedef Eigen::Matrix<double, 5, 5> DerivativeMatrix;

--- a/include/lsst/afw/geom/ellipses/radii.h
+++ b/include/lsst/afw/geom/ellipses/radii.h
@@ -54,7 +54,7 @@ class LogTraceRadius;
  * The determinant radius is equal to the standard radius for a circle, and
  * @f$\pi R_{det}^2@f$ is the area of the ellipse.
  */
-class DeterminantRadius {
+class DeterminantRadius final {
 public:
     void normalize() {
         if (_value < 0)
@@ -111,7 +111,7 @@ private:
  *
  * The trace radius is equal to the standard radius for a circle
  */
-class TraceRadius {
+class TraceRadius final {
 public:
     void normalize() {
         if (_value < 0)
@@ -166,7 +166,7 @@ private:
 /**
  * The natural logarithm of the DeterminantRadius
  */
-class LogDeterminantRadius {
+class LogDeterminantRadius final {
 public:
     void normalize() {}
 
@@ -217,7 +217,7 @@ private:
 /**
  * The natural logarithm of the TraceRadius
  */
-class LogTraceRadius {
+class LogTraceRadius final {
 public:
     void normalize() {}
 

--- a/include/lsst/afw/geom/polygon/Polygon.h
+++ b/include/lsst/afw/geom/polygon/Polygon.h
@@ -70,7 +70,7 @@ public:
     Polygon& operator=(Polygon const&);
     Polygon& operator=(Polygon&&);
 
-    virtual ~Polygon();
+    ~Polygon() override;
 
     /**
      * Construct a 4-sided Polygon from a transformed box
@@ -248,12 +248,12 @@ public:
 
     //@{
     /// Whether Polygon is persistable which is always true
-    virtual bool isPersistable() const noexcept override { return true; }
+    bool isPersistable() const noexcept override { return true; }
 
 protected:
-    virtual std::string getPersistenceName() const;
+    std::string getPersistenceName() const override;
 
-    virtual void write(OutputArchiveHandle& handle) const;
+    void write(OutputArchiveHandle& handle) const override;
 
 private:
     //@{

--- a/include/lsst/afw/image/ApCorrMap.h
+++ b/include/lsst/afw/image/ApCorrMap.h
@@ -57,7 +57,7 @@ public:
     ApCorrMap(ApCorrMap&&) = default;
     ApCorrMap& operator=(ApCorrMap const&) = default;
     ApCorrMap& operator=(ApCorrMap&&) = default;
-    virtual ~ApCorrMap() = default;
+    ~ApCorrMap() override = default;
 
     Iterator begin() const { return _internal.begin(); }
     Iterator end() const { return _internal.end(); }
@@ -74,18 +74,18 @@ public:
     void set(std::string const& name, std::shared_ptr<math::BoundedField> field);
 
     /// Whether the map is persistable (true IFF all contained BoundedFields are persistable).
-    virtual bool isPersistable() const noexcept override;
+    bool isPersistable() const noexcept override;
 
     /// Scale all fields by a constant
     ApCorrMap& operator*=(double const scale);
     ApCorrMap& operator/=(double const scale) { return *this *= 1.0 / scale; }
 
 private:
-    virtual std::string getPersistenceName() const;
+    std::string getPersistenceName() const override;
 
-    virtual std::string getPythonModule() const;
+    std::string getPythonModule() const override;
 
-    virtual void write(OutputArchiveHandle& handle) const;
+    void write(OutputArchiveHandle& handle) const override;
 
     Internal _internal;
 };

--- a/include/lsst/afw/image/Calib.h
+++ b/include/lsst/afw/image/Calib.h
@@ -119,7 +119,7 @@ public:
     Calib(Calib&&) noexcept;
     Calib& operator=(Calib const&) noexcept;
     Calib& operator=(Calib&&) noexcept;
-    virtual ~Calib() noexcept;
+    ~Calib() noexcept override;
 
     /**
      * Set the flux of a zero-magnitude object
@@ -207,9 +207,9 @@ public:
     bool isPersistable() const noexcept override { return true; }
 
 protected:
-    virtual std::string getPersistenceName() const;
+    std::string getPersistenceName() const override;
 
-    virtual void write(OutputArchiveHandle& handle) const;
+    void write(OutputArchiveHandle& handle) const override;
 
 private:
     double _fluxMag0;

--- a/include/lsst/afw/image/CoaddInputs.h
+++ b/include/lsst/afw/image/CoaddInputs.h
@@ -68,7 +68,7 @@ public:
     CoaddInputs(CoaddInputs&&);
     CoaddInputs& operator=(CoaddInputs const&);
     CoaddInputs& operator=(CoaddInputs&&);
-    virtual ~CoaddInputs();
+    ~CoaddInputs() override;
 
     /**
      *  Whether the object is in fact persistable - in this case, always true.
@@ -76,12 +76,12 @@ public:
      *  To avoid letting coadd provenance prevent coadd code from running, if a nested Wcs or
      *  Psf is not persistable, it will silently not be saved, instead of throwing an exception.
      */
-    virtual bool isPersistable() const noexcept override;
+    bool isPersistable() const noexcept override;
 
 protected:
-    virtual std::string getPersistenceName() const;
-    virtual std::string getPythonModule() const;
-    virtual void write(OutputArchiveHandle& handle) const;
+    std::string getPersistenceName() const override;
+    std::string getPythonModule() const override;
+    void write(OutputArchiveHandle& handle) const override;
 };
 }  // namespace image
 }  // namespace afw

--- a/include/lsst/afw/image/Color.h
+++ b/include/lsst/afw/image/Color.h
@@ -23,7 +23,7 @@ namespace image {
  * @note This is very much just a place holder until we work out what we need.  A full SED may be required,
  * in which case a constructor from an SED name might be appropriate, or a couple of colours, or ...
  */
-class Color {
+class Color final {
 public:
     explicit Color(double g_r = std::numeric_limits<double>::quiet_NaN()) : _g_r(g_r) {}
 

--- a/include/lsst/afw/image/Exposure.h
+++ b/include/lsst/afw/image/Exposure.h
@@ -223,7 +223,7 @@ public:
 
     /** Destructor
      */
-    virtual ~Exposure();
+    ~Exposure() override;
 
     // Get Members
     /// Return the MaskedImage

--- a/include/lsst/afw/image/ExposureInfo.h
+++ b/include/lsst/afw/image/ExposureInfo.h
@@ -84,7 +84,7 @@ class TransmissionCurve;
  *  clone its input argument, because while it technically isn't, we can safely consider a
  *  Detector to be immutable once it's attached to an ExposureInfo.
  */
-class ExposureInfo {
+class ExposureInfo final {
 public:
     /// Does this exposure have a Wcs?
     bool hasWcs() const { return static_cast<bool>(_wcs); }

--- a/include/lsst/afw/image/Filter.h
+++ b/include/lsst/afw/image/Filter.h
@@ -53,7 +53,7 @@ namespace image {
 /**
  * Describe the properties of a Filter (e.g. effective wavelength)
  */
-class FilterProperty {
+class FilterProperty final {
 public:
     explicit FilterProperty(std::string const& name, double lambdaEff, double lambdaMin = NAN,
                             double lambdaMax = NAN, bool force = false)
@@ -150,7 +150,7 @@ private:
 /**
  * Holds an integer identifier for an LSST filter.
  */
-class Filter {
+class Filter final {
 public:
     static int const AUTO;
     static int const UNKNOWN;

--- a/include/lsst/afw/image/Image.h
+++ b/include/lsst/afw/image/Image.h
@@ -192,7 +192,7 @@ public:
                    lsst::geom::Point2I const& xy0 = lsst::geom::Point2I())
             : image::ImageBase<PixelT>(array, deep, xy0) {}
 
-    virtual ~Image() = default;
+    ~Image() override = default;
     //
     // Assignment operators are not inherited
     //

--- a/include/lsst/afw/image/ImageBase.h
+++ b/include/lsst/afw/image/ImageBase.h
@@ -241,7 +241,7 @@ public:
     explicit ImageBase(Array const& array, bool deep = false,
                        lsst::geom::Point2I const& xy0 = lsst::geom::Point2I());
 
-    virtual ~ImageBase() = default;
+    ~ImageBase() override = default;
     /** Shallow assignment operator.
      *
      * @note that this has the effect of making the lhs share pixels with the rhs which may

--- a/include/lsst/afw/image/ImageSlice.h
+++ b/include/lsst/afw/image/ImageSlice.h
@@ -53,7 +53,7 @@ public:
      * @param img The image to represent as a slice.
      */
     explicit ImageSlice(Image<PixelT> const &img);
-    ~ImageSlice() {}
+    ~ImageSlice() override {}
     ImageSliceType getImageSliceType() const { return _sliceType; }
 
 private:

--- a/include/lsst/afw/image/Mask.h
+++ b/include/lsst/afw/image/Mask.h
@@ -229,7 +229,7 @@ public:
      */
     Mask(const Mask& src, const bool deep = false);
     Mask(Mask&& src);
-    ~Mask();
+    ~Mask() override;
     /**
      * Construct a Mask from a subregion of another Mask
      *

--- a/include/lsst/afw/image/MaskedImage.h
+++ b/include/lsst/afw/image/MaskedImage.h
@@ -763,7 +763,7 @@ public:
     MaskedImage& operator=(MaskedImage const& rhs);
     MaskedImage& operator=(MaskedImage&& rhs);
 
-    virtual ~MaskedImage() = default;
+    ~MaskedImage() override = default;
 
     void swap(MaskedImage& rhs);
 

--- a/include/lsst/afw/image/PhotoCalib.h
+++ b/include/lsst/afw/image/PhotoCalib.h
@@ -86,7 +86,7 @@ public:
     PhotoCalib &operator=(PhotoCalib const &) = delete;
     PhotoCalib &operator=(PhotoCalib &&) = delete;
 
-    virtual ~PhotoCalib() = default;
+    ~PhotoCalib() override = default;
 
     /**
      * Create a empty, zeroed calibration.
@@ -401,9 +401,9 @@ public:
     friend std::ostream &operator<<(std::ostream &os, PhotoCalib const &photoCalib);
 
 protected:
-    virtual std::string getPersistenceName() const;
+    std::string getPersistenceName() const override;
 
-    virtual void write(OutputArchiveHandle &handle) const;
+    void write(OutputArchiveHandle &handle) const override;
 
 private:
     std::shared_ptr<afw::math::BoundedField> _calibration;

--- a/include/lsst/afw/image/Pixel.h
+++ b/include/lsst/afw/image/Pixel.h
@@ -435,7 +435,7 @@ private:
 
 /// Class for representing binary operations
 template <typename ExprT1, typename ExprT2, typename ImageBinOp, typename MaskBinOp, typename VarianceBinOp>
-class BinaryExpr {
+class BinaryExpr final {
 public:
     typedef typename exprTraits<ExprT1>::ImagePixelT ImagePixelT;
     typedef typename exprTraits<ExprT1>::MaskPixelT MaskPixelT;
@@ -474,7 +474,7 @@ private:
  * @todo Could use a traits class to handle all scalar types
  */
 template <typename ExprT1, typename ImageBinOp, typename MaskBinOp, typename VarianceBinOp>
-class BinaryExpr<ExprT1, double, ImageBinOp, MaskBinOp, VarianceBinOp> {
+class BinaryExpr<ExprT1, double, ImageBinOp, MaskBinOp, VarianceBinOp> final {
 public:
     typedef typename exprTraits<ExprT1>::ImagePixelT ImagePixelT;
     typedef typename exprTraits<ExprT1>::MaskPixelT MaskPixelT;

--- a/include/lsst/afw/image/TransmissionCurve.h
+++ b/include/lsst/afw/image/TransmissionCurve.h
@@ -142,7 +142,7 @@ public:
     // TransmissionCurve is not move-assignable.
     TransmissionCurve &operator=(TransmissionCurve &&) = delete;
 
-    virtual ~TransmissionCurve() = default;
+    ~TransmissionCurve() override = default;
 
     /**
      *  Return the wavelength interval on which this TransmissionCurve varies.

--- a/include/lsst/afw/image/VisitInfo.h
+++ b/include/lsst/afw/image/VisitInfo.h
@@ -107,7 +107,7 @@ public:
 
     explicit VisitInfo(daf::base::PropertySet const &metadata);
 
-    virtual ~VisitInfo() = default;
+    ~VisitInfo() override = default;
 
     VisitInfo(VisitInfo const &) = default;
     VisitInfo(VisitInfo &&) = default;
@@ -184,9 +184,9 @@ public:
     lsst::geom::Angle getBoresightParAngle() const;
 
 protected:
-    virtual std::string getPersistenceName() const;
+    std::string getPersistenceName() const override;
 
-    virtual void write(OutputArchiveHandle &handle) const;
+    void write(OutputArchiveHandle &handle) const override;
 
 private:
     table::RecordId _exposureId;

--- a/include/lsst/afw/math/Background.h
+++ b/include/lsst/afw/math/Background.h
@@ -484,20 +484,20 @@ public:
     BackgroundMI(BackgroundMI&&) = delete;
     BackgroundMI& operator=(BackgroundMI const&) = delete;
     BackgroundMI& operator=(BackgroundMI&&) = delete;
-    ~BackgroundMI() = default;
+    ~BackgroundMI() override = default;
 
     /**
      * Add a scalar to the Background (equivalent to adding a constant to the original image)
      *
      * @param delta Value to add
      */
-    virtual BackgroundMI& operator+=(float const delta);
+    BackgroundMI& operator+=(float const delta) override;
     /**
      * Subtract a scalar from the Background (equivalent to subtracting a constant from the original image)
      *
      * @param delta Value to subtract
      */
-    virtual BackgroundMI& operator-=(float const delta);
+    BackgroundMI& operator-=(float const delta) override;
 
     /**
      * Method to retrieve the background level at a pixel coord.
@@ -534,8 +534,9 @@ private:
                          int const iX, std::vector<int> const& ypix) const;
 
 #if defined(LSST_makeBackground_getImage)
-    BOOST_PP_SEQ_FOR_EACH(LSST_makeBackground_getImage, , LSST_makeBackground_getImage_types)
-    BOOST_PP_SEQ_FOR_EACH(LSST_makeBackground_getApproximate, , LSST_makeBackground_getApproximate_types)
+    BOOST_PP_SEQ_FOR_EACH(LSST_makeBackground_getImage, override, LSST_makeBackground_getImage_types)
+    BOOST_PP_SEQ_FOR_EACH(LSST_makeBackground_getApproximate, override,
+                          LSST_makeBackground_getApproximate_types)
 #if 0  // keep for use in Background instantiations
 #undef LSST_makeBackground_getImage_types
 #undef LSST_makeBackground_getApproximate_types

--- a/include/lsst/afw/math/BoundedField.h
+++ b/include/lsst/afw/math/BoundedField.h
@@ -194,7 +194,7 @@ public:
     /// @copydoc operator==
     bool operator!=(BoundedField const& rhs) const { return !(*this == rhs); };
 
-    virtual ~BoundedField() = default;
+    ~BoundedField() override = default;
     BoundedField(BoundedField const&) = default;
     BoundedField(BoundedField&&) = default;
     BoundedField& operator=(BoundedField const&) = delete;

--- a/include/lsst/afw/math/ChebyshevBoundedField.h
+++ b/include/lsst/afw/math/ChebyshevBoundedField.h
@@ -119,7 +119,7 @@ public:
     ChebyshevBoundedField(ChebyshevBoundedField&&);
     ChebyshevBoundedField& operator=(ChebyshevBoundedField const&) = delete;
     ChebyshevBoundedField& operator=(ChebyshevBoundedField&&) = delete;
-    ~ChebyshevBoundedField();
+    ~ChebyshevBoundedField() override;
 
     /**
      *  Fit a Chebyshev approximation to non-gridded data with equal weights.
@@ -191,31 +191,31 @@ public:
     std::shared_ptr<ChebyshevBoundedField> relocate(lsst::geom::Box2I const& bbox) const;
 
     /// @copydoc BoundedField::evaluate
-    virtual double evaluate(lsst::geom::Point2D const& position) const;
+    double evaluate(lsst::geom::Point2D const& position) const override;
 
     using BoundedField::evaluate;
 
     /// @copydoc BoundedField::integrate
-    virtual double integrate() const;
+    double integrate() const override;
 
     /// @copydoc BoundedField::mean
-    virtual double mean() const;
+    double mean() const override;
 
     /// ChebyshevBoundedField is always persistable.
-    virtual bool isPersistable() const noexcept override { return true; }
+    bool isPersistable() const noexcept override { return true; }
 
     /// @copydoc BoundedField::operator*
-    virtual std::shared_ptr<BoundedField> operator*(double const scale) const;
+    std::shared_ptr<BoundedField> operator*(double const scale) const override;
 
     /// @copydoc BoundedField::operator==
-    virtual bool operator==(BoundedField const& rhs) const;
+    bool operator==(BoundedField const& rhs) const override;
 
 protected:
-    virtual std::string getPersistenceName() const;
+    std::string getPersistenceName() const override;
 
-    virtual std::string getPythonModule() const;
+    std::string getPythonModule() const override;
 
-    virtual void write(OutputArchiveHandle& handle) const;
+    void write(OutputArchiveHandle& handle) const override;
 
 private:
     // Internal constructor for fit() routines: just initializes the transform,
@@ -225,7 +225,7 @@ private:
     lsst::geom::AffineTransform _toChebyshevRange;     // maps points from the bbox to [-1,1]x[-1,1]
     ndarray::Array<double const, 2, 2> _coefficients;  // shape=(orderY+1, orderX+1)
 
-    virtual std::string toString() const;
+    std::string toString() const override;
 };
 }  // namespace math
 }  // namespace afw

--- a/include/lsst/afw/math/Function.h
+++ b/include/lsst/afw/math/Function.h
@@ -110,7 +110,7 @@ public:
     Function& operator=(Function const&) = default;
     Function& operator=(Function&&) = default;
 
-    virtual ~Function() noexcept = default;
+    ~Function() noexcept override = default;
 
     /**
      * Return the number of function parameters
@@ -193,7 +193,7 @@ protected:
     std::vector<double> _params;
     mutable bool _isCacheValid;
 
-    virtual std::string getPythonModule() const { return "lsst.afw.math"; }
+    std::string getPythonModule() const override { return "lsst.afw.math"; }
 
     /* Default constructor: intended only for serialization */
     explicit Function() : lsst::daf::base::Citizen(typeid(this)), _params(0), _isCacheValid(false) {}
@@ -235,7 +235,7 @@ public:
     Function1& operator=(Function1 const&) = default;
     Function1& operator=(Function1&&) = default;
 
-    virtual ~Function1() noexcept = default;
+    ~Function1() noexcept override = default;
 
     /**
      * Return a pointer to a deep copy of this function
@@ -252,7 +252,7 @@ public:
 
     virtual ReturnT operator()(double x) const = 0;
 
-    virtual std::string toString(std::string const& prefix = "") const {
+    std::string toString(std::string const& prefix = "") const override {
         return std::string("Function1: ") + Function<ReturnT>::toString(prefix);
     }
 
@@ -301,7 +301,7 @@ public:
     Function2& operator=(Function2 const&) = default;
     Function2& operator=(Function2&&) = default;
 
-    virtual ~Function2() noexcept = default;
+    ~Function2() noexcept override = default;
 
     /**
      * Return a pointer to a deep copy of this function
@@ -318,7 +318,7 @@ public:
 
     virtual ReturnT operator()(double x, double y) const = 0;
 
-    virtual std::string toString(std::string const& prefix = "") const {
+    std::string toString(std::string const& prefix = "") const override {
         return std::string("Function2: ") + Function<ReturnT>::toString(prefix);
     }
     /**
@@ -381,14 +381,14 @@ public:
     BasePolynomialFunction2& operator=(BasePolynomialFunction2 const&) = default;
     BasePolynomialFunction2& operator=(BasePolynomialFunction2&&) = default;
 
-    virtual ~BasePolynomialFunction2() noexcept = default;
+    ~BasePolynomialFunction2() noexcept override = default;
 
     /**
      * Get the polynomial order
      */
     int getOrder() const noexcept { return _order; }
 
-    virtual bool isLinearCombination() const noexcept { return true; }
+    bool isLinearCombination() const noexcept override { return true; }
 
     /**
      * Compute number of parameters from polynomial order.
@@ -437,7 +437,7 @@ public:
      * This isn't necessarily the most efficient algorithm, but it's general,
      * and you can override it if it isn't suitable for your particular subclass.
      */
-    virtual std::vector<double> getDFuncDParameters(double x, double y) const {
+    std::vector<double> getDFuncDParameters(double x, double y) const override {
         unsigned int const numParams = this->getNParameters();  // Number of parameters
         std::vector<double> deriv(numParams);                   // Derivatives, to return
 
@@ -478,12 +478,14 @@ template <typename ReturnT>
 class NullFunction1 : public Function1<ReturnT> {
 public:
     explicit NullFunction1() : Function1<ReturnT>(0) {}
-    std::shared_ptr<Function1<ReturnT>> clone() const {
+    std::shared_ptr<Function1<ReturnT>> clone() const override {
         return std::shared_ptr<Function1<ReturnT>>(new NullFunction1());
     }
 
 private:
-    ReturnT operator()(double) const noexcept(IS_NOTHROW_INIT<ReturnT>) { return static_cast<ReturnT>(0); }
+    ReturnT operator()(double) const noexcept(IS_NOTHROW_INIT<ReturnT>) override {
+        return static_cast<ReturnT>(0);
+    }
 
 private:
     friend class boost::serialization::access;
@@ -500,12 +502,12 @@ template <typename ReturnT>
 class NullFunction2 : public Function2<ReturnT> {
 public:
     explicit NullFunction2() : Function2<ReturnT>(0) {}
-    std::shared_ptr<Function2<ReturnT>> clone() const {
+    std::shared_ptr<Function2<ReturnT>> clone() const override {
         return std::shared_ptr<Function2<ReturnT>>(new NullFunction2());
     }
 
 private:
-    ReturnT operator()(double, double) const noexcept(IS_NOTHROW_INIT<ReturnT>) {
+    ReturnT operator()(double, double) const noexcept(IS_NOTHROW_INIT<ReturnT>) override {
         return static_cast<ReturnT>(0);
     }
 

--- a/include/lsst/afw/math/FunctionLibrary.h
+++ b/include/lsst/afw/math/FunctionLibrary.h
@@ -62,17 +62,17 @@ public:
     IntegerDeltaFunction1(IntegerDeltaFunction1&&) = default;
     IntegerDeltaFunction1& operator=(IntegerDeltaFunction1 const&) = default;
     IntegerDeltaFunction1& operator=(IntegerDeltaFunction1&&) = default;
-    virtual ~IntegerDeltaFunction1() noexcept = default;
+    ~IntegerDeltaFunction1() noexcept override = default;
 
-    virtual std::shared_ptr<Function1<ReturnT>> clone() const {
+    std::shared_ptr<Function1<ReturnT>> clone() const override {
         return std::shared_ptr<Function1<ReturnT>>(new IntegerDeltaFunction1(_xo));
     }
 
-    virtual ReturnT operator()(double x) const noexcept(IS_NOTHROW_INIT<ReturnT>) {
+    ReturnT operator()(double x) const noexcept(IS_NOTHROW_INIT<ReturnT>) override {
         return static_cast<ReturnT>(x == _xo);
     }
 
-    virtual std::string toString(std::string const& prefix = "") const {
+    std::string toString(std::string const& prefix = "") const override {
         std::ostringstream os;
         os << "IntegerDeltaFunction1 [" << _xo << "]: ";
         os << Function1<ReturnT>::toString(prefix);
@@ -117,17 +117,17 @@ public:
     IntegerDeltaFunction2(IntegerDeltaFunction2&&) = default;
     IntegerDeltaFunction2& operator=(IntegerDeltaFunction2 const&) = default;
     IntegerDeltaFunction2& operator=(IntegerDeltaFunction2&&) = default;
-    virtual ~IntegerDeltaFunction2() noexcept = default;
+    ~IntegerDeltaFunction2() noexcept override = default;
 
-    virtual std::shared_ptr<Function2<ReturnT>> clone() const {
+    std::shared_ptr<Function2<ReturnT>> clone() const override {
         return std::shared_ptr<Function2<ReturnT>>(new IntegerDeltaFunction2(_xo, _yo));
     }
 
-    virtual ReturnT operator()(double x, double y) const noexcept(IS_NOTHROW_INIT<ReturnT>) {
+    ReturnT operator()(double x, double y) const noexcept(IS_NOTHROW_INIT<ReturnT>) override {
         return static_cast<ReturnT>((x == _xo) && (y == _yo));
     }
 
-    virtual std::string toString(std::string const& prefix) const {
+    std::string toString(std::string const& prefix) const override {
         std::ostringstream os;
         os << "IntegerDeltaFunction2 [" << _xo << ", " << _yo << "]: ";
         os << Function2<ReturnT>::toString(prefix);
@@ -176,18 +176,18 @@ public:
     GaussianFunction1(GaussianFunction1&&) = default;
     GaussianFunction1& operator=(GaussianFunction1 const&) = default;
     GaussianFunction1& operator=(GaussianFunction1&&) = default;
-    virtual ~GaussianFunction1() noexcept = default;
+    ~GaussianFunction1() noexcept override = default;
 
-    virtual std::shared_ptr<Function1<ReturnT>> clone() const {
+    std::shared_ptr<Function1<ReturnT>> clone() const override {
         return std::shared_ptr<Function1<ReturnT>>(new GaussianFunction1(this->_params[0]));
     }
 
-    virtual ReturnT operator()(double x) const noexcept(IS_NOTHROW_INIT<ReturnT>) {
+    ReturnT operator()(double x) const noexcept(IS_NOTHROW_INIT<ReturnT>) override {
         return static_cast<ReturnT>((_multFac / this->_params[0]) *
                                     std::exp(-(x * x) / (2.0 * this->_params[0] * this->_params[0])));
     }
 
-    virtual std::string toString(std::string const& prefix) const {
+    std::string toString(std::string const& prefix) const override {
         std::ostringstream os;
         os << "GaussianFunction1 [" << _multFac << "]: ";
         os << Function1<ReturnT>::toString(prefix);
@@ -243,14 +243,14 @@ public:
     GaussianFunction2(GaussianFunction2&&) = default;
     GaussianFunction2& operator=(GaussianFunction2 const&) = default;
     GaussianFunction2& operator=(GaussianFunction2&&) = default;
-    virtual ~GaussianFunction2() noexcept = default;
+    ~GaussianFunction2() noexcept override = default;
 
-    virtual std::shared_ptr<Function2<ReturnT>> clone() const {
+    std::shared_ptr<Function2<ReturnT>> clone() const override {
         return std::shared_ptr<Function2<ReturnT>>(
                 new GaussianFunction2(this->_params[0], this->_params[1], this->_params[2]));
     }
 
-    virtual ReturnT operator()(double x, double y) const noexcept(IS_NOTHROW_INIT<ReturnT>) {
+    ReturnT operator()(double x, double y) const noexcept(IS_NOTHROW_INIT<ReturnT>) override {
         if (_angle != this->_params[2]) {
             _updateCache();
         }
@@ -261,19 +261,19 @@ public:
                                              ((pos2 * pos2) / (2.0 * this->_params[1] * this->_params[1]))));
     }
 
-    virtual std::string toString(std::string const& prefix) const {
+    std::string toString(std::string const& prefix) const override {
         std::ostringstream os;
         os << "GaussianFunction2: ";
         os << Function2<ReturnT>::toString(prefix);
         return os.str();
     }
 
-    virtual bool isPersistable() const noexcept override { return true; }
+    bool isPersistable() const noexcept override { return true; }
 
 protected:
-    virtual std::string getPersistenceName() const;
+    std::string getPersistenceName() const override;
 
-    virtual void write(afw::table::io::OutputArchiveHandle& handle) const;
+    void write(afw::table::io::OutputArchiveHandle& handle) const override;
 
 private:
     /**
@@ -357,14 +357,14 @@ public:
     DoubleGaussianFunction2(DoubleGaussianFunction2&&) = default;
     DoubleGaussianFunction2& operator=(DoubleGaussianFunction2 const&) = default;
     DoubleGaussianFunction2& operator=(DoubleGaussianFunction2&&) = default;
-    virtual ~DoubleGaussianFunction2() noexcept = default;
+    ~DoubleGaussianFunction2() noexcept override = default;
 
-    virtual std::shared_ptr<Function2<ReturnT>> clone() const {
+    std::shared_ptr<Function2<ReturnT>> clone() const override {
         return std::shared_ptr<Function2<ReturnT>>(
                 new DoubleGaussianFunction2(this->_params[0], this->_params[1], this->_params[2]));
     }
 
-    virtual ReturnT operator()(double x, double y) const noexcept(IS_NOTHROW_INIT<ReturnT>) {
+    ReturnT operator()(double x, double y) const noexcept(IS_NOTHROW_INIT<ReturnT>) override {
         double radSq = (x * x) + (y * y);
         double sigma1Sq = this->_params[0] * this->_params[0];
         double sigma2Sq = this->_params[1] * this->_params[1];
@@ -374,19 +374,19 @@ public:
                 (std::exp(-radSq / (2.0 * sigma1Sq)) + (b * std::exp(-radSq / (2.0 * sigma2Sq)))));
     }
 
-    virtual std::string toString(std::string const& prefix) const {
+    std::string toString(std::string const& prefix) const override {
         std::ostringstream os;
         os << "DoubleGaussianFunction2 [" << _multFac << "]: ";
         os << Function2<ReturnT>::toString(prefix);
         return os.str();
     }
 
-    virtual bool isPersistable() const noexcept override { return true; }
+    bool isPersistable() const noexcept override { return true; }
 
 protected:
-    virtual std::string getPersistenceName() const;
+    std::string getPersistenceName() const override;
 
-    virtual void write(afw::table::io::OutputArchiveHandle& handle) const;
+    void write(afw::table::io::OutputArchiveHandle& handle) const override;
 
 private:
     const double _multFac;  ///< precomputed scale factor
@@ -440,15 +440,15 @@ public:
     PolynomialFunction1(PolynomialFunction1&&) = default;
     PolynomialFunction1& operator=(PolynomialFunction1 const&) = default;
     PolynomialFunction1& operator=(PolynomialFunction1&&) = default;
-    virtual ~PolynomialFunction1() noexcept = default;
+    ~PolynomialFunction1() noexcept override = default;
 
-    virtual std::shared_ptr<Function1<ReturnT>> clone() const {
+    std::shared_ptr<Function1<ReturnT>> clone() const override {
         return std::shared_ptr<Function1<ReturnT>>(new PolynomialFunction1(this->_params));
     }
 
-    virtual bool isLinearCombination() const noexcept { return true; };
+    bool isLinearCombination() const noexcept override { return true; };
 
-    virtual ReturnT operator()(double x) const noexcept(IS_NOTHROW_INIT<ReturnT>) {
+    ReturnT operator()(double x) const noexcept(IS_NOTHROW_INIT<ReturnT>) override {
         int const order = static_cast<int>(this->_params.size()) - 1;
         double retVal = this->_params[order];
         for (int ii = order - 1; ii >= 0; --ii) {
@@ -462,7 +462,7 @@ public:
      */
     unsigned int getOrder() const noexcept { return this->getNParameters() - 1; };
 
-    virtual std::string toString(std::string const& prefix) const {
+    std::string toString(std::string const& prefix) const override {
         std::ostringstream os;
         os << "PolynomialFunction1 []: ";
         os << Function1<ReturnT>::toString(prefix);
@@ -527,13 +527,13 @@ public:
     PolynomialFunction2(PolynomialFunction2&&) = default;
     PolynomialFunction2& operator=(PolynomialFunction2 const&) = default;
     PolynomialFunction2& operator=(PolynomialFunction2&&) = default;
-    virtual ~PolynomialFunction2() noexcept = default;
+    ~PolynomialFunction2() noexcept override = default;
 
-    virtual std::shared_ptr<Function2<ReturnT>> clone() const {
+    std::shared_ptr<Function2<ReturnT>> clone() const override {
         return std::shared_ptr<Function2<ReturnT>>(new PolynomialFunction2(this->_params));
     }
 
-    virtual ReturnT operator()(double x, double y) const noexcept(IS_NOTHROW_INIT<ReturnT>) {
+    ReturnT operator()(double x, double y) const noexcept(IS_NOTHROW_INIT<ReturnT>) override {
         /* Solve as follows:
         - f(x,y) = Cx0 + Cx1 x + Cx2 x^2 + Cx3 x^3 + ...
         where:
@@ -587,21 +587,21 @@ public:
      * Return the coefficients of the Function's parameters, evaluated at (x, y)
      * I.e. given c0, c1, c2, c3 ... return 1, x, y, x^2 ...
      */
-    virtual std::vector<double> getDFuncDParameters(double x, double y) const;
+    std::vector<double> getDFuncDParameters(double x, double y) const override;
 
-    virtual std::string toString(std::string const& prefix) const {
+    std::string toString(std::string const& prefix) const override {
         std::ostringstream os;
         os << "PolynomialFunction2 [" << this->_order << "]: ";
         os << Function2<ReturnT>::toString(prefix);
         return os.str();
     }
 
-    virtual bool isPersistable() const noexcept override { return true; }
+    bool isPersistable() const noexcept override { return true; }
 
 protected:
-    virtual std::string getPersistenceName() const;
+    std::string getPersistenceName() const override;
 
-    virtual void write(afw::table::io::OutputArchiveHandle& handle) const;
+    void write(afw::table::io::OutputArchiveHandle& handle) const override;
 
 private:
     mutable double _oldY;                  ///< value of y for which _xCoeffs is valid
@@ -673,9 +673,9 @@ public:
     Chebyshev1Function1(Chebyshev1Function1&&) = default;
     Chebyshev1Function1& operator=(Chebyshev1Function1 const&) = default;
     Chebyshev1Function1& operator=(Chebyshev1Function1&&) = default;
-    virtual ~Chebyshev1Function1() noexcept = default;
+    ~Chebyshev1Function1() noexcept override = default;
 
-    virtual std::shared_ptr<Function1<ReturnT>> clone() const {
+    std::shared_ptr<Function1<ReturnT>> clone() const override {
         return std::shared_ptr<Function1<ReturnT>>(new Chebyshev1Function1(this->_params, _minX, _maxX));
     }
 
@@ -694,9 +694,9 @@ public:
      */
     unsigned int getOrder() const noexcept { return this->getNParameters() - 1; };
 
-    virtual bool isLinearCombination() const noexcept { return true; };
+    bool isLinearCombination() const noexcept override { return true; };
 
-    virtual ReturnT operator()(double x) const {
+    ReturnT operator()(double x) const override {
         double xPrime = (x + _offset) * _scale;
 
         // Clenshaw function for solving the Chebyshev polynomial
@@ -717,7 +717,7 @@ public:
         return (xPrime * csh) + this->_params[0] - cshPrev;
     }
 
-    virtual std::string toString(std::string const& prefix) const {
+    std::string toString(std::string const& prefix) const override {
         std::ostringstream os;
         os << "Chebyshev1Function1 [" << _minX << ", " << _maxX << "]: ";
         os << Function1<ReturnT>::toString(prefix);
@@ -828,9 +828,9 @@ public:
     Chebyshev1Function2(Chebyshev1Function2&&) = default;
     Chebyshev1Function2& operator=(Chebyshev1Function2 const&) = default;
     Chebyshev1Function2& operator=(Chebyshev1Function2&&) = default;
-    virtual ~Chebyshev1Function2() noexcept = default;
+    ~Chebyshev1Function2() noexcept override = default;
 
-    virtual std::shared_ptr<Function2<ReturnT>> clone() const {
+    std::shared_ptr<Function2<ReturnT>> clone() const override {
         return std::shared_ptr<Function2<ReturnT>>(
                 new Chebyshev1Function2(this->_params, this->getXYRange()));
     }
@@ -859,7 +859,7 @@ public:
         return Chebyshev1Function2(truncParams, this->getXYRange());
     }
 
-    virtual ReturnT operator()(double x, double y) const {
+    ReturnT operator()(double x, double y) const override {
         /* Solve as follows:
         - f(x,y) = Cy0 T0(y') + Cy1 T1(y') + Cy2 T2(y') + Cy3 T3(y') + ...
         where:
@@ -923,7 +923,7 @@ public:
         return (xPrime * csh) + _xCoeffs[0] - cshPrev;
     }
 
-    virtual std::string toString(std::string const& prefix) const {
+    std::string toString(std::string const& prefix) const override {
         std::ostringstream os;
         os << "Chebyshev1Function2 [";
         os << this->_order << ", " << this->getXYRange() << "]";
@@ -931,12 +931,12 @@ public:
         return os.str();
     }
 
-    virtual bool isPersistable() const noexcept override { return true; }
+    bool isPersistable() const noexcept override { return true; }
 
 protected:
-    virtual std::string getPersistenceName() const;
+    std::string getPersistenceName() const override;
 
-    virtual void write(afw::table::io::OutputArchiveHandle& handle) const;
+    void write(afw::table::io::OutputArchiveHandle& handle) const override;
 
 private:
     mutable double _oldYPrime;
@@ -1027,13 +1027,13 @@ public:
     LanczosFunction1(LanczosFunction1&&) = default;
     LanczosFunction1& operator=(LanczosFunction1 const&) = default;
     LanczosFunction1& operator=(LanczosFunction1&&) = default;
-    virtual ~LanczosFunction1() noexcept = default;
+    ~LanczosFunction1() noexcept override = default;
 
-    virtual std::shared_ptr<Function1<ReturnT>> clone() const {
+    std::shared_ptr<Function1<ReturnT>> clone() const override {
         return std::shared_ptr<Function1<ReturnT>>(new LanczosFunction1(this->getOrder(), this->_params[0]));
     }
 
-    virtual ReturnT operator()(double x) const noexcept(IS_NOTHROW_INIT<ReturnT>) {
+    ReturnT operator()(double x) const noexcept(IS_NOTHROW_INIT<ReturnT>) override {
         double xArg1 = (x - this->_params[0]) * lsst::geom::PI;
         double xArg2 = xArg1 * _invN;
         if (std::fabs(xArg1) > 1.0e-5) {
@@ -1048,7 +1048,7 @@ public:
      */
     unsigned int getOrder() const noexcept { return static_cast<unsigned int>(0.5 + (1.0 / _invN)); };
 
-    virtual std::string toString(std::string const& prefix) const {
+    std::string toString(std::string const& prefix) const override {
         std::ostringstream os;
         os << "LanczosFunction1 [" << this->getOrder() << "]: ";
         ;
@@ -1102,14 +1102,14 @@ public:
     LanczosFunction2(LanczosFunction2&&) = default;
     LanczosFunction2& operator=(LanczosFunction2 const&) = default;
     LanczosFunction2& operator=(LanczosFunction2&&) = default;
-    virtual ~LanczosFunction2() noexcept = default;
+    ~LanczosFunction2() noexcept override = default;
 
-    virtual std::shared_ptr<Function2<ReturnT>> clone() const {
+    std::shared_ptr<Function2<ReturnT>> clone() const override {
         return std::shared_ptr<Function2<ReturnT>>(
                 new LanczosFunction2(this->getOrder(), this->_params[0], this->_params[1]));
     }
 
-    virtual ReturnT operator()(double x, double y) const noexcept(IS_NOTHROW_INIT<ReturnT>) {
+    ReturnT operator()(double x, double y) const noexcept(IS_NOTHROW_INIT<ReturnT>) override {
         double xArg1 = (x - this->_params[0]) * lsst::geom::PI;
         double xArg2 = xArg1 * _invN;
         double xFunc = 1;
@@ -1130,7 +1130,7 @@ public:
      */
     unsigned int getOrder() const noexcept { return static_cast<unsigned int>(0.5 + (1.0 / _invN)); };
 
-    virtual std::string toString(std::string const& prefix) const {
+    std::string toString(std::string const& prefix) const override {
         std::ostringstream os;
         os << "LanczosFunction2 [" << this->getOrder() << "]: ";
         ;

--- a/include/lsst/afw/math/GaussianProcess.h
+++ b/include/lsst/afw/math/GaussianProcess.h
@@ -166,7 +166,7 @@ public:
 template <typename T>
 class SquaredExpCovariogram : public Covariogram<T> {
 public:
-    virtual ~SquaredExpCovariogram();
+    ~SquaredExpCovariogram() override;
 
     explicit SquaredExpCovariogram();
 
@@ -176,7 +176,7 @@ public:
      */
     void setEllSquared(double ellSquared);
 
-    virtual T operator()(ndarray::Array<const T, 1, 1> const &, ndarray::Array<const T, 1, 1> const &) const;
+    T operator()(ndarray::Array<const T, 1, 1> const &, ndarray::Array<const T, 1, 1> const &) const override;
 
 private:
     double _ellSquared;
@@ -195,7 +195,7 @@ private:
 template <typename T>
 class NeuralNetCovariogram : public Covariogram<T> {
 public:
-    virtual ~NeuralNetCovariogram();
+    ~NeuralNetCovariogram() override;
 
     explicit NeuralNetCovariogram();
 
@@ -209,7 +209,7 @@ public:
      */
     void setSigma1(double sigma1);
 
-    virtual T operator()(ndarray::Array<const T, 1, 1> const &, ndarray::Array<const T, 1, 1> const &) const;
+    T operator()(ndarray::Array<const T, 1, 1> const &, ndarray::Array<const T, 1, 1> const &) const override;
 
 private:
     double _sigma0, _sigma1;

--- a/include/lsst/afw/math/Integrate.h
+++ b/include/lsst/afw/math/Integrate.h
@@ -206,7 +206,7 @@ int nfeval = 0;
 }  // namespace details
 
 template <class T>
-struct IntRegion {
+struct IntRegion final {
 public:
     IntRegion(T const a, T const b, std::ostream *dbgout = 0)
             : _a(a), _b(b), _error(0.0), _area(0), _dbgout(dbgout) {}

--- a/include/lsst/afw/math/Kernel.h
+++ b/include/lsst/afw/math/Kernel.h
@@ -175,7 +175,7 @@ public:
     Kernel &operator=(const Kernel &) = delete;
     Kernel &operator=(Kernel &&) = delete;
 
-    virtual ~Kernel() = default;
+    ~Kernel() override = default;
 
     /**
      * Return a pointer to a deep copy of this kernel
@@ -459,7 +459,7 @@ public:
     struct PersistenceHelper;
 
 protected:
-    virtual std::string getPythonModule() const;
+    std::string getPythonModule() const override;
 
     /**
      * Set one kernel parameter
@@ -545,26 +545,26 @@ public:
     FixedKernel &operator=(const FixedKernel &) = delete;
     FixedKernel &operator=(FixedKernel &&) = delete;
 
-    virtual ~FixedKernel() = default;
+    ~FixedKernel() override = default;
 
-    virtual std::shared_ptr<Kernel> clone() const;
+    std::shared_ptr<Kernel> clone() const override;
 
-    virtual std::shared_ptr<Kernel> resized(int width, int height) const;
+    std::shared_ptr<Kernel> resized(int width, int height) const override;
 
-    virtual std::string toString(std::string const &prefix = "") const;
+    std::string toString(std::string const &prefix = "") const override;
 
     virtual Pixel getSum() const { return _sum; }
 
-    virtual bool isPersistable() const noexcept override { return true; }
+    bool isPersistable() const noexcept override { return true; }
 
     class Factory;
 
 protected:
-    double doComputeImage(lsst::afw::image::Image<Pixel> &image, bool doNormalize) const;
+    double doComputeImage(lsst::afw::image::Image<Pixel> &image, bool doNormalize) const override;
 
-    virtual std::string getPersistenceName() const;
+    std::string getPersistenceName() const override;
 
-    virtual void write(OutputArchiveHandle &handle) const;
+    void write(OutputArchiveHandle &handle) const override;
 
 private:
     lsst::afw::image::Image<Pixel> _image;
@@ -638,11 +638,11 @@ public:
     AnalyticKernel &operator=(const AnalyticKernel &) = delete;
     AnalyticKernel &operator=(AnalyticKernel &&) = delete;
 
-    virtual ~AnalyticKernel() = default;
+    ~AnalyticKernel() override = default;
 
-    virtual std::shared_ptr<Kernel> clone() const;
+    std::shared_ptr<Kernel> clone() const override;
 
-    virtual std::shared_ptr<Kernel> resized(int width, int height) const;
+    std::shared_ptr<Kernel> resized(int width, int height) const override;
 
     /**
      * Compute an image (pixellized representation of the kernel) in place
@@ -667,28 +667,28 @@ public:
     double computeImage(lsst::afw::image::Image<Pixel> &image, bool doNormalize, double x = 0.0,
                         double y = 0.0) const;
 
-    virtual std::vector<double> getKernelParameters() const;
+    std::vector<double> getKernelParameters() const override;
 
     /**
      * Get a deep copy of the kernel function
      */
     virtual KernelFunctionPtr getKernelFunction() const;
 
-    virtual std::string toString(std::string const &prefix = "") const;
+    std::string toString(std::string const &prefix = "") const override;
 
-    virtual bool isPersistable() const noexcept override { return true; }
+    bool isPersistable() const noexcept override { return true; }
 
     class Factory;
 
 protected:
-    virtual double doComputeImage(lsst::afw::image::Image<Pixel> &image, bool doNormalize) const;
+    double doComputeImage(lsst::afw::image::Image<Pixel> &image, bool doNormalize) const override;
 
-    virtual std::string getPersistenceName() const;
+    std::string getPersistenceName() const override;
 
-    virtual void write(OutputArchiveHandle &handle) const;
+    void write(OutputArchiveHandle &handle) const override;
 
 protected:
-    virtual void setKernelParameter(unsigned int ind, double value) const;
+    void setKernelParameter(unsigned int ind, double value) const override;
 
     KernelFunctionPtr _kernelFunctionPtr;
 
@@ -728,26 +728,26 @@ public:
     DeltaFunctionKernel &operator=(const DeltaFunctionKernel &) = delete;
     DeltaFunctionKernel &operator=(DeltaFunctionKernel &&) = delete;
 
-    virtual ~DeltaFunctionKernel() = default;
+    ~DeltaFunctionKernel() override = default;
 
-    virtual std::shared_ptr<Kernel> clone() const;
+    std::shared_ptr<Kernel> clone() const override;
 
-    virtual std::shared_ptr<Kernel> resized(int width, int height) const;
+    std::shared_ptr<Kernel> resized(int width, int height) const override;
 
     lsst::geom::Point2I getPixel() const { return _pixel; }
 
-    virtual std::string toString(std::string const &prefix = "") const;
+    std::string toString(std::string const &prefix = "") const override;
 
-    virtual bool isPersistable() const noexcept override { return true; }
+    bool isPersistable() const noexcept override { return true; }
 
     class Factory;
 
 protected:
-    virtual double doComputeImage(lsst::afw::image::Image<Pixel> &image, bool doNormalize) const;
+    double doComputeImage(lsst::afw::image::Image<Pixel> &image, bool doNormalize) const override;
 
-    virtual std::string getPersistenceName() const;
+    std::string getPersistenceName() const override;
 
-    virtual void write(OutputArchiveHandle &handle) const;
+    void write(OutputArchiveHandle &handle) const override;
 
 private:
     lsst::geom::Point2I _pixel;
@@ -818,13 +818,13 @@ public:
     LinearCombinationKernel &operator=(const LinearCombinationKernel &) = delete;
     LinearCombinationKernel &operator=(LinearCombinationKernel &&) = delete;
 
-    virtual ~LinearCombinationKernel() = default;
+    ~LinearCombinationKernel() override = default;
 
-    virtual std::shared_ptr<Kernel> clone() const;
+    std::shared_ptr<Kernel> clone() const override;
 
-    virtual std::shared_ptr<Kernel> resized(int width, int height) const;
+    std::shared_ptr<Kernel> resized(int width, int height) const override;
 
-    virtual std::vector<double> getKernelParameters() const;
+    std::vector<double> getKernelParameters() const override;
 
     /**
      * Get the fixed basis kernels
@@ -889,20 +889,20 @@ public:
      */
     std::shared_ptr<Kernel> refactor() const;
 
-    virtual std::string toString(std::string const &prefix = "") const;
+    std::string toString(std::string const &prefix = "") const override;
 
-    virtual bool isPersistable() const noexcept override { return true; }
+    bool isPersistable() const noexcept override { return true; }
 
     class Factory;
 
 protected:
-    virtual double doComputeImage(lsst::afw::image::Image<Pixel> &image, bool doNormalize) const;
+    double doComputeImage(lsst::afw::image::Image<Pixel> &image, bool doNormalize) const override;
 
-    virtual std::string getPersistenceName() const;
+    std::string getPersistenceName() const override;
 
-    virtual void write(OutputArchiveHandle &handle) const;
+    void write(OutputArchiveHandle &handle) const override;
 
-    virtual void setKernelParameter(unsigned int ind, double value) const;
+    void setKernelParameter(unsigned int ind, double value) const override;
 
 private:
     /**
@@ -994,11 +994,11 @@ public:
     SeparableKernel &operator=(const SeparableKernel &) = delete;
     SeparableKernel &operator=(SeparableKernel &&) = delete;
 
-    virtual ~SeparableKernel() = default;
+    ~SeparableKernel() override = default;
 
-    virtual std::shared_ptr<Kernel> clone() const;
+    std::shared_ptr<Kernel> clone() const override;
 
-    virtual std::shared_ptr<Kernel> resized(int width, int height) const;
+    std::shared_ptr<Kernel> resized(int width, int height) const override;
 
     /**
      * Compute the column and row arrays in place, where kernel(col, row) = colList(col) * rowList(row)
@@ -1019,7 +1019,7 @@ public:
     double computeVectors(std::vector<Pixel> &colList, std::vector<Pixel> &rowList, bool doNormalize,
                           double x = 0.0, double y = 0.0) const;
 
-    virtual double getKernelParameter(unsigned int i) const {
+    double getKernelParameter(unsigned int i) const override {
         unsigned int const ncol = _kernelColFunctionPtr->getNParameters();
         if (i < ncol) {
             return _kernelColFunctionPtr->getParameter(i);
@@ -1028,7 +1028,7 @@ public:
             return _kernelRowFunctionPtr->getParameter(i);
         }
     }
-    virtual std::vector<double> getKernelParameters() const;
+    std::vector<double> getKernelParameters() const override;
 
     /**
      * Get a deep copy of the col kernel function
@@ -1040,7 +1040,7 @@ public:
      */
     KernelFunctionPtr getKernelRowFunction() const;
 
-    virtual std::string toString(std::string const &prefix = "") const;
+    std::string toString(std::string const &prefix = "") const override;
 
     /***
      * Compute a cache of values for the x and y kernel functions
@@ -1051,17 +1051,17 @@ public:
      *
      * @param cacheSize cache size (number of double precision array elements in the x and y caches)
      */
-    virtual void computeCache(int const cacheSize);
+    void computeCache(int const cacheSize) override;
 
     /**
      * Get the current cache size (0 if none)
      */
-    virtual int getCacheSize() const;
+    int getCacheSize() const override;
 
 protected:
-    virtual double doComputeImage(lsst::afw::image::Image<Pixel> &image, bool doNormalize) const;
+    double doComputeImage(lsst::afw::image::Image<Pixel> &image, bool doNormalize) const override;
 
-    virtual void setKernelParameter(unsigned int ind, double value) const;
+    void setKernelParameter(unsigned int ind, double value) const override;
 
 private:
     /**
@@ -1104,7 +1104,7 @@ private:
         ar &make_nvp("kernelY", _kernelY);
     }
 
-    virtual void _setKernelXY() {
+    void _setKernelXY() override {
         lsst::geom::Extent2I const dim = getDimensions();
         lsst::geom::Point2I const ctr = getCtr();
 

--- a/include/lsst/afw/math/LeastSquares.h
+++ b/include/lsst/afw/math/LeastSquares.h
@@ -64,7 +64,7 @@ namespace math {
  *  to construct the normal equations in single precision, however, even when the data are
  *  single precision.
  */
-class LeastSquares {
+class LeastSquares final {
 public:
     class Impl;  ///< Private implementation; forward-declared publicly so we can inherit from it in .cc
 

--- a/include/lsst/afw/math/MaskedVector.h
+++ b/include/lsst/afw/math/MaskedVector.h
@@ -48,7 +48,7 @@ public:
     MaskedVector(MaskedVector &&) = default;
     MaskedVector &operator=(MaskedVector const &) = default;
     MaskedVector &operator=(MaskedVector &&) = default;
-    ~MaskedVector() = default;
+    ~MaskedVector() override = default;
 
     // Getters
     /// Return a (Ptr to) the MaskedImage's %image

--- a/include/lsst/afw/math/Random.h
+++ b/include/lsst/afw/math/Random.h
@@ -59,7 +59,7 @@ namespace math {
  * @see <a href="http://www.gnu.org/software/gsl/manual/html_node/Random-Number-Distributions.html">Random
  * number distributions in GSL</a>
  */
-class Random {
+class Random final {
 public:
     /** Identifiers for the list of supported algorithms. */
     enum Algorithm {

--- a/include/lsst/afw/math/SpatialCell.h
+++ b/include/lsst/afw/math/SpatialCell.h
@@ -134,7 +134,7 @@ public:
     SpatialCellImageCandidate(SpatialCellImageCandidate&&) = default;
     SpatialCellImageCandidate& operator=(SpatialCellImageCandidate const&) = default;
     SpatialCellImageCandidate& operator=(SpatialCellImageCandidate&&) = default;
-    virtual ~SpatialCellImageCandidate() = default;
+    ~SpatialCellImageCandidate() override = default;
 
     /// Set the width of the image that getImage should return
     static void setWidth(int width) { _width = width; }

--- a/include/lsst/afw/math/Statistics.h
+++ b/include/lsst/afw/math/Statistics.h
@@ -212,7 +212,7 @@ private:
  *       clips at mean +/- numSigmaClip*stdev.
  *
  */
-class Statistics {
+class Statistics final {
 public:
     /// The type used to report (value, error) for desired statistics
     typedef std::pair<double, double> Value;
@@ -433,7 +433,7 @@ Statistics makeStatistics(
  *        be processed by Statistics as though it were an Image.
  */
 template <typename ValueT>
-class ImageImposter {
+class ImageImposter final {
 public:
     // types we'll use in Statistics
     typedef typename std::vector<ValueT>::const_iterator x_iterator;

--- a/include/lsst/afw/math/TransformBoundedField.h
+++ b/include/lsst/afw/math/TransformBoundedField.h
@@ -50,7 +50,7 @@ public:
      */
     TransformBoundedField(lsst::geom::Box2I const &bbox, Transform const &transform);
 
-    ~TransformBoundedField() = default;
+    ~TransformBoundedField() override = default;
 
     TransformBoundedField(TransformBoundedField const &) = default;
     TransformBoundedField(TransformBoundedField &&) = default;

--- a/include/lsst/afw/math/detail/Convolve.h
+++ b/include/lsst/afw/math/detail/Convolve.h
@@ -331,7 +331,7 @@ private:
  *
  * Intended for iterating over subregions of a KernelImagesForRegion using computeNextRow.
  */
-class RowOfKernelImagesForRegion {
+class RowOfKernelImagesForRegion final {
 public:
     typedef std::vector<std::shared_ptr<KernelImagesForRegion>> RegionList;
     typedef RegionList::iterator Iterator;
@@ -415,7 +415,7 @@ void convolveWithInterpolation(OutImageT& outImage, InImageT const& inImage,
 /**
  * kernel images used by convolveRegionWithInterpolation
  */
-struct ConvolveWithInterpolationWorkingImages {
+struct ConvolveWithInterpolationWorkingImages final {
 public:
     typedef lsst::afw::image::Image<lsst::afw::math::Kernel::Pixel> Image;
     ConvolveWithInterpolationWorkingImages(lsst::geom::Extent2I const& dimensions)

--- a/include/lsst/afw/math/detail/TrapezoidalPacker.h
+++ b/include/lsst/afw/math/detail/TrapezoidalPacker.h
@@ -87,7 +87,7 @@ namespace detail {
  *      6   7   8
  *      9  10  11
  */
-struct TrapezoidalPacker {
+struct TrapezoidalPacker final {
     explicit TrapezoidalPacker(ChebyshevBoundedFieldControl const& ctrl);
 
     void pack(ndarray::Array<double, 1, 1> const& out, ndarray::Array<double const, 1, 1> const& tx,

--- a/include/lsst/afw/math/detail/WarpAtOnePoint.h
+++ b/include/lsst/afw/math/detail/WarpAtOnePoint.h
@@ -37,7 +37,7 @@ namespace detail {
  * A functor that computes one warped pixel
  */
 template <typename DestImageT, typename SrcImageT>
-class WarpAtOnePoint {
+class WarpAtOnePoint final {
 public:
     WarpAtOnePoint(SrcImageT const &srcImage, WarpingControl const &control,
                    typename DestImageT::SinglePixel padValue)

--- a/include/lsst/afw/math/minimize.h
+++ b/include/lsst/afw/math/minimize.h
@@ -42,7 +42,7 @@ namespace math {
 /**
  * Results from minimizing a function
  */
-struct FitResults {
+struct FitResults final {
 public:
     bool isValid;                       ///< true if the fit converged; false otherwise
     double chiSq;                       ///< chi squared; may be nan or infinite, but only if isValid false

--- a/include/lsst/afw/math/warpExposure.h
+++ b/include/lsst/afw/math/warpExposure.h
@@ -74,9 +74,9 @@ public:
     LanczosWarpingKernel &operator=(const LanczosWarpingKernel &) = delete;
     LanczosWarpingKernel &operator=(LanczosWarpingKernel &&) = delete;
 
-    virtual ~LanczosWarpingKernel() = default;
+    ~LanczosWarpingKernel() override = default;
 
-    virtual std::shared_ptr<Kernel> clone() const;
+    std::shared_ptr<Kernel> clone() const override;
 
     /**
      * get the order of the kernel
@@ -84,7 +84,7 @@ public:
     int getOrder() const;
 
 protected:
-    virtual void setKernelParameter(unsigned int ind, double value) const;
+    void setKernelParameter(unsigned int ind, double value) const override;
 };
 
 /**
@@ -106,9 +106,9 @@ public:
     BilinearWarpingKernel &operator=(const BilinearWarpingKernel &) = delete;
     BilinearWarpingKernel &operator=(BilinearWarpingKernel &&) = delete;
 
-    virtual ~BilinearWarpingKernel() = default;
+    ~BilinearWarpingKernel() override = default;
 
-    virtual std::shared_ptr<Kernel> clone() const;
+    std::shared_ptr<Kernel> clone() const override;
 
     /**
      * 1-dimensional bilinear interpolation function.
@@ -128,9 +128,9 @@ public:
                 : Function1<Kernel::Pixel>(1) {
             this->_params[0] = fracPos;
         }
-        virtual ~BilinearFunction1() {}
+        ~BilinearFunction1() override {}
 
-        virtual Function1Ptr clone() const { return Function1Ptr(new BilinearFunction1(this->_params[0])); }
+        Function1Ptr clone() const override { return Function1Ptr(new BilinearFunction1(this->_params[0])); }
 
         /**
          * Solve bilinear equation
@@ -139,16 +139,16 @@ public:
          * *  0.0 or 1.0 if the kernel center index is 0 in this axis
          * * -1.0 or 0.0 if the kernel center index is 1 in this axis
          */
-        virtual Kernel::Pixel operator()(double x) const;
+        Kernel::Pixel operator()(double x) const override;
 
         /**
          * Return string representation.
          */
-        virtual std::string toString(std::string const & = "") const;
+        std::string toString(std::string const & = "") const override;
     };
 
 protected:
-    virtual void setKernelParameter(unsigned int ind, double value) const;
+    void setKernelParameter(unsigned int ind, double value) const override;
 };
 
 /**
@@ -169,9 +169,9 @@ public:
     NearestWarpingKernel &operator=(const NearestWarpingKernel &) = delete;
     NearestWarpingKernel &operator=(NearestWarpingKernel &&) = delete;
 
-    virtual ~NearestWarpingKernel() = default;
+    ~NearestWarpingKernel() override = default;
 
-    virtual std::shared_ptr<Kernel> clone() const;
+    std::shared_ptr<Kernel> clone() const override;
 
     /**
      * 1-dimensional nearest neighbor interpolation function.
@@ -191,9 +191,9 @@ public:
                 : Function1<Kernel::Pixel>(1) {
             this->_params[0] = fracPos;
         }
-        virtual ~NearestFunction1() {}
+        ~NearestFunction1() override {}
 
-        virtual Function1Ptr clone() const { return Function1Ptr(new NearestFunction1(this->_params[0])); }
+        Function1Ptr clone() const override { return Function1Ptr(new NearestFunction1(this->_params[0])); }
 
         /**
          * Solve nearest neighbor equation
@@ -202,16 +202,16 @@ public:
          * *  0.0 or 1.0 if the kernel center index is 0 in this axis
          * * -1.0 or 0.0 if the kernel center index is 1 in this axis
          */
-        virtual Kernel::Pixel operator()(double x) const;
+        Kernel::Pixel operator()(double x) const override;
 
         /**
          * Return string representation.
          */
-        virtual std::string toString(std::string const & = "") const;
+        std::string toString(std::string const & = "") const override;
     };
 
 protected:
-    virtual void setKernelParameter(unsigned int ind, double value) const;
+    void setKernelParameter(unsigned int ind, double value) const override;
 };
 
 /**

--- a/include/lsst/afw/table/AliasMap.h
+++ b/include/lsst/afw/table/AliasMap.h
@@ -33,7 +33,7 @@ class BaseTable;
  *  by a Table will hold a pointer to that Table, and call BaseTable::handleAliasChanges() when its
  *  aliases are set or removed.
  */
-class AliasMap {
+class AliasMap final {
     typedef std::map<std::string, std::string> Internal;
 
 public:

--- a/include/lsst/afw/table/AmpInfo.h
+++ b/include/lsst/afw/table/AmpInfo.h
@@ -87,7 +87,7 @@ public:
     AmpInfoRecord(AmpInfoRecord &&) = delete;
     AmpInfoRecord &operator=(AmpInfoRecord const &) = delete;
     AmpInfoRecord &operator=(AmpInfoRecord &&) = delete;
-    ~AmpInfoRecord();
+    ~AmpInfoRecord() override;
 
     std::shared_ptr<AmpInfoTable const> getTable() const {
         return std::static_pointer_cast<AmpInfoTable const>(BaseRecord::getTable());
@@ -184,7 +184,7 @@ public:
 
     AmpInfoTable &operator=(AmpInfoTable const &) = delete;
     AmpInfoTable &operator=(AmpInfoTable &&) = delete;
-    ~AmpInfoTable();
+    ~AmpInfoTable() override;
 
     /**
      *  Construct a new table.

--- a/include/lsst/afw/table/BaseColumnView.h
+++ b/include/lsst/afw/table/BaseColumnView.h
@@ -39,7 +39,7 @@ class BaseColumnView;
  *
  *  A BitsColumn can only be constructed by calling BaseColumnView::getBits().
  */
-class BitsColumn {
+class BitsColumn final {
 public:
     typedef std::int64_t IntT;
 

--- a/include/lsst/afw/table/Exposure.h
+++ b/include/lsst/afw/table/Exposure.h
@@ -146,12 +146,12 @@ public:
     ExposureRecord(ExposureRecord&&) = delete;
     ExposureRecord& operator=(ExposureRecord const&) = delete;
     ExposureRecord& operator=(ExposureRecord&&) = delete;
-    ~ExposureRecord();
+    ~ExposureRecord() override;
 
 protected:
     explicit ExposureRecord(std::shared_ptr<ExposureTable> const& table);
 
-    virtual void _assign(BaseRecord const& other);
+    void _assign(BaseRecord const& other) override;
 
 private:
     friend class ExposureTable;
@@ -241,7 +241,7 @@ public:
 
     ExposureTable& operator=(ExposureTable const&) = delete;
     ExposureTable& operator=(ExposureTable&&) = delete;
-    ~ExposureTable();
+    ~ExposureTable() override;
 
 protected:
     explicit ExposureTable(Schema const& schema);

--- a/include/lsst/afw/table/Match.h
+++ b/include/lsst/afw/table/Match.h
@@ -64,7 +64,7 @@ public:
  *  matches.
  */
 template <typename Record1, typename Record2>
-struct Match {
+struct Match final {
     std::shared_ptr<Record1> first;
     std::shared_ptr<Record2> second;
     double distance;  // may be pixels or radians

--- a/include/lsst/afw/table/Schema.h
+++ b/include/lsst/afw/table/Schema.h
@@ -47,7 +47,7 @@ class BaseRecord;
  *  When creating a Python interface, functions that return Schema by const reference should be
  *  converted to return by value (%returnCopy) to ensure proper memory management and encapsulation.
  */
-class Schema {
+class Schema final {
     typedef detail::SchemaImpl Impl;
 
 public:
@@ -354,7 +354,7 @@ private:
  *      assert(schema["a_i"] == "a_i");
  *      assert(schema.find("a_p_x") == a_p.getX());
  */
-class SubSchema {
+class SubSchema final {
     typedef detail::SchemaImpl Impl;
 
 public:

--- a/include/lsst/afw/table/SchemaMapper.h
+++ b/include/lsst/afw/table/SchemaMapper.h
@@ -18,7 +18,7 @@ class BaseRecord;
  *  SchemaMapper is initialized with its input Schema, and contains member functions
  *  to add mapped or unmapped fields to the output Schema.
  */
-class SchemaMapper {
+class SchemaMapper final {
 public:
     /// Return the input schema (copy-on-write).
     Schema const getInputSchema() const { return _impl->_input; }

--- a/include/lsst/afw/table/Simple.h
+++ b/include/lsst/afw/table/Simple.h
@@ -75,7 +75,7 @@ public:
     SimpleRecord& operator=(const SimpleRecord&) = delete;
     SimpleRecord(SimpleRecord&&) = delete;
     SimpleRecord& operator=(SimpleRecord&&) = delete;
-    ~SimpleRecord();
+    ~SimpleRecord() override;
 
 protected:
     friend class SimpleTable;
@@ -181,7 +181,7 @@ public:
 
     SimpleTable& operator=(SimpleTable const&) = delete;
     SimpleTable& operator=(SimpleTable&&) = delete;
-    ~SimpleTable();
+    ~SimpleTable() override;
 
 protected:
     SimpleTable(Schema const& schema, std::shared_ptr<IdFactory> const& idFactory);

--- a/include/lsst/afw/table/aggregates.h
+++ b/include/lsst/afw/table/aggregates.h
@@ -68,7 +68,7 @@ public:
     PointKey(PointKey&&) noexcept = default;
     PointKey& operator=(PointKey const&) noexcept = default;
     PointKey& operator=(PointKey&&) noexcept = default;
-    virtual ~PointKey() noexcept = default;
+    ~PointKey() noexcept override = default;
 
     /**
      *  Construct from a subschema, assuming x and y subfields
@@ -81,10 +81,10 @@ public:
     PointKey(SubSchema const& s) : _x(s["x"]), _y(s["y"]) {}
 
     /// Get a Point from the given record
-    virtual lsst::geom::Point<T, 2> get(BaseRecord const& record) const;
+    lsst::geom::Point<T, 2> get(BaseRecord const& record) const override;
 
     /// Set a Point in the given record
-    virtual void set(BaseRecord& record, lsst::geom::Point<T, 2> const& value) const;
+    void set(BaseRecord& record, lsst::geom::Point<T, 2> const& value) const override;
 
     //@{
     /// Compare the FunctorKey for equality with another, using the underlying x and y Keys
@@ -156,13 +156,13 @@ public:
     BoxKey(BoxKey&&) noexcept = default;
     BoxKey& operator=(BoxKey const&) noexcept = default;
     BoxKey& operator=(BoxKey&&) noexcept = default;
-    virtual ~BoxKey() noexcept = default;
+    ~BoxKey() noexcept override = default;
 
     /// Get a Point from the given record
-    virtual Box get(BaseRecord const& record) const;
+    Box get(BaseRecord const& record) const override;
 
     /// Set a Point in the given record
-    virtual void set(BaseRecord& record, Box const& value) const;
+    void set(BaseRecord& record, Box const& value) const override;
 
     //@{
     /// Compare the FunctorKey for equality with another, using the underlying x and y Keys
@@ -226,13 +226,13 @@ public:
     CoordKey(CoordKey&&) noexcept = default;
     CoordKey& operator=(CoordKey const&) noexcept = default;
     CoordKey& operator=(CoordKey&&) noexcept = default;
-    virtual ~CoordKey() noexcept = default;
+    ~CoordKey() noexcept override = default;
 
     /// Get an lsst::geom::SpherePoint from the given record
-    virtual lsst::geom::SpherePoint get(BaseRecord const& record) const;
+    lsst::geom::SpherePoint get(BaseRecord const& record) const override;
 
     /// Set an lsst::geom::SpherePoint in the given record
-    virtual void set(BaseRecord& record, lsst::geom::SpherePoint const& value) const;
+    void set(BaseRecord& record, lsst::geom::SpherePoint const& value) const override;
 
     //@{
     /// Compare CoordKeys for equality using the constituent `ra` and `dec` Keys
@@ -302,13 +302,13 @@ public:
     QuadrupoleKey(QuadrupoleKey&&) noexcept = default;
     QuadrupoleKey& operator=(QuadrupoleKey const&) noexcept = default;
     QuadrupoleKey& operator=(QuadrupoleKey&&) noexcept = default;
-    virtual ~QuadrupoleKey() noexcept = default;
+    ~QuadrupoleKey() noexcept override = default;
 
     /// Get a Quadrupole from the given record
-    virtual geom::ellipses::Quadrupole get(BaseRecord const& record) const;
+    geom::ellipses::Quadrupole get(BaseRecord const& record) const override;
 
     /// Set a Quadrupole in the given record
-    virtual void set(BaseRecord& record, geom::ellipses::Quadrupole const& value) const;
+    void set(BaseRecord& record, geom::ellipses::Quadrupole const& value) const override;
 
     //@{
     /// Compare the FunctorKey for equality with another, using the underlying Ixx, Iyy, Ixy Keys
@@ -372,13 +372,13 @@ public:
     EllipseKey(EllipseKey&&) noexcept = default;
     EllipseKey& operator=(EllipseKey const&) noexcept = default;
     EllipseKey& operator=(EllipseKey&&) noexcept = default;
-    virtual ~EllipseKey() noexcept = default;
+    ~EllipseKey() noexcept override = default;
 
     /// Get an Ellipse from the given record
-    virtual geom::ellipses::Ellipse get(BaseRecord const& record) const;
+    geom::ellipses::Ellipse get(BaseRecord const& record) const override;
 
     /// Set an Ellipse in the given record
-    virtual void set(BaseRecord& record, geom::ellipses::Ellipse const& value) const;
+    void set(BaseRecord& record, geom::ellipses::Ellipse const& value) const override;
 
     //@{
     /// Compare the FunctorKey for equality with another, using the underlying Ixx, Iyy, Ixy Keys
@@ -483,13 +483,13 @@ public:
     CovarianceMatrixKey(CovarianceMatrixKey&&);
     CovarianceMatrixKey& operator=(CovarianceMatrixKey const&);
     CovarianceMatrixKey& operator=(CovarianceMatrixKey&&);
-    virtual ~CovarianceMatrixKey() noexcept;
+    ~CovarianceMatrixKey() noexcept override;
 
     /// Get a covariance matrix from the given record
-    virtual Eigen::Matrix<T, N, N> get(BaseRecord const& record) const;
+    Eigen::Matrix<T, N, N> get(BaseRecord const& record) const override;
 
     /// Set a covariance matrix in the given record (uses only the lower triangle of the given matrix)
-    virtual void set(BaseRecord& record, Eigen::Matrix<T, N, N> const& value) const;
+    void set(BaseRecord& record, Eigen::Matrix<T, N, N> const& value) const override;
 
     /// Return the element in row i and column j
     T getElement(BaseRecord const& record, int i, int j) const;

--- a/include/lsst/afw/table/arrays.h
+++ b/include/lsst/afw/table/arrays.h
@@ -100,22 +100,22 @@ public:
     ArrayKey(ArrayKey&&) noexcept;
     ArrayKey& operator=(ArrayKey const&) noexcept;
     ArrayKey& operator=(ArrayKey&&) noexcept;
-    virtual ~ArrayKey() noexcept;
+    ~ArrayKey() noexcept override;
 
     /// Return the number of elements in the array.
     int getSize() const noexcept { return _size; }
 
     /// Get an array from the given record
-    virtual ndarray::Array<T const, 1, 1> get(BaseRecord const& record) const;
+    ndarray::Array<T const, 1, 1> get(BaseRecord const& record) const override;
 
     /// Set an array in the given record
-    virtual void set(BaseRecord& record, ndarray::Array<T const, 1, 1> const& value) const;
+    void set(BaseRecord& record, ndarray::Array<T const, 1, 1> const& value) const override;
 
     /// Get non-const reference array from the given record
-    virtual ndarray::ArrayRef<T, 1, 1> getReference(BaseRecord& record) const;
+    ndarray::ArrayRef<T, 1, 1> getReference(BaseRecord& record) const override;
 
     /// Get const reference array from the given record
-    virtual ndarray::ArrayRef<T const, 1, 1> getConstReference(BaseRecord const& record) const;
+    ndarray::ArrayRef<T const, 1, 1> getConstReference(BaseRecord const& record) const override;
 
     //@{
     /// Compare the FunctorKey for equality with another, using the underlying scalar Keys

--- a/include/lsst/afw/table/detail/Access.h
+++ b/include/lsst/afw/table/detail/Access.h
@@ -28,7 +28,7 @@ namespace detail {
  *  related classes.  This is less secure, but it's obviously not part of the public interface,
  *  and that's good enough.
  */
-class Access {
+class Access final {
 public:
     /// @internal Return a sub-field key corresponding to the nth element.
     template <typename T>

--- a/include/lsst/afw/table/detail/SchemaImpl.h
+++ b/include/lsst/afw/table/detail/SchemaImpl.h
@@ -24,7 +24,7 @@ class SubSchema;
  *         (used for actual data access).
  */
 template <typename T>
-struct SchemaItem {
+struct SchemaItem final {
     Key<T> key;
     Field<T> field;
 

--- a/include/lsst/afw/table/detail/SchemaMapperImpl.h
+++ b/include/lsst/afw/table/detail/SchemaMapperImpl.h
@@ -25,7 +25,7 @@ namespace detail {
  *  pimpl (forEach) to Citizen; look there for more information (though SchemaMapper is
  *  not copy-on-write).
  */
-class SchemaMapperImpl {
+class SchemaMapperImpl final {
 private:
     /// Boost.MPL metafunction that returns a std::pair< Key<T>, Key<T> > given a T.
     struct MakeKeyPair {

--- a/include/lsst/afw/table/io/ArchiveIndexSchema.h
+++ b/include/lsst/afw/table/io/ArchiveIndexSchema.h
@@ -32,7 +32,7 @@ namespace io {
  *  name returned by Persistable::getPersistenceName() and used by InputArchive to
  *  look up a PersistableFactory in the registry.
  */
-struct ArchiveIndexSchema {
+struct ArchiveIndexSchema final {
     Schema schema;
     Key<int> id;
     Key<int> catArchive;      // 'cat.archive' in schema

--- a/include/lsst/afw/table/io/InputArchive.h
+++ b/include/lsst/afw/table/io/InputArchive.h
@@ -28,7 +28,7 @@ class CatalogVector;
  *
  *  @see OutputArchive
  */
-class InputArchive {
+class InputArchive final {
 public:
     typedef std::map<int, std::shared_ptr<Persistable>> Map;
 

--- a/include/lsst/afw/table/io/OutputArchive.h
+++ b/include/lsst/afw/table/io/OutputArchive.h
@@ -31,7 +31,7 @@ class OutputArchiveHandle;
  *
  *  See getIndexCatalog() for a more detailed description of the index.
  */
-class OutputArchive {
+class OutputArchive final {
 public:
     friend class OutputArchiveHandle;
 
@@ -114,7 +114,7 @@ private:
  *  OutputArchiveHandle provides an interface to add additional catalogs and save nested
  *  Persistables to the same archive.
  */
-class OutputArchiveHandle {
+class OutputArchiveHandle final {
 public:
     /**
      *  Return a new, empty catalog with the given schema.

--- a/src/detection/Footprint.cc
+++ b/src/detection/Footprint.cc
@@ -232,7 +232,7 @@ std::pair<afw::table::Schema&, table::Key<int>&> spanSetPersistenceHelper() {
 
 class FootprintFactory : public table::io::PersistableFactory {
 public:
-    virtual std::shared_ptr<afw::table::io::Persistable> read(
+    std::shared_ptr<afw::table::io::Persistable> read(
             afw::table::io::InputArchive const& archive,
             afw::table::io::CatalogVector const& catalogs) const override {
         // Verify there are two catalogs

--- a/src/detection/GaussianPsf.cc
+++ b/src/detection/GaussianPsf.cc
@@ -69,8 +69,8 @@ private:
 
 class GaussianPsfFactory : public afw::table::io::PersistableFactory {
 public:
-    virtual std::shared_ptr<afw::table::io::Persistable> read(InputArchive const& archive,
-                                                              CatalogVector const& catalogs) const {
+    std::shared_ptr<afw::table::io::Persistable> read(InputArchive const& archive,
+                                                      CatalogVector const& catalogs) const override {
         static GaussianPsfPersistenceHelper const& keys = GaussianPsfPersistenceHelper::get();
         LSST_ARCHIVE_ASSERT(catalogs.size() == 1u);
         LSST_ARCHIVE_ASSERT(catalogs.front().size() == 1u);

--- a/src/detection/HeavyFootprint.cc
+++ b/src/detection/HeavyFootprint.cc
@@ -289,8 +289,8 @@ class HeavyFootprint<ImagePixelT, MaskPixelT, VariancePixelT>::Factory
 public:
     explicit Factory(std::string const& name) : afw::table::io::PersistableFactory(name) {}
 
-    virtual std::shared_ptr<afw::table::io::Persistable> read(InputArchive const& archive,
-                                                              CatalogVector const& catalogs) const {
+    std::shared_ptr<afw::table::io::Persistable> read(InputArchive const& archive,
+                                                      CatalogVector const& catalogs) const override {
         HeavyFootprintPersistenceHelper<ImagePixelT, MaskPixelT, VariancePixelT> const& keys =
                 HeavyFootprintPersistenceHelper<ImagePixelT, MaskPixelT, VariancePixelT>::get();
         HeavyFootprintPersistenceHelper<ImagePixelT, std::uint16_t, VariancePixelT> const& legacyKeys =

--- a/src/detection/Peak.cc
+++ b/src/detection/Peak.cc
@@ -44,7 +44,7 @@ public:
     explicit PeakFitsWriter(Fits* fits, int flags) : afw::table::io::FitsWriter(fits, flags) {}
 
 protected:
-    virtual void _writeTable(std::shared_ptr<afw::table::BaseTable const> const& table, std::size_t nRows);
+    void _writeTable(std::shared_ptr<afw::table::BaseTable const> const& table, std::size_t nRows) override;
 };
 
 void PeakFitsWriter::_writeTable(std::shared_ptr<afw::table::BaseTable const> const& t, std::size_t nRows) {
@@ -72,9 +72,9 @@ class PeakFitsReader : public afw::table::io::FitsReader {
 public:
     PeakFitsReader() : afw::table::io::FitsReader("PEAK") {}
 
-    virtual std::shared_ptr<afw::table::BaseTable> makeTable(
-            afw::table::io::FitsSchemaInputMapper& mapper, std::shared_ptr<daf::base::PropertyList> metadata,
-            int ioFlags, bool stripMetadata) const {
+    std::shared_ptr<afw::table::BaseTable> makeTable(afw::table::io::FitsSchemaInputMapper& mapper,
+                                                     std::shared_ptr<daf::base::PropertyList> metadata,
+                                                     int ioFlags, bool stripMetadata) const override {
         std::shared_ptr<PeakTable> table = PeakTable::make(mapper.finalize());
         table->setMetadata(metadata);
         return table;

--- a/src/fits.cc
+++ b/src/fits.cc
@@ -803,7 +803,7 @@ bool isKeyIgnored(std::string const &key, bool write = false) {
 
 class MetadataIterationFunctor : public HeaderIterationFunctor {
 public:
-    virtual void operator()(std::string const &key, std::string const &value, std::string const &comment);
+    void operator()(std::string const &key, std::string const &value, std::string const &comment) override;
 
     template <typename T>
     void add(std::string const &key, T value, std::string const &comment) {

--- a/src/geom/OldWcs.cc
+++ b/src/geom/OldWcs.cc
@@ -75,8 +75,8 @@ class OldWcsFactory : public table::io::PersistableFactory {
 public:
     explicit OldWcsFactory(std::string const& name) : table::io::PersistableFactory(name) {}
 
-    virtual std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
-                                                         CatalogVector const& catalogs) const {
+    std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
+                                                 CatalogVector const& catalogs) const override {
         LSST_ARCHIVE_ASSERT(catalogs.size() >= 1u);
         LSST_ARCHIVE_ASSERT(catalogs.front().size() == 1u);
         auto const& record = catalogs.front().front();
@@ -92,8 +92,8 @@ class OldTanWcsFactory : public table::io::PersistableFactory {
 public:
     explicit OldTanWcsFactory(std::string const& name) : table::io::PersistableFactory(name) {}
 
-    virtual std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
-                                                         CatalogVector const& catalogs) const {
+    std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
+                                                 CatalogVector const& catalogs) const override {
         LSST_ARCHIVE_ASSERT(catalogs.size() >= 1u);
         auto const& record = catalogs.front().front();
         auto const metadata = getOldWcsMetadata(record);

--- a/src/geom/SkyWcs.cc
+++ b/src/geom/SkyWcs.cc
@@ -90,8 +90,8 @@ class SkyWcsFactory : public table::io::PersistableFactory {
 public:
     explicit SkyWcsFactory(std::string const& name) : table::io::PersistableFactory(name) {}
 
-    virtual std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
-                                                         CatalogVector const& catalogs) const {
+    std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
+                                                 CatalogVector const& catalogs) const override {
         SkyWcsPersistenceHelper const& keys = SkyWcsPersistenceHelper::get();
         LSST_ARCHIVE_ASSERT(catalogs.size() == 1u);
         LSST_ARCHIVE_ASSERT(catalogs.front().size() == 1u);

--- a/src/geom/SpanSet.cc
+++ b/src/geom/SpanSet.cc
@@ -995,8 +995,8 @@ std::string getSpanSetPersistenceName() { return "SpanSet"; }
 
 class SpanSetFactory : public table::io::PersistableFactory {
 public:
-    virtual std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
-                                                         CatalogVector const& catalogs) const {
+    std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
+                                                 CatalogVector const& catalogs) const override {
         // There should only be one catalog saved
         LSST_ARCHIVE_ASSERT(catalogs.size() == 1u);
         // Get the catalog with the spans

--- a/src/geom/Transform.cc
+++ b/src/geom/Transform.cc
@@ -224,8 +224,8 @@ class TransformFactory : public table::io::PersistableFactory {
 public:
     explicit TransformFactory(std::string const &name) : table::io::PersistableFactory(name) {}
 
-    virtual std::shared_ptr<table::io::Persistable> read(InputArchive const &archive,
-                                                         CatalogVector const &catalogs) const {
+    std::shared_ptr<table::io::Persistable> read(InputArchive const &archive,
+                                                 CatalogVector const &catalogs) const override {
         auto const &keys = TransformPersistenceHelper::get();
         LSST_ARCHIVE_ASSERT(catalogs.size() == 1u);
         LSST_ARCHIVE_ASSERT(catalogs.front().size() == 1u);

--- a/src/geom/polygon/Polygon.cc
+++ b/src/geom/polygon/Polygon.cc
@@ -540,8 +540,8 @@ class PolygonFactory : public table::io::PersistableFactory {
 public:
     explicit PolygonFactory(std::string const& name) : table::io::PersistableFactory(name) {}
 
-    virtual std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
-                                                         CatalogVector const& catalogs) const {
+    std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
+                                                 CatalogVector const& catalogs) const override {
         static PolygonSchema const& keys = PolygonSchema::get();
 
         LSST_ARCHIVE_ASSERT(catalogs.size() == 1u);

--- a/src/image/ApCorrMap.cc
+++ b/src/image/ApCorrMap.cc
@@ -88,8 +88,8 @@ private:
 
 class ApCorrMapFactory : public table::io::PersistableFactory {
 public:
-    virtual std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
-                                                         CatalogVector const& catalogs) const {
+    std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
+                                                 CatalogVector const& catalogs) const override {
         PersistenceHelper const& keys = PersistenceHelper::get();
         LSST_ARCHIVE_ASSERT(catalogs.size() == 1u);
         LSST_ARCHIVE_ASSERT(catalogs.front().getSchema() == keys.schema);

--- a/src/image/Calib.cc
+++ b/src/image/Calib.cc
@@ -390,8 +390,8 @@ public:
 
 class CalibFactory : public table::io::PersistableFactory {
 public:
-    virtual std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
-                                                         CatalogVector const& catalogs) const {
+    std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
+                                                 CatalogVector const& catalogs) const override {
         // table version is not persisted, so we don't have a clean way to determine the version;
         // the hack is version = 1 if exptime found, else current
         int tableVersion = 1;

--- a/src/image/CoaddInputs.cc
+++ b/src/image/CoaddInputs.cc
@@ -33,8 +33,8 @@ namespace {
 
 class CoaddInputsFactory : public table::io::PersistableFactory {
 public:
-    virtual std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
-                                                         CatalogVector const& catalogs) const {
+    std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
+                                                 CatalogVector const& catalogs) const override {
         LSST_ARCHIVE_ASSERT(catalogs.size() == 2);
         std::shared_ptr<CoaddInputs> result = std::make_shared<CoaddInputs>();
         result->visits = table::ExposureCatalog::readFromArchive(archive, catalogs.front());

--- a/src/image/Image.cc
+++ b/src/image/Image.cc
@@ -657,22 +657,30 @@ namespace {
  */
 template <typename LhsPixelT, typename RhsPixelT>
 struct plusEq : public pixelOp2<LhsPixelT, RhsPixelT> {
-    LhsPixelT operator()(LhsPixelT lhs, RhsPixelT rhs) const { return static_cast<LhsPixelT>(lhs + rhs); }
+    LhsPixelT operator()(LhsPixelT lhs, RhsPixelT rhs) const override {
+        return static_cast<LhsPixelT>(lhs + rhs);
+    }
 };
 
 template <typename LhsPixelT, typename RhsPixelT>
 struct minusEq : public pixelOp2<LhsPixelT, RhsPixelT> {
-    LhsPixelT operator()(LhsPixelT lhs, RhsPixelT rhs) const { return static_cast<LhsPixelT>(lhs - rhs); }
+    LhsPixelT operator()(LhsPixelT lhs, RhsPixelT rhs) const override {
+        return static_cast<LhsPixelT>(lhs - rhs);
+    }
 };
 
 template <typename LhsPixelT, typename RhsPixelT>
 struct timesEq : public pixelOp2<LhsPixelT, RhsPixelT> {
-    LhsPixelT operator()(LhsPixelT lhs, RhsPixelT rhs) const { return static_cast<LhsPixelT>(lhs * rhs); }
+    LhsPixelT operator()(LhsPixelT lhs, RhsPixelT rhs) const override {
+        return static_cast<LhsPixelT>(lhs * rhs);
+    }
 };
 
 template <typename LhsPixelT, typename RhsPixelT>
 struct divideEq : public pixelOp2<LhsPixelT, RhsPixelT> {
-    LhsPixelT operator()(LhsPixelT lhs, RhsPixelT rhs) const { return static_cast<LhsPixelT>(lhs / rhs); }
+    LhsPixelT operator()(LhsPixelT lhs, RhsPixelT rhs) const override {
+        return static_cast<LhsPixelT>(lhs / rhs);
+    }
 };
 }  // namespace
 

--- a/src/image/PhotoCalib.cc
+++ b/src/image/PhotoCalib.cc
@@ -243,8 +243,8 @@ private:
 
 class PhotoCalibFactory : public table::io::PersistableFactory {
 public:
-    virtual PTR(table::io::Persistable)
-            read(InputArchive const &archive, CatalogVector const &catalogs) const {
+    PTR(table::io::Persistable)
+    read(InputArchive const &archive, CatalogVector const &catalogs) const override {
         table::BaseRecord const &record = catalogs.front().front();
         PhotoCalibSchema const &keys = PhotoCalibSchema::get();
         return std::make_shared<PhotoCalib>(record.get(keys.calibrationMean), record.get(keys.calibrationErr),

--- a/src/image/VisitInfo.cc
+++ b/src/image/VisitInfo.cc
@@ -225,8 +225,8 @@ private:
 
 class VisitInfoFactory : public table::io::PersistableFactory {
 public:
-    virtual std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
-                                                         CatalogVector const& catalogs) const {
+    std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
+                                                 CatalogVector const& catalogs) const override {
         VisitInfoSchema const& keys = VisitInfoSchema::get();
         LSST_ARCHIVE_ASSERT(catalogs.size() == 1u);
         LSST_ARCHIVE_ASSERT(catalogs.front().size() == 1u);

--- a/src/math/AnalyticKernel.cc
+++ b/src/math/AnalyticKernel.cc
@@ -151,8 +151,8 @@ struct AnalyticKernelPersistenceHelper : public Kernel::PersistenceHelper {
 
 class AnalyticKernel::Factory : public afw::table::io::PersistableFactory {
 public:
-    virtual std::shared_ptr<afw::table::io::Persistable> read(InputArchive const &archive,
-                                                              CatalogVector const &catalogs) const {
+    std::shared_ptr<afw::table::io::Persistable> read(InputArchive const &archive,
+                                                      CatalogVector const &catalogs) const override {
         LSST_ARCHIVE_ASSERT(catalogs.size() == 1u);
         LSST_ARCHIVE_ASSERT(catalogs.front().size() == 1u);
         AnalyticKernelPersistenceHelper const keys(catalogs.front().getSchema());

--- a/src/math/Approximate.cc
+++ b/src/math/Approximate.cc
@@ -67,7 +67,7 @@ class ApproximateChebyshev : public Approximate<PixelT> {
                                                                  ApproximateControl const& ctrl);
 
 public:
-    virtual ~ApproximateChebyshev();
+    ~ApproximateChebyshev() override;
 
 private:
     math::Chebyshev1Function2<double> _poly;
@@ -75,10 +75,10 @@ private:
     ApproximateChebyshev(std::vector<double> const& xVec, std::vector<double> const& yVec,
                          image::MaskedImage<PixelT> const& im, lsst::geom::Box2I const& bbox,
                          ApproximateControl const& ctrl);
-    virtual std::shared_ptr<image::Image<typename Approximate<PixelT>::OutPixelT>> doGetImage(
-            int orderX, int orderY) const;
-    virtual std::shared_ptr<image::MaskedImage<typename Approximate<PixelT>::OutPixelT>> doGetMaskedImage(
-            int orderX, int orderY) const;
+    std::shared_ptr<image::Image<typename Approximate<PixelT>::OutPixelT>> doGetImage(
+            int orderX, int orderY) const override;
+    std::shared_ptr<image::MaskedImage<typename Approximate<PixelT>::OutPixelT>> doGetMaskedImage(
+            int orderX, int orderY) const override;
 };
 
 namespace {

--- a/src/math/ChebyshevBoundedField.cc
+++ b/src/math/ChebyshevBoundedField.cc
@@ -328,8 +328,8 @@ public:
     explicit ChebyshevBoundedFieldFactory(std::string const& name)
             : afw::table::io::PersistableFactory(name) {}
 
-    virtual std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
-                                                         CatalogVector const& catalogs) const {
+    std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
+                                                 CatalogVector const& catalogs) const override {
         LSST_ARCHIVE_ASSERT(catalogs.size() == 1u);
         LSST_ARCHIVE_ASSERT(catalogs.front().size() == 1u);
         table::BaseRecord const& record = catalogs.front().front();

--- a/src/math/DeltaFunctionKernel.cc
+++ b/src/math/DeltaFunctionKernel.cc
@@ -120,8 +120,8 @@ private:
 
 class DeltaFunctionKernel::Factory : public afw::table::io::PersistableFactory {
 public:
-    virtual std::shared_ptr<afw::table::io::Persistable> read(InputArchive const& archive,
-                                                              CatalogVector const& catalogs) const {
+    std::shared_ptr<afw::table::io::Persistable> read(InputArchive const& archive,
+                                                      CatalogVector const& catalogs) const override {
         LSST_ARCHIVE_ASSERT(catalogs.size() == 1u);
         LSST_ARCHIVE_ASSERT(catalogs.front().size() == 1u);
         DeltaFunctionKernelPersistenceHelper const& keys = DeltaFunctionKernelPersistenceHelper::get();

--- a/src/math/FixedKernel.cc
+++ b/src/math/FixedKernel.cc
@@ -147,8 +147,8 @@ struct FixedKernelPersistenceHelper : public Kernel::PersistenceHelper {
 
 class FixedKernel::Factory : public afw::table::io::PersistableFactory {
 public:
-    virtual std::shared_ptr<afw::table::io::Persistable> read(InputArchive const& archive,
-                                                              CatalogVector const& catalogs) const {
+    std::shared_ptr<afw::table::io::Persistable> read(InputArchive const& archive,
+                                                      CatalogVector const& catalogs) const override {
         LSST_ARCHIVE_ASSERT(catalogs.size() == 1u);
         LSST_ARCHIVE_ASSERT(catalogs.front().size() == 1u);
         FixedKernelPersistenceHelper const keys(catalogs.front().getSchema());

--- a/src/math/FunctionLibrary.cc
+++ b/src/math/FunctionLibrary.cc
@@ -110,8 +110,8 @@ struct Chebyshev1Function2PersistenceHelper : public PolynomialFunction2Persiste
 template <typename ReturnT>
 class GaussianFunction2Factory : public table::io::PersistableFactory {
 public:
-    virtual std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
-                                                         CatalogVector const& catalogs) const {
+    std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
+                                                 CatalogVector const& catalogs) const override {
         LSST_ARCHIVE_ASSERT(catalogs.size() == 1u);
         LSST_ARCHIVE_ASSERT(catalogs.front().size() == 1u);
         GaussianFunction2PersistenceHelper const& keys = GaussianFunction2PersistenceHelper::get();
@@ -127,8 +127,8 @@ public:
 template <typename ReturnT>
 class DoubleGaussianFunction2Factory : public table::io::PersistableFactory {
 public:
-    virtual std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
-                                                         CatalogVector const& catalogs) const {
+    std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
+                                                 CatalogVector const& catalogs) const override {
         LSST_ARCHIVE_ASSERT(catalogs.size() == 1u);
         LSST_ARCHIVE_ASSERT(catalogs.front().size() == 1u);
         DoubleGaussianFunction2PersistenceHelper const& keys =
@@ -145,8 +145,8 @@ public:
 template <typename ReturnT>
 class PolynomialFunction2Factory : public table::io::PersistableFactory {
 public:
-    virtual std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
-                                                         CatalogVector const& catalogs) const {
+    std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
+                                                 CatalogVector const& catalogs) const override {
         LSST_ARCHIVE_ASSERT(catalogs.size() == 1u);
         LSST_ARCHIVE_ASSERT(catalogs.front().size() == 1u);
         PolynomialFunction2PersistenceHelper const keys(catalogs.front().getSchema());
@@ -160,8 +160,8 @@ public:
 template <typename ReturnT>
 class Chebyshev1Function2Factory : public table::io::PersistableFactory {
 public:
-    virtual std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
-                                                         CatalogVector const& catalogs) const {
+    std::shared_ptr<table::io::Persistable> read(InputArchive const& archive,
+                                                 CatalogVector const& catalogs) const override {
         LSST_ARCHIVE_ASSERT(catalogs.size() == 1u);
         LSST_ARCHIVE_ASSERT(catalogs.front().size() == 1u);
         Chebyshev1Function2PersistenceHelper keys(catalogs.front().getSchema());

--- a/src/math/Interpolate.cc
+++ b/src/math/Interpolate.cc
@@ -79,8 +79,8 @@ class InterpolateConstant : public Interpolate {
                                                         Interpolate::Style const style);
 
 public:
-    virtual ~InterpolateConstant() {}
-    virtual double interpolate(double const x) const;
+    ~InterpolateConstant() override {}
+    double interpolate(double const x) const override;
 
 private:
     InterpolateConstant(std::vector<double> const &x,   ///< @internal the x-values of points
@@ -173,8 +173,8 @@ class InterpolateGsl : public Interpolate {
                                                         Interpolate::Style const style);
 
 public:
-    virtual ~InterpolateGsl();
-    virtual double interpolate(double const x) const;
+    ~InterpolateGsl() override;
+    double interpolate(double const x) const override;
 
 private:
     InterpolateGsl(std::vector<double> const &x, std::vector<double> const &y,

--- a/src/math/LeastSquares.cc
+++ b/src/math/LeastSquares.cc
@@ -131,7 +131,7 @@ class EigensystemSolver : public LeastSquares::Impl {
 public:
     explicit EigensystemSolver(int dimension) : Impl(dimension), _eig(dimension), _svd(), _tmp(dimension) {}
 
-    virtual void factor() {
+    void factor() override {
         ensure(LOWER_FISHER_MATRIX | RHS_VECTOR);
         _eig.compute(fisher);
         if (_eig.info() == Eigen::Success) {
@@ -150,7 +150,7 @@ public:
         }
     }
 
-    virtual void updateRank() {
+    void updateRank() override {
         if (_eig.info() == Eigen::Success) {
             setRank(_eig.eigenvalues().reverse());
         } else {
@@ -158,7 +158,7 @@ public:
         }
     }
 
-    virtual void updateDiagnostic() {
+    void updateDiagnostic() override {
         if (whichDiagnostic == LeastSquares::NORMAL_CHOLESKY) {
             throw LSST_EXCEPT(
                     pex::exceptions::LogicError,
@@ -174,7 +174,7 @@ public:
         }
     }
 
-    virtual void updateSolution() {
+    void updateSolution() override {
         if (rank == 0) {
             ndarray::asEigenMatrix(solution).setZero();
             return;
@@ -190,7 +190,7 @@ public:
         }
     }
 
-    virtual void updateCovariance() {
+    void updateCovariance() override {
         if (rank == 0) {
             ndarray::asEigenMatrix(covariance).setZero();
             return;
@@ -218,14 +218,14 @@ class CholeskySolver : public LeastSquares::Impl {
 public:
     explicit CholeskySolver(int dimension) : Impl(dimension, 0.0), _ldlt(dimension) {}
 
-    virtual void factor() {
+    void factor() override {
         ensure(LOWER_FISHER_MATRIX | RHS_VECTOR);
         _ldlt.compute(fisher);
     }
 
-    virtual void updateRank() {}
+    void updateRank() override {}
 
-    virtual void updateDiagnostic() {
+    void updateDiagnostic() override {
         if (whichDiagnostic != LeastSquares::NORMAL_CHOLESKY) {
             throw LSST_EXCEPT(
                     pex::exceptions::LogicError,
@@ -234,9 +234,9 @@ public:
         ndarray::asEigenMatrix(diagnostic) = _ldlt.vectorD();
     }
 
-    virtual void updateSolution() { ndarray::asEigenMatrix(solution) = _ldlt.solve(rhs); }
+    void updateSolution() override { ndarray::asEigenMatrix(solution) = _ldlt.solve(rhs); }
 
-    virtual void updateCovariance() {
+    void updateCovariance() override {
         auto cov = ndarray::asEigenMatrix(covariance);
         cov.setIdentity();
         cov = _ldlt.solve(cov);
@@ -250,7 +250,7 @@ class SvdSolver : public LeastSquares::Impl {
 public:
     explicit SvdSolver(int dimension) : Impl(dimension), _svd(), _tmp(dimension) {}
 
-    virtual void factor() {
+    void factor() override {
         if (!(state & DESIGN_AND_DATA)) {
             throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                               "Cannot initialize DIRECT_SVD solver with normal equations.");
@@ -260,9 +260,9 @@ public:
         LOGL_DEBUG(_log, "Using direct SVD method; dimension=%d, rank=%d", dimension, rank);
     }
 
-    virtual void updateRank() { setRank(_svd.singularValues()); }
+    void updateRank() override { setRank(_svd.singularValues()); }
 
-    virtual void updateDiagnostic() {
+    void updateDiagnostic() override {
         switch (whichDiagnostic) {
             case LeastSquares::NORMAL_EIGENSYSTEM:
                 ndarray::asEigenArray(diagnostic) = _svd.singularValues().array().square();
@@ -277,7 +277,7 @@ public:
         }
     }
 
-    virtual void updateSolution() {
+    void updateSolution() override {
         if (rank == 0) {
             ndarray::asEigenMatrix(solution).setZero();
             return;
@@ -287,7 +287,7 @@ public:
         ndarray::asEigenMatrix(solution) = _svd.matrixV().leftCols(rank) * _tmp.head(rank);
     }
 
-    virtual void updateCovariance() {
+    void updateCovariance() override {
         if (rank == 0) {
             ndarray::asEigenMatrix(covariance).setZero();
             return;

--- a/src/math/LinearCombinationKernel.cc
+++ b/src/math/LinearCombinationKernel.cc
@@ -320,8 +320,8 @@ struct LinearCombinationKernelPersistenceHelper : public Kernel::PersistenceHelp
 
 class LinearCombinationKernel::Factory : public afw::table::io::PersistableFactory {
 public:
-    virtual std::shared_ptr<afw::table::io::Persistable> read(InputArchive const &archive,
-                                                              CatalogVector const &catalogs) const {
+    std::shared_ptr<afw::table::io::Persistable> read(InputArchive const &archive,
+                                                      CatalogVector const &catalogs) const override {
         LSST_ARCHIVE_ASSERT(catalogs.size() == 1u);
         LSST_ARCHIVE_ASSERT(catalogs.front().size() == 1u);
         LinearCombinationKernelPersistenceHelper const keys(catalogs.front().getSchema());

--- a/src/math/RandomImage.cc
+++ b/src/math/RandomImage.cc
@@ -47,21 +47,21 @@ template <typename T>
 struct do_uniform : public do_random<T> {
     do_uniform(Random &rand) : do_random<T>(rand) {}
 
-    virtual T operator()() const { return do_random<T>::_rand.uniform(); }
+    T operator()() const override { return do_random<T>::_rand.uniform(); }
 };
 
 template <typename T>
 struct do_uniformPos : public do_random<T> {
     do_uniformPos(Random &rand) : do_random<T>(rand) {}
 
-    virtual T operator()() const { return do_random<T>::_rand.uniformPos(); }
+    T operator()() const override { return do_random<T>::_rand.uniformPos(); }
 };
 
 template <typename T>
 struct do_uniformInt : public do_random<T> {
     do_uniformInt(Random &rand, unsigned long n) : do_random<T>(rand), _n(n) {}
 
-    virtual T operator()() const { return do_random<T>::_rand.uniformInt(_n); }
+    T operator()() const override { return do_random<T>::_rand.uniformInt(_n); }
 
 private:
     unsigned long _n;
@@ -71,7 +71,7 @@ template <typename T>
 struct do_flat : public do_random<T> {
     do_flat(Random &rand, double const a, double const b) : do_random<T>(rand), _a(a), _b(b) {}
 
-    virtual T operator()() const { return do_random<T>::_rand.flat(_a, _b); }
+    T operator()() const override { return do_random<T>::_rand.flat(_a, _b); }
 
 private:
     double const _a;
@@ -82,14 +82,14 @@ template <typename T>
 struct do_gaussian : public do_random<T> {
     do_gaussian(Random &rand) : do_random<T>(rand) {}
 
-    virtual T operator()() const { return do_random<T>::_rand.gaussian(); }
+    T operator()() const override { return do_random<T>::_rand.gaussian(); }
 };
 
 template <typename T>
 struct do_chisq : public do_random<T> {
     do_chisq(Random &rand, double nu) : do_random<T>(rand), _nu(nu) {}
 
-    virtual T operator()() const { return do_random<T>::_rand.chisq(_nu); }
+    T operator()() const override { return do_random<T>::_rand.chisq(_nu); }
 
 private:
     double const _nu;
@@ -99,7 +99,7 @@ template <typename T>
 struct do_poisson : public do_random<T> {
     do_poisson(Random &rand, double mu) : do_random<T>(rand), _mu(mu) {}
 
-    virtual T operator()() const { return do_random<T>::_rand.poisson(_mu); }
+    T operator()() const override { return do_random<T>::_rand.poisson(_mu); }
 
 private:
     double const _mu;

--- a/src/math/minimize.cc
+++ b/src/math/minimize.cc
@@ -57,10 +57,10 @@ public:
     MinimizerFunctionBase1(MinimizerFunctionBase1 &&) = default;
     MinimizerFunctionBase1 &operator=(MinimizerFunctionBase1 const &) = default;
     MinimizerFunctionBase1 &operator=(MinimizerFunctionBase1 &&) = default;
-    virtual ~MinimizerFunctionBase1() = default;
+    ~MinimizerFunctionBase1() override = default;
     // Required by ROOT::Minuit2::FCNBase
-    virtual double Up() const { return _errorDef; }
-    virtual double operator()(const std::vector<double> &) const;
+    double Up() const override { return _errorDef; }
+    double operator()(const std::vector<double> &) const override;
 
 #if 0  // not used
         inline std::vector<double> getMeasurements() const {return _measurementList;}
@@ -91,10 +91,10 @@ public:
     MinimizerFunctionBase2(MinimizerFunctionBase2 &&) = default;
     MinimizerFunctionBase2 &operator=(MinimizerFunctionBase2 const &) = default;
     MinimizerFunctionBase2 &operator=(MinimizerFunctionBase2 &&) = default;
-    virtual ~MinimizerFunctionBase2() = default;
+    ~MinimizerFunctionBase2() override = default;
     // Required by ROOT::Minuit2::FCNBase
-    virtual double Up() const { return _errorDef; }
-    virtual double operator()(const std::vector<double> &par) const;
+    double Up() const override { return _errorDef; }
+    double operator()(const std::vector<double> &par) const override;
 
 #if 0  // not used
         inline std::vector<double> getMeasurements() const {return _measurementList;}

--- a/src/table/AmpInfo.cc
+++ b/src/table/AmpInfo.cc
@@ -23,7 +23,7 @@ public:
     explicit AmpInfoFitsWriter(Fits *fits, int flags) : io::FitsWriter(fits, flags) {}
 
 protected:
-    virtual void _writeTable(std::shared_ptr<BaseTable const> const &table, std::size_t nRows);
+    void _writeTable(std::shared_ptr<BaseTable const> const &table, std::size_t nRows) override;
 };
 
 void AmpInfoFitsWriter::_writeTable(std::shared_ptr<BaseTable const> const &t, std::size_t nRows) {
@@ -51,9 +51,9 @@ class AmpInfoFitsReader : public io::FitsReader {
 public:
     AmpInfoFitsReader() : io::FitsReader("AMPINFO") {}
 
-    virtual std::shared_ptr<BaseTable> makeTable(io::FitsSchemaInputMapper &mapper,
-                                                 std::shared_ptr<daf::base::PropertyList> metadata,
-                                                 int ioFlags, bool stripMetadata) const {
+    std::shared_ptr<BaseTable> makeTable(io::FitsSchemaInputMapper &mapper,
+                                         std::shared_ptr<daf::base::PropertyList> metadata, int ioFlags,
+                                         bool stripMetadata) const override {
         std::shared_ptr<AmpInfoTable> table = AmpInfoTable::make(mapper.finalize());
         table->setMetadata(metadata);
         return table;

--- a/src/table/Exposure.cc
+++ b/src/table/Exposure.cc
@@ -190,11 +190,11 @@ public:
     }
 
 protected:
-    virtual void _writeTable(std::shared_ptr<BaseTable const> const &table, std::size_t nRows);
+    void _writeTable(std::shared_ptr<BaseTable const> const &table, std::size_t nRows) override;
 
-    virtual void _writeRecord(BaseRecord const &r);
+    void _writeRecord(BaseRecord const &r) override;
 
-    virtual void _finish() {
+    void _finish() override {
         if (_doWriteArchive) _archive->writeFits(*_fits);
     }
 
@@ -250,8 +250,8 @@ public:
 
     PersistableObjectColumnReader(int column) : _column(column) {}
 
-    virtual void readCell(BaseRecord &record, std::size_t row, fits::Fits &fits,
-                          std::shared_ptr<io::InputArchive> const &archive) const {
+    void readCell(BaseRecord &record, std::size_t row, fits::Fits &fits,
+                  std::shared_ptr<io::InputArchive> const &archive) const override {
         int id = 0;
         fits.readTableScalar<int>(row, _column, id);
         std::shared_ptr<T> value = archive->get<T>(id);
@@ -269,9 +269,9 @@ class ExposureFitsReader : public io::FitsReader {
 public:
     ExposureFitsReader() : afw::table::io::FitsReader("EXPOSURE") {}
 
-    virtual std::shared_ptr<BaseTable> makeTable(io::FitsSchemaInputMapper &mapper,
-                                                 std::shared_ptr<daf::base::PropertyList> metadata,
-                                                 int ioFlags, bool stripMetadata) const {
+    std::shared_ptr<BaseTable> makeTable(io::FitsSchemaInputMapper &mapper,
+                                         std::shared_ptr<daf::base::PropertyList> metadata, int ioFlags,
+                                         bool stripMetadata) const override {
         // We rely on the table version stored in the metadata when loading an ExposureCatalog
         // persisted on its own.  This is not as flexible in terms of backwards compatibility
         // as the code that loads ExposureCatalogs persisted as part of something else, but
@@ -299,7 +299,7 @@ public:
         return table;
     }
 
-    virtual bool usesArchive(int ioFlags) const { return true; }
+    bool usesArchive(int ioFlags) const override { return true; }
 };
 
 static ExposureFitsReader const exposureFitsReader;

--- a/src/table/IdFactory.cc
+++ b/src/table/IdFactory.cc
@@ -12,11 +12,11 @@ namespace {
 
 class SimpleIdFactory : public IdFactory {
 public:
-    virtual RecordId operator()() { return ++_current; }
+    RecordId operator()() override { return ++_current; }
 
-    virtual void notify(RecordId id) { _current = id; }
+    void notify(RecordId id) override { _current = id; }
 
-    virtual std::shared_ptr<IdFactory> clone() const { return std::make_shared<SimpleIdFactory>(*this); }
+    std::shared_ptr<IdFactory> clone() const override { return std::make_shared<SimpleIdFactory>(*this); }
 
     SimpleIdFactory() : _current(0) {}
 
@@ -26,7 +26,7 @@ private:
 
 class SourceIdFactory : public IdFactory {
 public:
-    virtual RecordId operator()() {
+    RecordId operator()() override {
         if (++_lower & _upperMask) {
             --_lower;
             throw LSST_EXCEPT(pex::exceptions::LengthError,
@@ -37,7 +37,7 @@ public:
         return _upper | _lower;
     }
 
-    virtual void notify(RecordId id) {
+    void notify(RecordId id) override {
         RecordId newLower = id & (~_upper);  // chop off the exact exposure ID
         if (newLower & _upperMask) {
             throw LSST_EXCEPT(
@@ -47,7 +47,7 @@ public:
         _lower = newLower;
     }
 
-    virtual std::shared_ptr<IdFactory> clone() const { return std::make_shared<SourceIdFactory>(*this); }
+    std::shared_ptr<IdFactory> clone() const override { return std::make_shared<SourceIdFactory>(*this); }
 
     SourceIdFactory(RecordId expId, int reserved)
             : _upper(expId << reserved),

--- a/src/table/Simple.cc
+++ b/src/table/Simple.cc
@@ -24,7 +24,7 @@ public:
     explicit SimpleFitsWriter(Fits* fits, int flags) : io::FitsWriter(fits, flags) {}
 
 protected:
-    virtual void _writeTable(std::shared_ptr<BaseTable const> const& table, std::size_t nRows);
+    void _writeTable(std::shared_ptr<BaseTable const> const& table, std::size_t nRows) override;
 };
 
 void SimpleFitsWriter::_writeTable(std::shared_ptr<BaseTable const> const& t, std::size_t nRows) {
@@ -52,9 +52,9 @@ class SimpleFitsReader : public io::FitsReader {
 public:
     SimpleFitsReader() : io::FitsReader("SIMPLE") {}
 
-    virtual std::shared_ptr<BaseTable> makeTable(io::FitsSchemaInputMapper& mapper,
-                                                 std::shared_ptr<daf::base::PropertyList> metadata,
-                                                 int ioFlags, bool stripMetadata) const {
+    std::shared_ptr<BaseTable> makeTable(io::FitsSchemaInputMapper& mapper,
+                                         std::shared_ptr<daf::base::PropertyList> metadata, int ioFlags,
+                                         bool stripMetadata) const override {
         std::shared_ptr<SimpleTable> table = SimpleTable::make(mapper.finalize());
         table->setMetadata(metadata);
         return table;

--- a/src/table/Source.cc
+++ b/src/table/Source.cc
@@ -53,11 +53,11 @@ public:
     explicit SourceFitsWriter(Fits *fits, int flags) : io::FitsWriter(fits, flags) {}
 
 protected:
-    virtual void _writeTable(std::shared_ptr<BaseTable const> const &table, std::size_t nRows);
+    void _writeTable(std::shared_ptr<BaseTable const> const &table, std::size_t nRows) override;
 
-    virtual void _writeRecord(BaseRecord const &record);
+    void _writeRecord(BaseRecord const &record) override;
 
-    virtual void _finish() {
+    void _finish() override {
         if (!(_flags & SOURCE_IO_NO_FOOTPRINTS)) {
             _archive.writeFits(*_fits);
         }
@@ -203,8 +203,8 @@ public:
         mapper.customize(std::move(reader));
     }
 
-    virtual void readCell(BaseRecord &baseRecord, std::size_t row, fits::Fits &fits,
-                          std::shared_ptr<io::InputArchive> const &archive) const {
+    void readCell(BaseRecord &baseRecord, std::size_t row, fits::Fits &fits,
+                  std::shared_ptr<io::InputArchive> const &archive) const override {
         SourceRecord &record = static_cast<SourceRecord &>(baseRecord);
         std::vector<geom::Span> spansVector;
 
@@ -307,8 +307,8 @@ public:
 
     SourceFootprintReader(bool noHeavy, int column) : _noHeavy(noHeavy), _column(column) {}
 
-    virtual void readCell(BaseRecord &record, std::size_t row, fits::Fits &fits,
-                          std::shared_ptr<io::InputArchive> const &archive) const {
+    void readCell(BaseRecord &record, std::size_t row, fits::Fits &fits,
+                  std::shared_ptr<io::InputArchive> const &archive) const override {
         int id = 0;
         fits.readTableScalar<int>(row, _column, id);
         std::shared_ptr<Footprint> footprint = archive->get<Footprint>(id);
@@ -336,9 +336,9 @@ class SourceFitsReader : public io::FitsReader {
 public:
     SourceFitsReader() : afw::table::io::FitsReader("SOURCE") {}
 
-    virtual std::shared_ptr<BaseTable> makeTable(io::FitsSchemaInputMapper &mapper,
-                                                 std::shared_ptr<daf::base::PropertyList> metadata,
-                                                 int ioFlags, bool stripMetadata) const {
+    std::shared_ptr<BaseTable> makeTable(io::FitsSchemaInputMapper &mapper,
+                                         std::shared_ptr<daf::base::PropertyList> metadata, int ioFlags,
+                                         bool stripMetadata) const override {
         // Look for old-style persistence of Footprints.  If we have both that and an archive, we
         // load the footprints from the archive, but still need to remove the old-style header keys
         // from the metadata and the corresponding fields from the FitsSchemaInputMapper.
@@ -351,7 +351,7 @@ public:
         return table;
     }
 
-    virtual bool usesArchive(int ioFlags) const { return !(ioFlags & SOURCE_IO_NO_FOOTPRINTS); }
+    bool usesArchive(int ioFlags) const override { return !(ioFlags & SOURCE_IO_NO_FOOTPRINTS); }
 };
 
 // registers the reader so FitsReader::make can use it.

--- a/src/table/io/FitsSchemaInputMapper.cc
+++ b/src/table/io/FitsSchemaInputMapper.cc
@@ -370,8 +370,8 @@ public:
     StandardReader(Schema &schema, FitsSchemaItem const &item, FieldBase<T> const &base)
             : _column(item.column), _key(schema.addField<T>(item.ttype, item.doc, item.tunit, base)) {}
 
-    virtual void readCell(BaseRecord &record, std::size_t row, afw::fits::Fits &fits,
-                          std::shared_ptr<InputArchive> const &archive) const {
+    void readCell(BaseRecord &record, std::size_t row, afw::fits::Fits &fits,
+                  std::shared_ptr<InputArchive> const &archive) const override {
         fits.readTableArray(row, _column, _key.getElementCount(), record.getElement(_key));
     }
 
@@ -400,8 +400,8 @@ public:
         }
     }
 
-    virtual void readCell(BaseRecord &record, std::size_t row, afw::fits::Fits &fits,
-                          std::shared_ptr<InputArchive> const &archive) const {
+    void readCell(BaseRecord &record, std::size_t row, afw::fits::Fits &fits,
+                  std::shared_ptr<InputArchive> const &archive) const override {
         double tmp = 0;
         fits.readTableScalar(row, _column, tmp);
         record.set(_key, tmp * lsst::geom::radians);
@@ -423,8 +423,8 @@ public:
               _key(schema.addField<std::string>(item.ttype, item.doc, item.tunit, size)),
               _isVariableLength(size == 0) {}
 
-    virtual void readCell(BaseRecord &record, std::size_t row, afw::fits::Fits &fits,
-                          std::shared_ptr<InputArchive> const &archive) const {
+    void readCell(BaseRecord &record, std::size_t row, afw::fits::Fits &fits,
+                  std::shared_ptr<InputArchive> const &archive) const override {
         std::string s;
         fits.readTableScalar(row, _column, s, _isVariableLength);
         record.set(_key, s);
@@ -446,8 +446,8 @@ public:
     VariableLengthArrayReader(Schema &schema, FitsSchemaItem const &item)
             : _column(item.column), _key(schema.addField<Array<T>>(item.ttype, item.doc, item.tunit, 0)) {}
 
-    virtual void readCell(BaseRecord &record, std::size_t row, afw::fits::Fits &fits,
-                          std::shared_ptr<InputArchive> const &archive) const {
+    void readCell(BaseRecord &record, std::size_t row, afw::fits::Fits &fits,
+                  std::shared_ptr<InputArchive> const &archive) const override {
         int size = fits.getTableArraySize(row, _column);
         ndarray::Array<T, 1, 1> array = ndarray::allocate(size);
         fits.readTableArray(row, _column, size, array.getData());
@@ -471,8 +471,8 @@ public:
     PointConversionReader(Schema &schema, FitsSchemaItem const &item)
             : _column(item.column), _key(PointKey<T>::addFields(schema, item.ttype, item.doc, item.tunit)) {}
 
-    virtual void readCell(BaseRecord &record, std::size_t row, afw::fits::Fits &fits,
-                          std::shared_ptr<InputArchive> const &archive) const {
+    void readCell(BaseRecord &record, std::size_t row, afw::fits::Fits &fits,
+                  std::shared_ptr<InputArchive> const &archive) const override {
         std::array<T, 2> buffer;
         fits.readTableArray(row, _column, 2, buffer.data());
         record.set(_key, lsst::geom::Point<T, 2>(buffer[0], buffer[1]));
@@ -494,8 +494,8 @@ public:
     CoordConversionReader(Schema &schema, FitsSchemaItem const &item)
             : _column(item.column), _key(CoordKey::addFields(schema, item.ttype, item.doc)) {}
 
-    virtual void readCell(BaseRecord &record, std::size_t row, afw::fits::Fits &fits,
-                          std::shared_ptr<InputArchive> const &archive) const {
+    void readCell(BaseRecord &record, std::size_t row, afw::fits::Fits &fits,
+                  std::shared_ptr<InputArchive> const &archive) const override {
         std::array<lsst::geom::Angle, 2> buffer;
         fits.readTableArray(row, _column, 2, buffer.data());
         record.set(_key, lsst::geom::SpherePoint(buffer[0], buffer[1]));
@@ -518,8 +518,8 @@ public:
             : _column(item.column),
               _key(QuadrupoleKey::addFields(schema, item.ttype, item.doc, CoordinateType::PIXEL)) {}
 
-    virtual void readCell(BaseRecord &record, std::size_t row, afw::fits::Fits &fits,
-                          std::shared_ptr<InputArchive> const &archive) const {
+    void readCell(BaseRecord &record, std::size_t row, afw::fits::Fits &fits,
+                  std::shared_ptr<InputArchive> const &archive) const override {
         std::array<double, 3> buffer;
         fits.readTableArray(row, _column, 3, buffer.data());
         record.set(_key, geom::ellipses::Quadrupole(buffer[0], buffer[1], buffer[2], false));
@@ -559,8 +559,8 @@ public:
               _key(CovarianceMatrixKey<T, N>::addFields(schema, item.ttype, names, guessUnits(item.tunit))),
               _buffer(new T[detail::computeCovariancePackedSize(names.size())]) {}
 
-    virtual void readCell(BaseRecord &record, std::size_t row, afw::fits::Fits &fits,
-                          std::shared_ptr<InputArchive> const &archive) const {
+    void readCell(BaseRecord &record, std::size_t row, afw::fits::Fits &fits,
+                  std::shared_ptr<InputArchive> const &archive) const override {
         fits.readTableArray(row, _column, detail::computeCovariancePackedSize(_size), _buffer.get());
         for (int i = 0; i < _size; ++i) {
             for (int j = i; j < _size; ++j) {


### PR DESCRIPTION
This PR adds `override` to all overriding methods, as done by `clang-tidy`. Since I was running `clang-tidy` on a non-`clang` system, there may be some errors that slipped through (though the code does run, of course).

This PR also adds `final` to classes that were not intended to be used with inheritence, as judged by the following criteria:
* the class is not a sub- or superclass of another class,
* the class contains no virtual methods (in particular, no virtual destructor), and
* the class contains no protected methods