### PR TITLE
DM-9938: Make some afw types hashable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,7 +139,9 @@ tests/statistics
 tests/statisticsSpeed
 tests/testLib.py
 tests/test_cameraSys
+tests/test_coord
 tests/test_endpoint
+tests/test_polygon
 tests/test_spherePoint
 tests/test_transform
 tests/test_trapezoidalPacker
@@ -161,6 +163,7 @@ tests/ramFitsIO_fpC-005902-r6-0677_sub.fits_imageRamOut.fit
 tests/test_simpleTable
 tests/test_distortion
 tests/test_schema
+tests/test_span
 tests/test_fitsTables
 tests/test_tableAliases
 testTable.fits

--- a/.gitignore
+++ b/.gitignore
@@ -141,7 +141,9 @@ tests/testLib.py
 tests/test_cameraSys
 tests/test_coord
 tests/test_endpoint
+tests/test_functorKeys
 tests/test_imageHash
+tests/test_key
 tests/test_polygon
 tests/test_spherePoint
 tests/test_transform

--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,7 @@ tests/stacker
 tests/statistics
 tests/statisticsSpeed
 tests/testLib.py
+tests/test_cameraSys
 tests/test_endpoint
 tests/test_spherePoint
 tests/test_transform

--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,7 @@ tests/testLib.py
 tests/test_cameraSys
 tests/test_coord
 tests/test_endpoint
+tests/test_imageHash
 tests/test_polygon
 tests/test_spherePoint
 tests/test_transform

--- a/include/lsst/afw/cameraGeom/CameraSys.h
+++ b/include/lsst/afw/cameraGeom/CameraSys.h
@@ -71,7 +71,7 @@ public:
      *
      * @note Workhorse for std::hash<CameraSysPrefix>.
      */
-    size_t hash() const noexcept;
+    std::size_t hash_value() const noexcept;
 
 private:
     std::string _sysName;  ///< coordinate system name
@@ -145,7 +145,7 @@ public:
      *
      * @note Workhorse for std::hash<CameraSys>.
      */
-    size_t hash() const noexcept;
+    size_t hash_value() const noexcept;
 
 private:
     std::string _sysName;       ///< coordinate system name
@@ -211,12 +211,18 @@ std::ostream &operator<<(std::ostream &os, CameraSys const &cameraSys);
 namespace std {
 template <>
 struct hash<lsst::afw::cameraGeom::CameraSysPrefix> {
-    size_t operator()(lsst::afw::cameraGeom::CameraSysPrefix const &obj) const noexcept { return obj.hash(); }
+    using argument_type = lsst::afw::cameraGeom::CameraSysPrefix;
+    using result_type = size_t;
+    size_t operator()(lsst::afw::cameraGeom::CameraSysPrefix const &obj) const noexcept {
+        return obj.hash_value();
+    }
 };
 
 template <>
 struct hash<lsst::afw::cameraGeom::CameraSys> {
-    size_t operator()(lsst::afw::cameraGeom::CameraSys const &obj) const noexcept { return obj.hash(); }
+    using argument_type = lsst::afw::cameraGeom::CameraSys;
+    using result_type = size_t;
+    size_t operator()(lsst::afw::cameraGeom::CameraSys const &obj) const noexcept { return obj.hash_value(); }
 };
 }  // namespace std
 

--- a/include/lsst/afw/coord/Observatory.h
+++ b/include/lsst/afw/coord/Observatory.h
@@ -29,6 +29,8 @@
  */
 
 #include <iostream>
+
+#include "lsst/utils/hashCombine.h"
 #include "lsst/geom/Angle.h"
 
 namespace lsst {
@@ -90,6 +92,12 @@ public:
     }
     bool operator!=(Observatory const& rhs) const noexcept { return !(*this == rhs); }
 
+    /// Return a hash of this object
+    std::size_t hash_value() const noexcept {
+        // Completely arbitrary seed
+        return utils::hashCombine(17, _latitude.wrapCtr(), _longitude.wrapCtr(), _elevation);
+    }
+
 private:
     lsst::geom::Angle _latitude;
     lsst::geom::Angle _longitude;
@@ -106,5 +114,14 @@ std::ostream& operator<<(std::ostream& os, Observatory const& obs);
 }  // namespace coord
 }  // namespace afw
 }  // namespace lsst
+
+namespace std {
+template <>
+struct hash<lsst::afw::coord::Observatory> {
+    using argument_type = lsst::afw::coord::Observatory;
+    using result_type = size_t;
+    size_t operator()(argument_type const& obj) const noexcept { return obj.hash_value(); }
+};
+}  // namespace std
 
 #endif

--- a/include/lsst/afw/coord/Weather.h
+++ b/include/lsst/afw/coord/Weather.h
@@ -57,6 +57,9 @@ public:
     bool operator==(Weather const &other) const noexcept;
     bool operator!=(Weather const &other) const noexcept { return !(*this == other); }
 
+    /// Return a hash of this object
+    std::size_t hash_value() const noexcept;
+
     /// get outside air temperature (C)
     double getAirTemperature() const noexcept { return _airTemperature; };
 
@@ -83,5 +86,14 @@ std::ostream &operator<<(std::ostream &os, Weather const &weath);
 }  // namespace coord
 }  // namespace afw
 }  // namespace lsst
+
+namespace std {
+template <>
+struct hash<lsst::afw::coord::Weather> {
+    using argument_type = lsst::afw::coord::Weather;
+    using result_type = size_t;
+    size_t operator()(argument_type const &obj) const noexcept { return obj.hash_value(); }
+};
+}  // namespace std
 
 #endif  // !LSST_AFW_COORD_WEATHER_H_INCLUDED

--- a/include/lsst/afw/geom/Span.h
+++ b/include/lsst/afw/geom/Span.h
@@ -28,6 +28,7 @@
 #include <iostream>
 
 #include "lsst/base.h"
+#include "lsst/utils/hashCombine.h"
 #include "lsst/geom.h"
 #include "lsst/afw/geom/SpanPixelIterator.h"
 
@@ -112,6 +113,12 @@ public:
     }
     bool operator!=(Span const& other) const noexcept { return !(*this == other); }
 
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept {
+        // Completely arbitrary seed
+        return utils::hashCombine(42, getY(), getMinX(), getMaxX());
+    }
+
     /* Required to make Span "LessThanComparable" so they can be used
      * in sorting, binary search, etc.
      * http://www.sgi.com/tech/stl/LessThanComparable.html
@@ -128,5 +135,14 @@ private:
 }  // namespace geom
 }  // namespace afw
 }  // namespace lsst
+
+namespace std {
+template <>
+struct hash<lsst::afw::geom::Span> {
+    using argument_type = lsst::afw::geom::Span;
+    using result_type = size_t;
+    result_type operator()(argument_type const& obj) const noexcept { return obj.hash_value(); }
+};
+}  // namespace std
 
 #endif  // LSST_AFW_GEOM_Span_h_INCLUDED

--- a/include/lsst/afw/geom/polygon/Polygon.h
+++ b/include/lsst/afw/geom/polygon/Polygon.h
@@ -136,6 +136,9 @@ public:
     bool operator==(Polygon const& other) const;
     bool operator!=(Polygon const& other) const { return !(*this == other); }
 
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept;
+
     /// Returns whether the polygon contains the point
     bool contains(Point const& point) const;
 
@@ -270,5 +273,14 @@ std::ostream& operator<<(std::ostream& os, Polygon const& poly);
 }  // namespace geom
 }  // namespace afw
 }  // namespace lsst
+
+namespace std {
+template <>
+struct hash<lsst::afw::geom::polygon::Polygon> {
+    using argument_type = lsst::afw::geom::polygon::Polygon;
+    using result_type = size_t;
+    size_t operator()(argument_type const& obj) const noexcept { return obj.hash_value(); }
+};
+}  // namespace std
 
 #endif

--- a/include/lsst/afw/image/Calib.h
+++ b/include/lsst/afw/image/Calib.h
@@ -198,6 +198,9 @@ public:
     bool operator==(Calib const& rhs) const noexcept;
     bool operator!=(Calib const& rhs) const noexcept { return !(*this == rhs); }
 
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept;
+
     Calib& operator*=(double const scale);
     Calib& operator/=(double const scale) {
         (*this) *= 1.0 / scale;
@@ -232,5 +235,14 @@ int stripCalibKeywords(std::shared_ptr<lsst::daf::base::PropertySet> metadata);
 }  // namespace image
 }  // namespace afw
 }  // namespace lsst
+
+namespace std {
+template <>
+struct hash<lsst::afw::image::Calib> {
+    using argument_type = lsst::afw::image::Calib;
+    using result_type = size_t;
+    size_t operator()(argument_type const& obj) const noexcept { return obj.hash_value(); }
+};
+}  // namespace std
 
 #endif  // LSST_AFW_IMAGE_CALIB_H

--- a/include/lsst/afw/image/Color.h
+++ b/include/lsst/afw/image/Color.h
@@ -53,6 +53,9 @@ public:
     bool operator!=(Color const &other) const noexcept { return !operator==(other); }
     //@}
 
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept { return isIndeterminate() ? 42 : std::hash<double>()(_g_r); }
+
     /** Return the effective wavelength for this object in the given filter
      */
     double getLambdaEff(Filter const &  ///< The filter in question
@@ -66,5 +69,14 @@ private:
 }  // namespace image
 }  // namespace afw
 }  // namespace lsst
+
+namespace std {
+template <>
+struct hash<lsst::afw::image::Color> {
+    using argument_type = lsst::afw::image::Color;
+    using result_type = size_t;
+    size_t operator()(argument_type const &obj) const noexcept { return obj.hash_value(); }
+};
+}  // namespace std
 
 #endif

--- a/include/lsst/afw/image/Filter.h
+++ b/include/lsst/afw/image/Filter.h
@@ -99,6 +99,8 @@ public:
                     ) const noexcept {
         return !(*this == rhs);
     }
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept;
     /**
      * Clear all definitions
      */
@@ -173,6 +175,9 @@ public:
      */
     bool operator==(Filter const& rhs) const noexcept;
     bool operator!=(Filter const& rhs) const noexcept { return !(*this == rhs); }
+
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept;
 
     /**
      * Return a Filter's integral id
@@ -267,5 +272,21 @@ int stripFilterKeywords(std::shared_ptr<lsst::daf::base::PropertySet> metadata);
 }  // namespace image
 }  // namespace afw
 }  // namespace lsst
+
+namespace std {
+template <>
+struct hash<lsst::afw::image::FilterProperty> {
+    using argument_type = lsst::afw::image::FilterProperty;
+    using result_type = size_t;
+    size_t operator()(argument_type const& obj) const noexcept { return obj.hash_value(); }
+};
+
+template <>
+struct hash<lsst::afw::image::Filter> {
+    using argument_type = lsst::afw::image::Filter;
+    using result_type = size_t;
+    size_t operator()(argument_type const& obj) const noexcept { return obj.hash_value(); }
+};
+}  // namespace std
 
 #endif  // LSST_AFW_IMAGE_FILTER_H

--- a/include/lsst/afw/image/VisitInfo.h
+++ b/include/lsst/afw/image/VisitInfo.h
@@ -117,6 +117,9 @@ public:
     bool operator==(VisitInfo const &other) const;
     bool operator!=(VisitInfo const &other) const { return !(*this == other); };
 
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept;
+
     /// get exposure ID
     table::RecordId getExposureId() const { return _exposureId; }
 
@@ -229,5 +232,14 @@ int stripVisitInfoKeywords(daf::base::PropertySet &metadata);
 }  // namespace image
 }  // namespace afw
 }  // namespace lsst
+
+namespace std {
+template <>
+struct hash<lsst::afw::image::VisitInfo> {
+    using argument_type = lsst::afw::image::VisitInfo;
+    using result_type = size_t;
+    size_t operator()(argument_type const &obj) const noexcept { return obj.hash_value(); }
+};
+}  // namespace std
 
 #endif  // !LSST_AFW_IMAGE_VISITINFO_H_INCLUDED

--- a/include/lsst/afw/table/AliasMap.h
+++ b/include/lsst/afw/table/AliasMap.h
@@ -112,6 +112,9 @@ public:
     bool operator!=(AliasMap const& other) const { return !(other == *this); }
     //@}
 
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept;
+
     /// Return true if all aliases in this are also in other (with the same targets).
     bool contains(AliasMap const& other) const;
 
@@ -133,5 +136,14 @@ private:
 }  // namespace table
 }  // namespace afw
 }  // namespace lsst
+
+namespace std {
+template <>
+struct hash<lsst::afw::table::AliasMap> {
+    using argument_type = lsst::afw::table::AliasMap;
+    using result_type = size_t;
+    size_t operator()(argument_type const& obj) const noexcept { return obj.hash_value(); }
+};
+}  // namespace std
 
 #endif  // !AFW_TABLE_AliasMap_h_INCLUDED

--- a/include/lsst/afw/table/Flag.h
+++ b/include/lsst/afw/table/Flag.h
@@ -4,6 +4,8 @@
 
 #include <cstdint>
 
+#include "lsst/utils/hashCombine.h"
+
 #include "lsst/afw/table/misc.h"
 #include "lsst/afw/table/FieldBase.h"
 #include "lsst/afw/table/KeyBase.h"
@@ -114,6 +116,12 @@ public:
     bool operator!=(Key const &other) const { return !this->operator==(other); }
     //@}
 
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept {
+        // Completely arbitrary seed
+        return utils::hashCombine(17, _offset, _bit);
+    }
+
     /// Return the offset in bytes of the integer element that holds this field's bit.
     int getOffset() const { return _offset; }
 
@@ -175,5 +183,14 @@ private:
 }  // namespace table
 }  // namespace afw
 }  // namespace lsst
+
+namespace std {
+template <>
+struct hash<lsst::afw::table::Key<lsst::afw::table::Flag>> {
+    using argument_type = lsst::afw::table::Key<lsst::afw::table::Flag>;
+    using result_type = size_t;
+    size_t operator()(argument_type const &obj) const noexcept { return obj.hash_value(); }
+};
+}  // namespace std
 
 #endif  // !LSST_AFW_TABLE_Flag_h_INCLUDED

--- a/include/lsst/afw/table/Key.h
+++ b/include/lsst/afw/table/Key.h
@@ -2,6 +2,8 @@
 #ifndef AFW_TABLE_Key_h_INCLUDED
 #define AFW_TABLE_Key_h_INCLUDED
 
+#include "lsst/utils/hashCombine.h"
+
 #include "lsst/afw/table/FieldBase.h"
 #include "lsst/afw/table/Flag.h"
 #include "lsst/afw/table/KeyBase.h"
@@ -75,6 +77,12 @@ public:
     bool operator!=(Key const& other) const noexcept { return !this->operator==(other); }
     //@}
 
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept {
+        // Completely arbitrary seed
+        return utils::hashCombine(17, _offset, this->getElementCount());
+    }
+
     /// Return the offset (in bytes) of this field within a record.
     int getOffset() const noexcept { return _offset; }
 
@@ -119,5 +127,14 @@ private:
 }  // namespace table
 }  // namespace afw
 }  // namespace lsst
+
+namespace std {
+template <typename T>
+struct hash<lsst::afw::table::Key<T>> {
+    using argument_type = lsst::afw::table::Key<T>;
+    using result_type = size_t;
+    size_t operator()(argument_type const& obj) const noexcept { return obj.hash_value(); }
+};
+}  // namespace std
 
 #endif  // !AFW_TABLE_Key_h_INCLUDED

--- a/include/lsst/afw/table/Schema.h
+++ b/include/lsst/afw/table/Schema.h
@@ -226,6 +226,9 @@ public:
     bool operator!=(Schema const& other) const { return !this->operator==(other); }
     //@}
 
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept;
+
     /**
      *  Do a detailed equality comparison of two schemas.
      *
@@ -457,5 +460,14 @@ inline SubSchema Schema::operator[](std::string const& name) const {
 }  // namespace table
 }  // namespace afw
 }  // namespace lsst
+
+namespace std {
+template <>
+struct hash<lsst::afw::table::Schema> {
+    using argument_type = lsst::afw::table::Schema;
+    using result_type = size_t;
+    size_t operator()(argument_type const& obj) const noexcept { return obj.hash_value(); }
+};
+}  // namespace std
 
 #endif  // !AFW_TABLE_Schema_h_INCLUDED

--- a/include/lsst/afw/table/aggregates.h
+++ b/include/lsst/afw/table/aggregates.h
@@ -253,12 +253,6 @@ private:
     Key<lsst::geom::Angle> _dec;
 };
 
-//@{
-/// Compare CoordKeys for equality using the constituent Keys
-bool operator==(CoordKey const& lhs, CoordKey const& rhs);
-bool operator!=(CoordKey const& lhs, CoordKey const& rhs);
-//@}
-
 /// Enum used to set units for geometric FunctorKeys
 enum class CoordinateType { PIXEL, CELESTIAL };
 

--- a/include/lsst/afw/table/aggregates.h
+++ b/include/lsst/afw/table/aggregates.h
@@ -23,6 +23,8 @@
 #ifndef AFW_TABLE_aggregates_h_INCLUDED
 #define AFW_TABLE_aggregates_h_INCLUDED
 
+#include "lsst/utils/hashCombine.h"
+
 #include "lsst/afw/table/FunctorKey.h"
 #include "lsst/afw/table/Schema.h"
 #include "lsst/geom.h"
@@ -92,6 +94,12 @@ public:
     bool operator!=(PointKey<T> const& other) const noexcept { return !(*this == other); }
     //@}
 
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept {
+        // Completely arbitrary seed
+        return utils::hashCombine(17, _x, _y);
+    }
+
     /// Return True if both the x and y Keys are valid.
     bool isValid() const noexcept { return _x.isValid() && _y.isValid(); }
 
@@ -157,6 +165,12 @@ public:
     BoxKey& operator=(BoxKey const&) noexcept = default;
     BoxKey& operator=(BoxKey&&) noexcept = default;
     ~BoxKey() noexcept override = default;
+
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept {
+        // Completely arbitrary seed
+        return utils::hashCombine(17, _min, _max);
+    }
 
     /// Get a Point from the given record
     Box get(BaseRecord const& record) const override;
@@ -240,6 +254,12 @@ public:
     bool operator!=(CoordKey const& other) const noexcept { return !(*this == other); }
     //@}
 
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept {
+        // Completely arbitrary seed
+        return utils::hashCombine(17, _ra, _dec);
+    }
+
     bool isValid() const noexcept { return _ra.isValid() && _dec.isValid(); }
 
     //@{
@@ -312,6 +332,12 @@ public:
     bool operator!=(QuadrupoleKey const& other) const noexcept { return !(*this == other); }
     //@}
 
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept {
+        // Completely arbitrary seed
+        return utils::hashCombine(17, _ixx, _iyy, _ixy);
+    }
+
     /// Return True if all the constituent Keys are valid.
     bool isValid() const noexcept { return _ixx.isValid() && _iyy.isValid() && _ixy.isValid(); }
 
@@ -381,6 +407,12 @@ public:
     }
     bool operator!=(EllipseKey const& other) const noexcept { return !(*this == other); }
     //@}
+
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept {
+        // Completely arbitrary seed
+        return utils::hashCombine(17, _qKey, _pKey);
+    }
 
     /// Return True if all the constituent Keys are valid.
     bool isValid() const noexcept { return _qKey.isValid() && _pKey.isValid(); }
@@ -505,6 +537,9 @@ public:
     bool operator!=(CovarianceMatrixKey const& other) const noexcept { return !(*this == other); }
     //@}
 
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept;
+
 private:
     ErrKeyArray _err;
     CovarianceKeyArray _cov;
@@ -512,5 +547,49 @@ private:
 }  // namespace table
 }  // namespace afw
 }  // namespace lsst
+
+namespace std {
+template <typename T>
+struct hash<lsst::afw::table::PointKey<T>> {
+    using argument_type = lsst::afw::table::PointKey<T>;
+    using result_type = size_t;
+    size_t operator()(argument_type const& obj) const noexcept { return obj.hash_value(); }
+};
+
+template <typename T>
+struct hash<lsst::afw::table::BoxKey<T>> {
+    using argument_type = lsst::afw::table::BoxKey<T>;
+    using result_type = size_t;
+    size_t operator()(argument_type const& obj) const noexcept { return obj.hash_value(); }
+};
+
+template <>
+struct hash<lsst::afw::table::CoordKey> {
+    using argument_type = lsst::afw::table::CoordKey;
+    using result_type = size_t;
+    size_t operator()(argument_type const& obj) const noexcept { return obj.hash_value(); }
+};
+
+template <>
+struct hash<lsst::afw::table::QuadrupoleKey> {
+    using argument_type = lsst::afw::table::QuadrupoleKey;
+    using result_type = size_t;
+    size_t operator()(argument_type const& obj) const noexcept { return obj.hash_value(); }
+};
+
+template <>
+struct hash<lsst::afw::table::EllipseKey> {
+    using argument_type = lsst::afw::table::EllipseKey;
+    using result_type = size_t;
+    size_t operator()(argument_type const& obj) const noexcept { return obj.hash_value(); }
+};
+
+template <typename T, int N>
+struct hash<lsst::afw::table::CovarianceMatrixKey<T, N>> {
+    using argument_type = lsst::afw::table::CovarianceMatrixKey<T, N>;
+    using result_type = size_t;
+    size_t operator()(argument_type const& obj) const noexcept { return obj.hash_value(); }
+};
+}  // namespace std
 
 #endif  // !AFW_TABLE_aggregates_h_INCLUDED

--- a/include/lsst/afw/table/arrays.h
+++ b/include/lsst/afw/table/arrays.h
@@ -23,6 +23,8 @@
 #ifndef AFW_TABLE_arrays_h_INCLUDED
 #define AFW_TABLE_arrays_h_INCLUDED
 
+#include "lsst/utils/hashCombine.h"
+
 #include "lsst/afw/table/FunctorKey.h"
 #include "lsst/afw/table/Schema.h"
 
@@ -125,6 +127,12 @@ public:
     bool operator!=(ArrayKey<T> const& other) const noexcept { return !operator==(other); }
     //@}
 
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept {
+        // Completely arbitrary seed
+        return utils::hashCombine(17, _begin, _size);
+    }
+
     /// Return True if the FunctorKey contains valid scalar keys.
     bool isValid() const noexcept { return _begin.isValid(); }
 
@@ -143,5 +151,14 @@ private:
 }  // namespace table
 }  // namespace afw
 }  // namespace lsst
+
+namespace std {
+template <typename T>
+struct hash<lsst::afw::table::ArrayKey<T>> {
+    using argument_type = lsst::afw::table::ArrayKey<T>;
+    using result_type = size_t;
+    size_t operator()(argument_type const& obj) const noexcept { return obj.hash_value(); }
+};
+}  // namespace std
 
 #endif  // !AFW_TABLE_arrays_h_INCLUDED

--- a/src/cameraGeom/CameraSys.cc
+++ b/src/cameraGeom/CameraSys.cc
@@ -20,6 +20,7 @@
  * see <http://www.lsstcorp.org/LegalNotices/>.
  */
 
+#include "lsst/utils/hashCombine.h"
 #include "lsst/afw/cameraGeom/CameraSys.h"
 
 namespace lsst {
@@ -36,20 +37,11 @@ CameraSysPrefix const TAN_PIXELS = CameraSysPrefix("TanPixels");
 
 CameraSysPrefix const ACTUAL_PIXELS = CameraSysPrefix("ActualPixels");
 
-size_t CameraSysPrefix::hash() const noexcept {
-    // Java community algorithm; see Effective Java, Item 9 for rationale
-    size_t result = 42;
-    result = 31 * result + std::hash<std::string>()(_sysName);
-    return result;
-}
+size_t CameraSysPrefix::hash_value() const noexcept { return std::hash<std::string>()(_sysName); }
 
-size_t CameraSys::hash() const noexcept {
-    using std::hash;
-    // Java community algorithm; see Effective Java, Item 9 for rationale
-    size_t result = 43;
-    result = 31 * result + hash<std::string>()(_sysName);
-    result = 31 * result + hash<std::string>()(_detectorName);
-    return result;
+size_t CameraSys::hash_value() const noexcept {
+    // Completely arbitrary seed
+    return utils::hashCombine(43, _sysName, _detectorName);
 }
 
 std::ostream &operator<<(std::ostream &os, CameraSysPrefix const &camSysPrefix) {

--- a/src/coord/Weather.cc
+++ b/src/coord/Weather.cc
@@ -24,6 +24,7 @@
 
 #include <sstream>
 
+#include "lsst/utils/hashCombine.h"
 #include "lsst/pex/exceptions.h"
 #include "lsst/afw/coord/Weather.h"
 
@@ -39,6 +40,11 @@ Weather::Weather(double airTemperature, double airPressure, double humidity)
 bool Weather::operator==(Weather const& other) const noexcept {
     return (_airTemperature == other.getAirTemperature() && _airPressure == other.getAirPressure() &&
             _humidity == other.getHumidity());
+}
+
+std::size_t Weather::hash_value() const noexcept {
+    // Completely arbitrary seed
+    return utils::hashCombine(17, _airTemperature, _airPressure, _humidity);
 }
 
 void Weather::validate() const {

--- a/src/detection/Psf.cc
+++ b/src/detection/Psf.cc
@@ -5,7 +5,6 @@
 #include <memory>
 
 #include "lsst/utils/Cache.h"
-#include "lsst/utils/hashCombine.h"
 #include "lsst/afw/detection/Psf.h"
 #include "lsst/afw/math/offsetImage.h"
 #include "lsst/afw/table/io/Persistable.cc"
@@ -48,12 +47,13 @@ namespace std {
 
 // Template specialisation for hashing PsfCacheKey
 //
-// We currently ignore the color.
+// We currently ignore the color, consistent with operator==.
 template <>
 struct hash<lsst::afw::detection::detail::PsfCacheKey> {
-    std::size_t operator()(lsst::afw::detection::detail::PsfCacheKey const &key) const {
-        std::size_t seed = 0;
-        return lsst::utils::hashCombine(seed, key.position.getX(), key.position.getY());
+    using argument_type = lsst::afw::detection::detail::PsfCacheKey;
+    using result_type = std::size_t;
+    std::size_t operator()(lsst::afw::detection::detail::PsfCacheKey const &key) const noexcept {
+        return std::hash<lsst::geom::Point2D>()(key.position);
     }
 };
 

--- a/src/geom/polygon/Polygon.cc
+++ b/src/geom/polygon/Polygon.cc
@@ -2,6 +2,7 @@
 #include <algorithm>
 
 #include "boost/geometry/geometry.hpp"
+#include <boost/container_hash/hash.hpp>
 #include <memory>
 
 #include "lsst/pex/exceptions.h"
@@ -339,6 +340,13 @@ std::vector<LsstPoint>::const_iterator Polygon::end() const {
 
 bool Polygon::operator==(Polygon const& other) const {
     return boost::geometry::equals(_impl->poly, other._impl->poly);
+}
+
+std::size_t Polygon::hash_value() const noexcept {
+    // boost::hash allows hash functions to throw, but the container hashes throw
+    // only if the element [geom::Point] has a throwing hash
+    static boost::hash<BoostPolygon::ring_type> polygonHash;
+    return polygonHash(_impl->poly.outer());
 }
 
 bool Polygon::contains(LsstPoint const& point) const { return boost::geometry::within(point, _impl->poly); }

--- a/src/image/Calib.cc
+++ b/src/image/Calib.cc
@@ -33,6 +33,7 @@
 #include "boost/algorithm/string/trim.hpp"
 
 #include "ndarray.h"
+#include "lsst/utils/hashCombine.h"
 #include "lsst/pex/exceptions.h"
 #include "lsst/daf/base/PropertySet.h"
 #include "lsst/afw/image/Calib.h"
@@ -178,6 +179,11 @@ int stripCalibKeywords(std::shared_ptr<lsst::daf::base::PropertySet> metadata) {
 
 bool Calib::operator==(Calib const& rhs) const noexcept {
     return _fluxMag0 == rhs._fluxMag0 && _fluxMag0Err == rhs._fluxMag0Err;
+}
+
+std::size_t Calib::hash_value() const noexcept {
+    // Completely arbitrary seed
+    return utils::hashCombine(17, _fluxMag0, _fluxMag0Err);
 }
 
 void Calib::setFluxMag0(double fluxMag0, double fluxMag0Err) {

--- a/src/image/Filter.cc
+++ b/src/image/Filter.cc
@@ -83,6 +83,8 @@ bool FilterProperty::operator==(FilterProperty const& rhs) const noexcept {
     return (_lambdaEff == rhs._lambdaEff);
 }
 
+std::size_t FilterProperty::hash_value() const noexcept { return std::hash<double>()(_lambdaEff); };
+
 void FilterProperty::_initRegistry() {
     if (_propertyMap) {
         delete _propertyMap;
@@ -167,6 +169,8 @@ std::vector<std::string> Filter::getNames() {
 }
 
 bool Filter::operator==(Filter const& rhs) const noexcept { return _id != UNKNOWN && _id == rhs._id; }
+
+std::size_t Filter::hash_value() const noexcept { return std::hash<int>()(_id); }
 
 void Filter::_initRegistry() {
     _id0 = UNKNOWN;

--- a/src/image/VisitInfo.cc
+++ b/src/image/VisitInfo.cc
@@ -27,6 +27,7 @@
 
 #include "boost/algorithm/string/trim.hpp"
 
+#include "lsst/utils/hashCombine.h"
 #include "lsst/pex/exceptions.h"
 #include "lsst/geom/Angle.h"
 #include "lsst/geom/SpherePoint.h"
@@ -387,6 +388,13 @@ bool VisitInfo::operator==(VisitInfo const& other) const {
            _boresightAzAlt == other.getBoresightAzAlt() && _boresightAirmass == other.getBoresightAirmass() &&
            _boresightRotAngle == other.getBoresightRotAngle() && _rotType == other.getRotType() &&
            _observatory == other.getObservatory() && _weather == other.getWeather();
+}
+
+std::size_t VisitInfo::hash_value() const noexcept {
+    // Completely arbitrary seed
+    return utils::hashCombine(17, _exposureId, _exposureTime, _darkTime, _date, _ut1, _era, _boresightRaDec,
+                              _boresightAzAlt, _boresightAirmass, _boresightRotAngle, _rotType, _observatory,
+                              _weather);
 }
 
 std::string VisitInfo::getPersistenceName() const { return getVisitInfoPersistenceName(); }

--- a/src/table/AliasMap.cc
+++ b/src/table/AliasMap.cc
@@ -21,6 +21,11 @@
  * see <http://www.lsstcorp.org/LegalNotices/>.
  */
 
+#include <algorithm>
+#include <vector>
+
+#include "lsst/utils/hashCombine.h"
+
 #include "lsst/pex/exceptions.h"
 #include "lsst/afw/table/AliasMap.h"
 #include "lsst/afw/table/BaseTable.h"
@@ -90,6 +95,16 @@ bool AliasMap::erase(std::string const& alias) {
 }
 
 bool AliasMap::operator==(AliasMap const& other) const { return _internal == other._internal; }
+
+std::size_t AliasMap::hash_value() const noexcept {
+    // Warning: this algorithm will be invalid if _internal is replaced by an unsorted map
+    // Completely arbitrary seed
+    std::size_t result = 42;
+    for (auto entry : _internal) {
+        result = utils::hashCombine(result, entry.first, entry.second);
+    }
+    return result;
+}
 
 bool AliasMap::contains(AliasMap const& other) const {
     return std::includes(begin(), end(), other.begin(), other.end());

--- a/src/table/Schema.cc
+++ b/src/table/Schema.cc
@@ -10,6 +10,7 @@
 #include "boost/preprocessor/seq/for_each.hpp"
 #include "boost/preprocessor/tuple/to_seq.hpp"
 
+#include "lsst/utils/hashCombine.h"
 #include "lsst/afw/table/Schema.h"
 #include "lsst/afw/table/detail/Access.h"
 #include "lsst/afw/table/io/FitsReader.h"
@@ -702,6 +703,14 @@ int Schema::compare(Schema const &other, int flags) const {
     if (getAliasMap()->size() != other.getAliasMap()->size()) {
         result &= ~EQUAL_ALIASES;
     }
+    return result;
+}
+
+std::size_t Schema::hash_value() const noexcept {
+    // Completely arbitrary seed
+    std::size_t result = 17;
+    auto hasher = [&result](auto const &item) { result = utils::hashCombine(result, item.key); };
+    forEach(hasher);
     return result;
 }
 

--- a/src/table/aggregates.cc
+++ b/src/table/aggregates.cc
@@ -326,6 +326,13 @@ bool CovarianceMatrixKey<T, N>::operator==(CovarianceMatrixKey const &other) con
 }
 
 template <typename T, int N>
+std::size_t CovarianceMatrixKey<T, N>::hash_value() const noexcept {
+    // Completely arbitrary seeds, different to avoid any weird degeneracies/interactions
+    return utils::hashCombine(17, utils::hashIterable(19, _err.begin(), _err.end()),
+                              utils::hashIterable(23, _cov.begin(), _cov.end()));
+}
+
+template <typename T, int N>
 T CovarianceMatrixKey<T, N>::getElement(BaseRecord const &record, int i, int j) const {
     if (i == j) {
         T err = record.get(_err[i]);

--- a/tests/test_cameraSys.cc
+++ b/tests/test_cameraSys.cc
@@ -1,0 +1,51 @@
+/*
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE CameraSysCpp
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
+#include "boost/test/unit_test.hpp"
+#pragma clang diagnostic pop
+
+#include "lsst/utils/tests.h"
+
+#include "lsst/afw/cameraGeom/CameraSys.h"
+
+namespace lsst {
+namespace afw {
+namespace cameraGeom {
+
+BOOST_AUTO_TEST_CASE(Hash) {
+    utils::assertValidHash<CameraSysPrefix>();
+
+    utils::assertHashesEqual(PIXELS, CameraSysPrefix("Pixels"));
+    utils::assertHashesEqual(ACTUAL_PIXELS, CameraSysPrefix("ActualPixels"));
+
+    utils::assertValidHash<CameraSys>();
+
+    utils::assertHashesEqual(FOCAL_PLANE, CameraSys("FocalPlane"));
+    utils::assertHashesEqual(FIELD_ANGLE, CameraSys("FieldAngle"));
+}
+
+}  // namespace cameraGeom
+}  // namespace afw
+}  // namespace lsst

--- a/tests/test_coord.cc
+++ b/tests/test_coord.cc
@@ -1,0 +1,58 @@
+/*
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE CoordCpp
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
+#include "boost/test/unit_test.hpp"
+#pragma clang diagnostic pop
+
+#include "lsst/utils/tests.h"
+
+#include "lsst/geom/Angle.h"
+#include "lsst/afw/coord/Observatory.h"
+#include "lsst/afw/coord/Weather.h"
+
+namespace lsst {
+namespace afw {
+namespace coord {
+
+BOOST_AUTO_TEST_CASE(ObservatoryHash) {
+    using geom::radians;
+
+    utils::assertValidHash<Observatory>();
+
+    utils::assertHashesEqual(Observatory(((geom::TWOPI + 1.2) * radians).wrap(), 0.4 * radians, 5143.0),
+                             Observatory((geom::TWOPI + 1.2) * radians, 0.4 * radians, 5143.0));
+    utils::assertHashesEqual(Observatory(-0.3 * radians, ((0.4 + geom::TWOPI) * radians).wrap(), 716.0),
+                             Observatory(-0.3 * radians, (0.4 + geom::TWOPI) * radians, 716.0));
+}
+
+BOOST_AUTO_TEST_CASE(WeatherHash) {
+    utils::assertValidHash<Weather>();
+
+    utils::assertHashesEqual(Weather(-5.0, 1.01e5, 70.0), Weather(-5.0, 1.01e5, 70.0));
+}
+
+}  // namespace coord
+}  // namespace afw
+}  // namespace lsst

--- a/tests/test_functorKeys.cc
+++ b/tests/test_functorKeys.cc
@@ -1,0 +1,147 @@
+/*
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE FunctorKeysCpp
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
+#include "boost/test/unit_test.hpp"
+#pragma clang diagnostic pop
+
+#include "lsst/utils/tests.h"
+
+#include "lsst/geom/Angle.h"
+#include "lsst/afw/table/aggregates.h"
+#include "lsst/afw/table/arrays.h"
+#include "lsst/afw/table/Schema.h"
+
+/*
+ * Unit tests for C++-only functionality in Key.
+ */
+namespace lsst {
+namespace afw {
+namespace table {
+
+BOOST_AUTO_TEST_CASE(ArrayKeyHash) {
+    utils::assertValidHash<ArrayKey<double>>();
+
+    Schema schema;
+    Key<double> a0 = schema.addField<double>("a_0", "");
+    Key<double> a1 = schema.addField<double>("a_1", "");
+    Key<double> a2 = schema.addField<double>("a_2", "");
+
+    utils::assertHashesEqual(ArrayKey<double>(), ArrayKey<double>());
+    utils::assertHashesEqual(ArrayKey<double>({a0, a1, a2}), ArrayKey<double>(schema["a"]));
+}
+
+BOOST_AUTO_TEST_CASE(PointKeyHash) {
+    utils::assertValidHash<Point2IKey>();
+    utils::assertValidHash<Point2DKey>();
+
+    Schema schema;
+    Key<double> aX = schema.addField<double>("a_x", "");
+    Key<int> bX = schema.addField<int>("b_x", "");
+    Key<int> bY = schema.addField<int>("b_y", "");
+    Key<double> aY = schema.addField<double>("a_y", "");
+
+    utils::assertHashesEqual(Point2DKey(), Point2DKey());
+    utils::assertHashesEqual(Point2DKey(aX, aY), Point2DKey(schema["a"]));
+    utils::assertHashesEqual(Point2IKey(bX, bY), Point2IKey(schema["b"]));
+}
+
+BOOST_AUTO_TEST_CASE(BoxKeyHash) {
+    utils::assertValidHash<Box2IKey>();
+    utils::assertValidHash<Box2DKey>();
+
+    Schema schema;
+    Key<double> aX = schema.addField<double>("a_min_x", "");
+    Key<double> bX = schema.addField<double>("a_max_x", "");
+    Key<double> bY = schema.addField<double>("a_max_y", "");
+    Key<double> aY = schema.addField<double>("a_min_y", "");
+
+    utils::assertHashesEqual(Box2IKey(), Box2IKey());
+    utils::assertHashesEqual(Box2DKey(Point2DKey(schema["a_min"]), Point2DKey(bX, bY)),
+                             Box2DKey(schema["a"]));
+}
+
+BOOST_AUTO_TEST_CASE(CoordKeyHash) {
+    utils::assertValidHash<CoordKey>();
+
+    Schema schema;
+    Key<lsst::geom::Angle> aRa = schema.addField<lsst::geom::Angle>("a_ra", "");
+    Key<lsst::geom::Angle> aDec = schema.addField<lsst::geom::Angle>("a_dec", "");
+
+    utils::assertHashesEqual(CoordKey(), CoordKey());
+    utils::assertHashesEqual(CoordKey(aRa, aDec), CoordKey(schema["a"]));
+    utils::assertHashesEqual(CoordKey(aRa, aDec), CoordKey(schema["a"]));
+}
+
+BOOST_AUTO_TEST_CASE(QuadrupoleKeyHash) {
+    utils::assertValidHash<QuadrupoleKey>();
+
+    Schema schema;
+    Key<double> aXX = schema.addField<double>("a_xx", "");
+    Key<double> aYY = schema.addField<double>("a_yy", "");
+    Key<double> aXY = schema.addField<double>("a_xy", "");
+
+    utils::assertHashesEqual(QuadrupoleKey(), QuadrupoleKey());
+    utils::assertHashesEqual(QuadrupoleKey(aXX, aYY, aXY), QuadrupoleKey(schema["a"]));
+}
+
+BOOST_AUTO_TEST_CASE(EllipseKeyHash) {
+    utils::assertValidHash<EllipseKey>();
+
+    Schema schema;
+    Key<double> aXX = schema.addField<double>("a_xx", "");
+    Key<double> aY = schema.addField<double>("a_y", "");
+    Key<double> aYY = schema.addField<double>("a_yy", "");
+    Key<double> aX = schema.addField<double>("a_x", "");
+    Key<double> aXY = schema.addField<double>("a_xy", "");
+
+    utils::assertHashesEqual(EllipseKey(), EllipseKey());
+    utils::assertHashesEqual(EllipseKey(QuadrupoleKey(aXX, aYY, aXY), Point2DKey(aX, aY)),
+                             EllipseKey(schema["a"]));
+}
+
+BOOST_AUTO_TEST_CASE(CovarianceMatrixKeyHash) {
+    using namespace std::string_literals;
+
+    utils::assertValidHash<CovarianceMatrixKey<double, 5>>();
+    utils::assertValidHash<CovarianceMatrixKey<float, Eigen::Dynamic>>();
+
+    Schema schema;
+    Key<double> a00 = schema.addField<double>("a_fooErr", "");
+    Key<double> a11 = schema.addField<double>("a_barErr", "");
+    Key<double> a22 = schema.addField<double>("a_cowErr", "");
+    Key<double> a01 = schema.addField<double>("a_foo_bar_Cov", "");
+    Key<double> a02 = schema.addField<double>("a_foo_cow_Cov", "");
+    Key<double> a12 = schema.addField<double>("a_bar_cow_Cov", "");
+    auto names = {"foo"s, "bar"s, "cow"s};
+
+    utils::assertHashesEqual(CovarianceMatrixKey<float, 2>(), CovarianceMatrixKey<float, 2>());
+    utils::assertHashesEqual(CovarianceMatrixKey<double, 3>({a00, a11, a22}, {a01, a02, a12}),
+                             CovarianceMatrixKey<double, 3>(schema["a"], names));
+}
+
+}  // namespace table
+}  // namespace afw
+}  // namespace lsst

--- a/tests/test_imageHash.cc
+++ b/tests/test_imageHash.cc
@@ -1,0 +1,124 @@
+/*
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE ImageHashCpp
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
+#include "boost/test/unit_test.hpp"
+#pragma clang diagnostic pop
+
+#include <limits>
+
+#include "lsst/utils/tests.h"
+
+#include "lsst/afw/image.h"
+#include "lsst/afw/image/Color.h"
+
+namespace lsst {
+namespace afw {
+namespace image {
+
+BOOST_AUTO_TEST_CASE(CalibHash) {
+    utils::assertValidHash<Calib>();
+
+    Calib test1a, test1b;
+    test1a.setFluxMag0(42.0, 5.0);
+    test1b.setFluxMag0(42.0, 5.0);
+
+    utils::assertHashesEqual(test1a, test1b);
+}
+
+BOOST_AUTO_TEST_CASE(ColorHash) {
+    utils::assertValidHash<Color>();
+
+    utils::assertHashesEqual(Color(), Color());
+    utils::assertHashesEqual(Color(std::numeric_limits<double>::quiet_NaN()),
+                             Color(std::numeric_limits<double>::signaling_NaN()));
+    utils::assertHashesEqual(Color(2.7), Color(2.7));
+}
+
+BOOST_AUTO_TEST_CASE(FilterPropertyHash) {
+    utils::assertValidHash<FilterProperty>();
+
+    utils::assertHashesEqual(FilterProperty("Filter1", 540.0), FilterProperty("Filter2", 540.0));
+    utils::assertHashesEqual(FilterProperty("Filter3", 470.0, 460.0, 490.0),
+                             FilterProperty("Filter4", 470.0, 400.0, 550.0));
+}
+
+BOOST_AUTO_TEST_CASE(FilterHash) {
+    utils::assertValidHash<Filter>();
+
+    Filter::define(FilterProperty("Filter5", 470.0, 460.0, 490.0));
+    Filter::defineAlias("Filter5", "Filter5b");
+    int id6 = Filter::define(FilterProperty("Filter6", 470.0, 400.0, 550.0));
+
+    utils::assertHashesEqual(Filter("Filter5"), Filter("Filter5"));
+    utils::assertHashesEqual(Filter("Filter5"), Filter("Filter5b"));
+    utils::assertHashesEqual(Filter("Filter6"), Filter(id6));
+}
+
+BOOST_AUTO_TEST_CASE(PixelHash) {
+    using IntPixel = pixel::Pixel<int, int, double>;
+    using FloatPixel = pixel::Pixel<double, int, double>;
+    using IntSinglePixel = pixel::SinglePixel<int, int, double>;
+
+    utils::assertValidHash<IntPixel>();
+    utils::assertValidHash<FloatPixel>();
+    utils::assertValidHash<IntSinglePixel>();
+
+    utils::assertHashesEqual(IntPixel(42, 0, 1.0), IntPixel(42, 0, 1.0));
+    utils::assertHashesEqual(FloatPixel(42.0, 0, 1.0), FloatPixel(42.0, 0, 1.0));
+    // utils::assertHashesEqual(IntSinglePixel(42, 0, 1.0), IntSinglePixel(42, 0, 1.0));
+
+    // Asymmetric cross-class equality needs some special handling
+    BOOST_TEST_REQUIRE(IntPixel(42, 0, 1.0) == FloatPixel(42.0, 0, 1.0));
+    BOOST_TEST(std::hash<IntPixel>()(IntPixel(42, 0, 1.0)) ==
+               std::hash<FloatPixel>()(FloatPixel(42.0, 0, 1.0)));
+    BOOST_TEST_REQUIRE(IntPixel(42, 0, 1.0) == IntSinglePixel(42, 0, 1.0));
+    BOOST_TEST(std::hash<IntPixel>()(IntPixel(42, 0, 1.0)) ==
+               std::hash<IntSinglePixel>()(IntSinglePixel(42, 0, 1.0)));
+}
+
+BOOST_AUTO_TEST_CASE(VisitInfoHash) {
+    using lsst::daf::base::DateTime;
+    using lsst::geom::degrees;
+
+    utils::assertValidHash<VisitInfo>();
+
+    // A builder would be really nice...
+    VisitInfo info1(10313423, 10.01, 11.02, DateTime(65321.1, DateTime::MJD, DateTime::TAI), 12345.1,
+                    45.1 * degrees, lsst::geom::SpherePoint(23.1 * degrees, 73.2 * degrees),
+                    lsst::geom::SpherePoint(134.5 * degrees, 33.3 * degrees), 1.73, 73.2 * degrees,
+                    RotType::SKY, coord::Observatory(11.1 * degrees, 22.2 * degrees, 0.333),
+                    coord::Weather(1.1, 2.2, 34.5));
+    VisitInfo info2(10313423, 10.01, 11.02, DateTime(65321.1, DateTime::MJD, DateTime::TAI), 12345.1,
+                    45.1 * degrees, lsst::geom::SpherePoint(23.1 * degrees, 73.2 * degrees),
+                    lsst::geom::SpherePoint(134.5 * degrees, 33.3 * degrees), 1.73, 73.2 * degrees,
+                    RotType::SKY, coord::Observatory(11.1 * degrees, 22.2 * degrees, 0.333),
+                    coord::Weather(1.1, 2.2, 34.5));
+
+    utils::assertHashesEqual(info1, info2);
+}
+
+}  // namespace image
+}  // namespace afw
+}  // namespace lsst

--- a/tests/test_key.cc
+++ b/tests/test_key.cc
@@ -1,0 +1,61 @@
+/*
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE KeyCpp
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
+#include "boost/test/unit_test.hpp"
+#pragma clang diagnostic pop
+
+#include "lsst/utils/tests.h"
+
+#include "lsst/geom/Angle.h"
+#include "lsst/afw/table/Key.h"
+#include "lsst/afw/table/Flag.h"
+#include "lsst/afw/table/Schema.h"
+
+/*
+ * Unit tests for C++-only functionality in Key.
+ */
+namespace lsst {
+namespace afw {
+namespace table {
+
+BOOST_AUTO_TEST_CASE(Hash) {
+    utils::assertValidHash<Key<lsst::geom::Angle>>();
+    utils::assertValidHash<Key<std::string>>();
+    utils::assertValidHash<Key<Flag>>();
+
+    Schema schema;
+    auto key1 = schema.addField<lsst::geom::Angle>("key1", "");
+    auto key2 = schema.addField<std::string>("key2", "", "", 42);
+    auto key3 = schema.addField<Flag>("key3", "");
+
+    utils::assertHashesEqual(key1, schema.find<lsst::geom::Angle>("key1").key);
+    utils::assertHashesEqual(key2, schema.find<std::string>("key2").key);
+    utils::assertHashesEqual(key3, schema.find<Flag>("key3").key);
+}
+
+}  // namespace table
+}  // namespace afw
+}  // namespace lsst

--- a/tests/test_polygon.cc
+++ b/tests/test_polygon.cc
@@ -1,0 +1,54 @@
+/*
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE PolygonCpp
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
+#include "boost/test/unit_test.hpp"
+#pragma clang diagnostic pop
+
+#include "lsst/utils/tests.h"
+
+#include "lsst/geom/Point.h"
+#include "lsst/afw/geom/polygon/Polygon.h"
+
+namespace lsst {
+namespace afw {
+namespace geom {
+namespace polygon {
+
+BOOST_AUTO_TEST_CASE(Hash) {
+    using lsst::geom::Point2D;
+
+    utils::assertValidHash<Polygon>();
+
+    utils::assertHashesEqual(Polygon({Point2D(-1.0, -1.0), Point2D(-1.0, 1.0), Point2D(1.0, 1.0)}),
+                             Polygon({Point2D(-1.0, -1.0), Point2D(-1.0, 1.0), Point2D(1.0, 1.0)}));
+    utils::assertHashesEqual(
+            Polygon({Point2D(-1.0, -1.0), Point2D(-1.0, 1.0), Point2D(1.0, 1.0), Point2D(1.0, -1.0)}),
+            Polygon(lsst::geom::Box2D(Point2D(-1.0, -1.0), lsst::geom::Extent2D(2.0, 2.0))));
+}
+
+}  // namespace polygon
+}  // namespace geom
+}  // namespace afw
+}  // namespace lsst

--- a/tests/test_schema.cc
+++ b/tests/test_schema.cc
@@ -1,0 +1,64 @@
+/*
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE SchemaCpp
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
+#include "boost/test/unit_test.hpp"
+#pragma clang diagnostic pop
+
+#include "lsst/utils/tests.h"
+
+#include "lsst/afw/table/aggregates.h"
+#include "lsst/afw/table/Schema.h"
+
+/*
+ * Unit tests for C++-only functionality in Schema.
+ *
+ * See test_schema.py for remaining unit tests.
+ */
+namespace lsst {
+namespace afw {
+namespace table {
+
+BOOST_AUTO_TEST_CASE(Hash) {
+    utils::assertValidHash<Schema>();
+
+    // Schemas are equal even if they have different key names, documentation, units, and aliases
+    Schema schema1;
+    schema1.addField<int>("a_i", "", "pixels");
+    schema1.addField<float>("a_f", "descriptive description");
+    schema1.addField<lsst::geom::Angle>("a_a", "");
+    schema1.getAliasMap()->set("a_AAA", "a_a");
+
+    Schema schema2;
+    schema2.addField<int>("b_i", "", "bovines");
+    schema2.addField<float>("b_f", "non-descriptive description");
+    schema2.addField<lsst::geom::Angle>("b_a", "");
+
+    utils::assertHashesEqual(schema1, schema2);
+}
+
+}  // namespace table
+}  // namespace afw
+}  // namespace lsst

--- a/tests/test_span.cc
+++ b/tests/test_span.cc
@@ -1,0 +1,46 @@
+/*
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE SpanCpp
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
+#include "boost/test/unit_test.hpp"
+#pragma clang diagnostic pop
+
+#include "lsst/utils/tests.h"
+
+#include "lsst/afw/geom/Span.h"
+
+namespace lsst {
+namespace afw {
+namespace geom {
+
+BOOST_AUTO_TEST_CASE(Hash) {
+    utils::assertValidHash<Span>();
+
+    utils::assertHashesEqual(Span(42, 26, 28), Span(42, 26, 28));
+    utils::assertHashesEqual(Span(20, 1, 5), Span(20, 1, 5));
+}
+
+}  // namespace geom
+}  // namespace afw
+}  // namespace lsst

--- a/tests/test_tableAliases.cc
+++ b/tests/test_tableAliases.cc
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "lsst/utils/tests.h"
 #include "lsst/afw/table/AliasMap.h"
 #include "lsst/afw/table/Schema.h"
 #include "lsst/afw/table/BaseTable.h"
@@ -80,4 +81,21 @@ BOOST_AUTO_TEST_CASE(aliasMapLinks) {
 
     // If the link isn't broken, this will segfault.
     aliases->set("d", "a");
+}
+
+BOOST_AUTO_TEST_CASE(Hash) {
+    lsst::utils::assertValidHash<lsst::afw::table::AliasMap>();
+
+    lsst::afw::table::AliasMap map1, map2;
+    lsst::afw::table::Schema schema;
+    schema.addField<int>("a", "doc for a");
+
+    map1.set("b", "a");
+    map2.set("b", "a");
+    schema.getAliasMap()->set("b", "a");
+    std::shared_ptr<TestTable> table = TestTable::make(schema);
+    lsst::afw::table::AliasMap map3 = *(table->getSchema().getAliasMap());
+
+    lsst::utils::assertHashesEqual(map1, map2);
+    lsst::utils::assertHashesEqual(map2, map3);
 }


### PR DESCRIPTION
This PR adds hash support to many value types in `afw` (defined as copyable types supporting `operator==`).

I've excluded types that define `operator==` in a non-leaf class, as the `std::hash` template would give inconsistent results unless we explicitly defined a specialization for every concrete subclass and possibly _every_ subclass. Hash support for these class hierarchies can still be added if somebody finds it useful later.

This PR requires lsst/utils#65, lsst/daf_base#45, and lsst/geom#17.