### PR TITLE
DM-16858: Convert afw.display to numpydoc

### DIFF
--- a/doc/lsst.afw.display/index.rst
+++ b/doc/lsst.afw.display/index.rst
@@ -11,4 +11,6 @@ lsst.afw.display
 Python API reference
 ====================
 
-.. .. automodapi:: lsst.afw.display
+.. automodapi:: lsst.afw.display
+   :no-inheritance-diagram:
+

--- a/python/lsst/afw/display/ds9.py
+++ b/python/lsst/afw/display/ds9.py
@@ -20,11 +20,6 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 #
 
-##
-# @file
-# @brief Support for talking to ds9 from python
-# @deprecated  New code should use lsst.afw.display and set the backend to ds9
-
 import lsst.afw.display
 import lsst.afw.image as afwImage
 from .interface import getDisplay as _getDisplay, getDefaultBackend, setDefaultBackend

--- a/python/lsst/afw/display/ds9Regions.py
+++ b/python/lsst/afw/display/ds9Regions.py
@@ -20,32 +20,46 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 #
 
-##
-# @file
-# @brief Convert the display primitives into lists of ds9 region commands
-##
-# See e.g. http://ds9.si.edu/doc/ref/region.html
-
 import math
 import re
 import lsst.afw.geom as afwGeom
 
 
 def dot(symb, c, r, size, ctype=None, fontFamily="helvetica", textAngle=None):
-    """Draw a symbol onto the specified DS9 frame at (col,row) = (c,r) [0-based coordinates]
-Possible values are:
-        +                Draw a +
-        x                Draw an x
-        *                Draw a *
-        o                Draw a circle
-        @:Mxx,Mxy,Myy    Draw an ellipse with moments (Mxx, Mxy, Myy) (argument size is ignored)
-        An object derived from afwGeom.ellipses.BaseCore Draw the ellipse (argument size is ignored)
-Any other value is interpreted as a string to be drawn. Strings obey the fontFamily (which may be extended
-with other characteristics, e.g. "times bold italic".  Text will be drawn rotated by textAngle (textAngle is
-ignored otherwise).
+    """Draw a symbol onto the specified DS9 frame.
 
-N.b. objects derived from BaseCore include Axes and Quadrupole.
-"""
+    Parameters
+    ----------
+    symb
+        Possible values are:
+
+            ``"+"``
+                Draw a +
+            ``"x"``
+                Draw an x
+            ``"*"``
+                Draw a *
+            ``"o"``
+                Draw a circle
+            ``"@:Mxx,Mxy,Myy"``
+                Draw an ellipse with moments (Mxx, Mxy, Myy) (argument size is ignored)
+            `lsst.afw.geom.ellipses.BaseCore`
+                Draw the ellipse (argument size is ignored). N.b. objects
+                derived from `~lsst.afw.geom.ellipses.BaseCore` include
+                `~lsst.afw.geom.ellipses.Axes` and `~lsst.afw.geom.ellipses.Quadrupole`.
+            Any other value
+                Interpreted as a string to be drawn. Strings obey the ``fontFamily``
+                (which may be extended with other characteristics, e.g. "times
+                bold italic".  Text will be drawn rotated by ``textAngle``
+                (textAngle is ignored otherwise).
+    c, r
+        Zero-based coordinates at which to draw the symbol
+    size
+    ctype : `str`
+        the name of the desired color (e.g. 'red', 'orchid')
+    fontFamily
+    textAngle
+    """
     if ctype is None:
         color = ""                       # the default
     else:
@@ -107,9 +121,14 @@ N.b. objects derived from BaseCore include Axes and Quadrupole.
 
 
 def drawLines(points, ctype=None):
-    """!Draw a line by connecting the points
-    @param points a list of (col,row)
-    @param ctype the name of the desired colour (e.g. 'red', 'orchid')
+    """Draw a line by connecting the points
+
+    Parameters
+    ----------
+    points : `list` of `tuple` of `float`
+        a list of (col,row)
+    ctype : `str`
+        the name of the desired color (e.g. 'red', 'orchid')
     """
 
     if ctype is None:  # default

--- a/python/lsst/afw/display/utils.py
+++ b/python/lsst/afw/display/utils.py
@@ -33,13 +33,16 @@ __all__ = (
 
 
 def _getDisplayFromDisplayOrFrame(display, frame=None):
-    """!Return an afwDisplay.Display given either a display or a frame ID.
+    """Return an `lsst.afw.display.Display` given either a display or a frame ID.
 
+    Notes
+    -----
     If the two arguments are consistent, return the desired display; if they are not,
-    raise a RuntimeError exception.
+    raise a `RuntimeError` exception.
 
-    If the desired display is None, return None;
-    if (display, frame) == ("deferToFrame", None), return the default display"""
+    If the desired display is `None`, return `None`;
+    if ``(display, frame) == ("deferToFrame", None)``, return the default display
+    """
 
     # import locally to allow this file to be imported by __init__
     import lsst.afw.display as afwDisplay
@@ -66,39 +69,53 @@ def _getDisplayFromDisplayOrFrame(display, frame=None):
 
 
 class Mosaic:
-    """A class to handle mosaics of one or more identically-sized images (or Masks or MaskedImages)
-    E.g.
-    m = Mosaic()
-    m.setGutter(5)
-    m.setBackground(10)
-    m.setMode("square")                     # the default; other options are "x" or "y"
+    """A class to handle mosaics of one or more identically-sized images
+    (or `~lsst.afw.image.Mask` or `~lsst.afw.image.MaskedImage`)
 
-    mosaic = m.makeMosaic(im1, im2, im3)    # build the mosaic
-    display = afwDisplay.getDisplay()
-    display.mtv(mosaic)                         # display it
-    m.drawLabels(["Label 1", "Label 2", "Label 3"], display) # label the panels
+    Notes
+    -----
+    Note that this mosaic is a patchwork of the input images;  if you want to
+    make a mosaic of a set images of the sky, you probably want to use the coadd code
 
-    # alternative way to build a mosaic
-    images = [im1, im2, im3]
-    labels = ["Label 1", "Label 2", "Label 3"]
+    Examples
+    --------
 
-    mosaic = m.makeMosaic(images)
-    display.mtv(mosaic)
-    m.drawLabels(labels, display)
+    .. code-block:: py
 
-    # Yet another way to build a mosaic (no need to build the images/labels lists)
-    for i in range(len(images)):
-        m.append(images[i], labels[i])
-    # You may optionally include a colour, e.g. afwDisplay.YELLOW, as a third argument
+       m = Mosaic()
+       m.setGutter(5)
+       m.setBackground(10)
+       m.setMode("square")                     # the default; other options are "x" or "y"
 
-    mosaic = m.makeMosaic()
-    display.mtv(mosaic)
-    m.drawLabels(display=display)
+       mosaic = m.makeMosaic(im1, im2, im3)    # build the mosaic
+       display = afwDisplay.getDisplay()
+       display.mtv(mosaic)                         # display it
+       m.drawLabels(["Label 1", "Label 2", "Label 3"], display) # label the panels
+
+       # alternative way to build a mosaic
+       images = [im1, im2, im3]
+       labels = ["Label 1", "Label 2", "Label 3"]
+
+       mosaic = m.makeMosaic(images)
+       display.mtv(mosaic)
+       m.drawLabels(labels, display)
+
+       # Yet another way to build a mosaic (no need to build the images/labels lists)
+       for i in range(len(images)):
+           m.append(images[i], labels[i])
+       # You may optionally include a colour, e.g. afwDisplay.YELLOW, as a third argument
+
+       mosaic = m.makeMosaic()
+       display.mtv(mosaic)
+       m.drawLabels(display=display)
 
     Or simply:
-    mosaic = m.makeMosaic(display=display)
 
-    You can return the (ix, iy)th (or nth) bounding box (in pixels) with getBBox()
+    .. code-block:: py
+
+       mosaic = m.makeMosaic(display=display)
+
+    You can return the (ix, iy)th (or nth) bounding box (in pixels) with `getBBox()`
     """
 
     def __init__(self, gutter=3, background=0, mode="square"):
@@ -117,9 +134,15 @@ class Mosaic:
 
     def append(self, image, label=None, ctype=None):
         """Add an image to the list of images to be mosaiced
-        Set may be cleared with Mosaic.reset()
 
-        Returns the index of this image (may be passed to getBBox())
+        Returns
+        -------
+        index
+            the index of this image (may be passed to `getBBox()`)
+
+        Notes
+        -----
+        Set may be cleared with ``Mosaic.reset()``
         """
         if not self.xsize:
             self.xsize = image.getWidth()
@@ -132,11 +155,9 @@ class Mosaic:
 
     def makeMosaic(self, images=None, display="deferToFrame", mode=None,
                    background=None, title="", frame=None):
-        """Return a mosaic of all the images provided; if none are specified,
-        use the list accumulated with Mosaic.append().
+        """Return a mosaic of all the images provided.
 
-        Note that this mosaic is a patchwork of the input images;  if you want to
-        make a mosaic of a set images of the sky, you probably want to use the coadd code
+        If none are specified, use the list accumulated with `Mosaic.append()`.
 
         If display or frame (deprecated) is specified, display the mosaic
         """
@@ -233,19 +254,30 @@ class Mosaic:
         return mosaic
 
     def setGutter(self, gutter):
-        """Set the number of pixels between panels in a mosaic"""
+        """Set the number of pixels between panels in a mosaic
+        """
         self.gutter = gutter
 
     def setBackground(self, background):
-        """Set the value in the gutters"""
+        """Set the value in the gutters
+        """
         self.background = background
 
     def setMode(self, mode):
-        """Set mosaicing mode.  Valid options:
-           square       Make mosaic as square as possible
-           x            Make mosaic one image high
-           y            Make mosaic one image wide
-    """
+        """Set mosaicing mode.
+
+        Parameters
+        ----------
+        mode : {"square", "x", "y"}
+            Valid options:
+
+            square
+                Make mosaic as square as possible
+            x
+                Make mosaic one image high
+            y
+                Make mosaic one image wide
+        """
 
         if mode not in ("square", "x", "y"):
             raise RuntimeError("Unknown mosaicing mode: %s" % mode)
@@ -253,7 +285,16 @@ class Mosaic:
         self.mode = mode
 
     def getBBox(self, ix, iy=None):
-        """Get the BBox for the nth or (ix, iy)the panel"""
+        """Get the BBox for a panel
+
+        Parameters
+        ----------
+        ix : `int`
+            If ``iy`` is not `None`, this is the x coordinate of the panel.
+            If ``iy`` is `None`, this is the number of the panel.
+        iy : `int`, optional
+            The y coordinate of the panel.
+        """
 
         if iy is None:
             ix, iy = ix % self.nx, ix//self.nx
@@ -262,8 +303,12 @@ class Mosaic:
                                lsst.geom.ExtentI(self.xsize, self.ysize))
 
     def drawLabels(self, labels=None, display="deferToFrame", frame=None):
-        """Draw the list labels at the corners of each panel.  If labels is None, use the ones
-        specified by Mosaic.append()"""
+        """Draw the list labels at the corners of each panel.
+
+        Notes
+        -----
+        If labels is None, use the ones specified by ``Mosaic.append()``
+        """
 
         if not labels:
             labels = self.labels
@@ -296,15 +341,28 @@ class Mosaic:
 
     @property
     def nImage(self):
-        """Number of images"""
+        """Number of images
+        """
         return len(self.images)
 
 
 def drawBBox(bbox, borderWidth=0.0, origin=None, display="deferToFrame", ctype=None, bin=1, frame=None):
-    """Draw an afwImage::BBox on a display frame with the specified ctype.  Include an extra borderWidth pixels
-If origin is present, it's Added to the BBox
+    """Draw a bounding box on a display frame with the specified ctype.
 
-All BBox coordinates are divided by bin, as is right and proper for overlaying on a binned image
+    Parameters
+    ----------
+    bbox : `lsst.geom.Box2I` or `lsst.geom.Box2D`
+        The box to draw
+    borderWidth : `float`
+        Include this many pixels
+    origin
+        If specified, the box is shifted by ``origin``
+    display : `str`
+    ctype : `str`
+        The desired color, either e.g. `lsst.afw.display.RED` or a color name known to X11
+    bin : `int`
+        All BBox coordinates are divided by bin, as is right and proper for overlaying on a binned image
+    frame
     """
     x0, y0 = bbox.getMinX(), bbox.getMinY()
     x1, y1 = bbox.getMaxX(), bbox.getMaxY()
@@ -332,12 +390,31 @@ All BBox coordinates are divided by bin, as is right and proper for overlaying o
 
 def drawFootprint(foot, borderWidth=0.5, origin=None, XY0=None, frame=None, ctype=None, bin=1,
                   peaks=False, symb="+", size=0.4, ctypePeak=None, display="deferToFrame"):
-    """Draw an afwDetection::Footprint on a display frame with the specified ctype.  Include an extra borderWidth
-pixels If origin is present, it's Added to the Footprint; if XY0 is present is Subtracted from the Footprint
+    """Draw an `lsst.afw.detection.Footprint` on a display frame with the specified ctype.
 
-If peaks is True, also show the object's Peaks using the specified symbol and size and ctypePeak
-
-All Footprint coordinates are divided by bin, as is right and proper for overlaying on a binned image
+    Parameters
+    ----------
+    foot : `lsst.afw.detection.Footprint`
+    borderWidth : `float`
+        Include an extra borderWidth pixels
+    origin
+        If ``origin`` is present, it's arithmetically added to the Footprint
+    XY0
+        if ``XY0`` is present is subtracted from the Footprint
+    frame
+    ctype : `str`
+        The desired color, either e.g. `lsst.afw.display.RED` or a color name known to X11
+    bin : `int`
+        All Footprint coordinates are divided by bin, as is right and proper
+        for overlaying on a binned image
+    peaks : `bool`
+        If peaks is `True`, also show the object's Peaks using the specified
+        ``symb`` and ``size`` and ``ctypePeak``
+    symb : `str`
+    size : `float`
+    ctypePeak : `str`
+        The desired color for peaks, either e.g. `lsst.afw.display.RED` or a color name known to X11
+    display : `str`
     """
 
     if XY0:
@@ -382,11 +459,11 @@ All Footprint coordinates are divided by bin, as is right and proper for overlay
 
 
 def drawCoaddInputs(exposure, frame=None, ctype=None, bin=1, display="deferToFrame"):
-    """Draw the bounding boxes of input exposures to a coadd on a display frame with the specified ctype,
-    assuming display.mtv() has already been called on the given exposure on this frame.
+    """Draw the bounding boxes of input exposures to a coadd on a display
+    frame with the specified ctype, assuming ``display.mtv()`` has already been
+    called on the given exposure on this frame.
 
-
-    All coordinates are divided by bin, as is right and proper for overlaying on a binned image
+    All coordinates are divided by ``bin``, as is right and proper for overlaying on a binned image
     """
     coaddWcs = exposure.getWcs()
     catalog = exposure.getInfo().getCoaddInputs().ccds

--- a/python/lsst/afw/display/virtualDevice.py
+++ b/python/lsst/afw/display/virtualDevice.py
@@ -20,17 +20,18 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 #
 
-##
-# @file
-# @brief A dummy image display
-
 
 class DisplayImpl:
+    """Back-end for display objects.
+
+    Parameters
+    ----------
+    display
+        The display object that we're providing the implementation for
+    verbose : `bool`
+        be chatty?
+    """
     def __init__(self, display, verbose=False):
-        """! Initialise the display
-        @param display The display object that we're providing the implementation for
-        @param verbose be chatty?
-        """
         self.display = display
         self.verbose = verbose
 
@@ -38,48 +39,68 @@ class DisplayImpl:
         self._close()
 
     def _close(self):
-        """!Close the display, cleaning up any allocated resources"""
+        """Close the display, cleaning up any allocated resources
+        """
         if hasattr(self, "verbose") and self.verbose and hasattr(self, "display"):
             print("virtual[%s]._close()" % (self.frame))
 
     def _buffer(self, enable=True):
-        """!Enable or disable buffering of writes to the display
-        @param enable  True or False, as appropriate
+        """Enable or disable buffering of writes to the display
+
+        Parameters
+        ----------
+        enable : `bool`
+            `True` or `False`, as appropriate
         """
         if self.verbose:
             print("virtual[%s]._buffer(%s)" % (self.frame, enable))
 
     def _dot(self, symb, c, r, size, ctype, *args, **kwargs):
-        """!Draw symbol a symbol at (c, r)
-        @param symb The desired symbol.  See dot() for details
-        @param c (x) column position
-        @param r (y) row position
-        @param size  Size of symbol, in pixels
-        @param ctype The desired colour, either e.g. afw.display.RED or a colour name known to X11
-        @param args  Extra arguments
-        @param kwargs Extra keyword arguments
+        """Draw a symbol at (c, r)
+
+        Parameters
+        ----------
+        symb
+            The desired symbol. See `dot` for details
+        c : `float`
+            (x) column position
+        r : `float`
+            (y) row position
+        size : `int`
+            Size of symbol, in pixels
+        ctype : `str`
+            The desired color, either e.g. `lsst.afw.display.RED` or a color name known to X11
+        *args
+            Extra arguments to backend
+        **kwargs
+            Extra keyword arguments to backend
         """
         if self.verbose:
             print("virtual[%s]._dot('%s', %.2f, %.2f, size=%g, ctype=%s, %s, %s)" %
                   (self.frame, symb, c, r, size, ctype, args, kwargs))
 
     def _drawLines(self, points, ctype):
-        """!Draw line defined by the list points
-        @param points A list of 0-indexed positions [(x, y), (x, y), ...]
-        @param ctype The desired colour, either e.g. afw.display.RED or a colour name known to X11
+        """Draw line defined by the list points
+
+        Parameters
+        ----------
+        points : `list` of `tuple` of `float`
+            A list of 0-indexed positions [(x, y), (x, y), ...]
+        ctype : `str`
+            The desired color, either e.g. `lsst.afw.display.RED` or a color name known to X11
         """
         if self.verbose:
             print("virtual[%s]._drawLines(%s, ctype=%s)" %
                   (self.frame, points, ctype))
 
     def _erase(self):
-        """!Erase all glyphs drawn on display
+        """Erase all glyphs drawn on display
         """
         if self.verbose:
             print("virtual[%s]._erase()" % (self.frame))
 
     def _flush(self):
-        """!Flush any I/O buffers
+        """Flush any I/O buffers
         """
         if self.verbose:
             print("virtual[%s]._flush()" % self.frame)
@@ -107,10 +128,17 @@ class DisplayImpl:
 
     def _mtv(self, image, wcs=None, mask=None, title=""):
         """Display an image and maybe a mask overlay on a display
-        @param image afwImage.Image to display
-        @param mask afwImage.Mask to display
-        @param wcs A Wcs to associate with data
-        @param title Name to display with the data
+
+        Parameters
+        ----------
+        image : `lsst.afw.image.Image`
+            `~lsst.afw.image.Image` to display
+        mask : `lsst.afw.image.Mask`
+            `~lsst.afw.image.Mask` to display
+        wcs : `lsst.afw.geom.SkyWcs`
+            A Wcs to associate with data
+        title : `str`
+            Name to display with the data
         """
         if self.verbose:
             print("virtual[%s]._mtv(image=%s, mask=%s, wcs=%s, title=\"%s\")" %
@@ -118,30 +146,47 @@ class DisplayImpl:
                    "Mask" if mask else None, "Wcs" if wcs else None, title))
 
     def _setImageColormap(self, cmap):
-        """Set the desired colourmap
+        """Set the desired colormap
 
-        @param the name of a colourmap (e.g. "gray") or a backend-specific object
+        Parameters
+        ----------
+        cmap : `str`
+            the name of a colormap (e.g. "gray") or a backend-specific object
         """
         if self.verbose:
             print("virtual[%s]._setImageColormap(cmap=\"%s\")" % (self.frame, cmap))
 
     def _setMaskTransparency(self, transparency, maskplane):
         """Set the transparency of a maskplane
-        @param transparency The desired transparency, in the range [0, 100]
-        @param maskplane The maskplane to set (None: all)
+
+        Parameters
+        ----------
+        transparency : `float`
+            The desired transparency, in the range [0, 100]
+        maskplane
+            The maskplane to set (None: all)
         """
         if self.verbose:
             print("virtual[%s]._setMaskTransparency(%g, maskplane=\"%s\")" %
                   (self.frame, transparency, maskplane))
 
-    def _scale(self, algorithm, min, max, unit=None, *args, **kwargs):
+    def _scale(self, algorithm, min, max, *args, unit=None, **kwargs):
         """Set the scaling from DN to displayed pixels
-        @param algorithm Scaling algorithm (e.g. linear)
-        @param min  The minimum value of the stretch (or "zscale" or "minmax")
-        @param max  The maximum value of the stretch
-        @param unit Units for min and max (e.g. Percent, Absolute, Sigma)
-        @param *args Optional arguments
-        @param **kwargs Optional keyword arguments
+
+        Parameters
+        ----------
+        algorithm
+            Scaling algorithm (e.g. linear)
+        min
+            The minimum value of the stretch (or "zscale" or "minmax")
+        max
+            The maximum value of the stretch
+        unit
+            Units for min and max (e.g. Percent, Absolute, Sigma)
+        *args
+            Optional arguments to the backend
+        **kwargs
+            Optional keyword arguments to the backend
         """
         if self.verbose:
             print("virtual[%s]._scale(%s, %s, %s, %s, %s, %s)" % (self.frame, algorithm,
@@ -154,16 +199,25 @@ class DisplayImpl:
             print("virtual[%s]._show()" % self.frame)
 
     def _pan(self, r, c):
-        """Pan to (colc, rowc)
-        @param c Desired column (x) position
-        @param r Desired row (y) position
+        """Pan to a row and column
+
+        Parameters
+        ----------
+        c : `float`
+            Desired column (x) position
+        r : `float`
+            Desired row (y) position
         """
         if self.verbose:
             print("virtual[%s]._pan(%.2f, %.2f)" % (self.frame, r, c))
 
     def _zoom(self, zoomfac):
         """Set the zoom
-        @param zoomfac  Zoom factor to use
+
+        Parameters
+        ----------
+        zoomfac : `float`
+            Zoom factor to use
         """
         if self.verbose:
             print("virtual[%s]._zoom(%g)" % (self.frame, zoomfac))


### PR DESCRIPTION
This PR converts all docstrings in `lsst.afw.display` to numpydoc format. It makes no attempt to fill in types, descriptions, etc. that cannot be easily inferred from adjacent code.