### PR TITLE
restore keyword option to retrieve a masked image

### DIFF
--- a/python/lsst/afw/cameraGeom/utils.py
+++ b/python/lsst/afw/cameraGeom/utils.py
@@ -449,7 +449,7 @@ class ButlerImage(FakeImageDataSource):
 
         return im
 
-    def getCcdImage(self, ccd, imageFactory=afwImage.ImageF, binSize=1):
+    def getCcdImage(self, ccd, imageFactory=afwImage.ImageF, binSize=1, as_masked_image=False):
         """Return an image of the specified ccd, and also the (possibly updated) ccd"""
 
         log = lsst.log.Log.getLogger("afw.cameraGeom.utils.ButlerImage")
@@ -477,7 +477,10 @@ class ButlerImage(FakeImageDataSource):
                     break
 
             if im:
-                im = im.getMaskedImage().getImage()
+                if as_masked_image:
+                    im = im.getMaskedImage()
+                else:
+                    im = im.getMaskedImage().getImage()
             else:
                 if self.verbose:
                     print("Reading %s: %s" % (ccd.getId(), err))  # lost by jupyterLab


### PR DESCRIPTION
These changes are needed to support https://github.com/lsst/obs_lsstCam/pull/40