### PR TITLE
DM-16291: Use NumPy stringification to generate test results.

### DIFF
--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -573,13 +573,13 @@ class ImageTestCase(lsst.utils.tests.TestCase):
         imageISmall = afwImage.ImageI(2, 2)
         imageU = afwImage.ImageU(100, 100)
 
-        # numpy defaults to threshold=1000 for collapsing array output
-        self.assertIn("...", str(imageF))
+        # NumPy's string representation varies depending on the size of the
+        # array; we test both large and small.
+        self.assertIn(str(np.zeros((100, 100), dtype=imageF.dtype)), str(imageF))
         self.assertIn("bbox=%s" % str(imageF.getBBox()), str(imageF))
 
-        # for small arrays, numpy's representation prints the whole array
-        self.assertIn("[[0. 0.]\n [0. 0.]]", str(imageDSmall))
-        self.assertIn("[[0 0]\n [0 0]]", str(imageISmall))
+        self.assertIn(str(np.zeros((2, 2), dtype=imageDSmall.dtype)), str(imageDSmall))
+        self.assertIn(str(np.zeros((2, 2), dtype=imageISmall.dtype)), str(imageISmall))
 
         self.assertIn("ImageF=", repr(imageF))
         self.assertIn("ImageU=", repr(imageU))

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -340,14 +340,12 @@ class MaskTestCase(utilsTests.TestCase):
 
     def testString(self):
         mask = afwImage.Mask(100, 100)
-        # numpy defaults to threshold=1000 for collapsing array output
-        self.assertIn("...", str(mask))
+        self.assertIn(str(np.zeros((100, 100), dtype=mask.dtype)), str(mask))
         self.assertIn("bbox=%s"%str(mask.getBBox()), str(mask))
         self.assertIn("maskPlaneDict=%s"%str(mask.getMaskPlaneDict()), str(mask))
 
-        # for small arrays, numpy's representation prints the whole array
         smallMask = afwImage.Mask(2, 2)
-        self.assertIn("[[0 0]\n [0 0]]", str(smallMask))
+        self.assertIn(str(np.zeros((2, 2), dtype=mask.dtype)), str(smallMask))
 
         self.assertIn("MaskX=", repr(mask))
 

--- a/tests/test_maskedImage.py
+++ b/tests/test_maskedImage.py
@@ -817,7 +817,9 @@ class MaskedImageTestCase(lsst.utils.tests.TestCase):
         self.assertIn("image=", str(image))
         self.assertIn("mask=", str(image))
         self.assertIn("variance=", str(image))
-        self.assertIn("...", str(image))
+        self.assertIn(str(np.zeros((100, 100), dtype=image.image.dtype)), str(image))
+        self.assertIn(str(np.zeros((100, 100), dtype=image.mask.dtype)), str(image))
+        self.assertIn(str(np.zeros((100, 100), dtype=image.variance.dtype)), str(image))
         self.assertIn("bbox=%s"%str(image.getBBox()), str(image))
         self.assertIn("maskPlaneDict=%s"%str(image.mask.getMaskPlaneDict()), str(image))
 


### PR DESCRIPTION
Previously, we were checking against hard-coded “guesses” of what NumPy might
return for a given array. That conflates two different tests:

- Are we correctly delegating formatting to NumPy?
- Is NumPy actually giving us what we want?

This modification means we are only testing the former, which, I suggest, is
appropriate. We could consider adding a test to verify that some future
version of NumPy doesn't change its output to something which is unhelpful to
us, but I suggest that that is out of scope for this work.