### PR TITLE
DM-16386: Update makeLimitedFitsHeader to force floats to correct type

### DIFF
--- a/include/lsst/afw/geom/detail/frameSetUtils.h
+++ b/include/lsst/afw/geom/detail/frameSetUtils.h
@@ -107,6 +107,20 @@ Copy values from an AST FitsChan into a PropertyList
 */
 std::shared_ptr<daf::base::PropertyList> getPropertyListFromFitsChan(ast::FitsChan& fitsChan);
 
+/**
+Construct AST FitsChan from PropertyList
+
+@param[in] metadata  Metadata to transfer; if this is a PropertyList then the order of items is preserved.
+@param[in] excludeNames  Names of entries to exclude from the returned header string.
+@param[in] options  Options string to pass to ast::FitsChan constructor.
+
+@return an ast::FitsChan representing this PropertyList
+
+*/
+ast::FitsChan getFitsChanFromPropertyList(daf::base::PropertySet& metadata,
+                                          std::set<std::string> const& excludeNames = {},
+                                          std::string options = "");
+
 }  // namespace detail
 }  // namespace geom
 }  // namespace afw

--- a/src/fits.cc
+++ b/src/fits.cc
@@ -60,7 +60,7 @@ std::string makeLimitedFitsHeaderImpl(std::vector<std::string> const &paramNames
         out = (boost::format("%-8s= ") % name).str();
 
         if (type == typeid(bool)) {
-            out += metadata.get<bool>(name) ? "1" : "0";
+            out += metadata.get<bool>(name) ? "T" : "F";
         } else if (type == typeid(std::uint8_t)) {
             out += (boost::format("%20d") % static_cast<int>(metadata.get<std::uint8_t>(name))).str();
         } else if (type == typeid(int)) {

--- a/src/fits.cc
+++ b/src/fits.cc
@@ -67,9 +67,9 @@ std::string makeLimitedFitsHeaderImpl(std::vector<std::string> const &paramNames
             out += (boost::format("%20d") % metadata.get<int>(name)).str();
         } else if (type == typeid(double)) {
             // use G because FITS wants uppercase E for exponents
-            out += (boost::format("%20.15G") % metadata.get<double>(name)).str();
+            out += (boost::format("%#20.17G") % metadata.get<double>(name)).str();
         } else if (type == typeid(float)) {
-            out += (boost::format("%20.15G") % metadata.get<float>(name)).str();
+            out += (boost::format("%#20.15G") % metadata.get<float>(name)).str();
         } else if (type == typeid(std::string)) {
             out += "'" + metadata.get<std::string>(name) + "'";
             if (out.size() > 80) {


### PR DESCRIPTION
In FITS a "0" is an integer so we must ensure that "0.0" becomes a floating point number when written as a FITS header card. This PR also includes some improvements to the tests and a fix to booleans.