### PR TITLE
DM-16856: Convert afw.coord to numpydoc

### DIFF
--- a/doc/lsst.afw.coord/index.rst
+++ b/doc/lsst.afw.coord/index.rst
@@ -11,4 +11,6 @@ lsst.afw.coord
 Python API reference
 ====================
 
-.. .. automodapi:: lsst.afw.coord
+.. automodapi:: lsst.afw.coord
+   :no-main-docstr:
+   :no-inheritance-diagram:

--- a/python/lsst/afw/coord/__init__.py
+++ b/python/lsst/afw/coord/__init__.py
@@ -22,4 +22,5 @@
 import lsst.afw.geom
 
 from .observatory import *
+from .refraction import *
 from .weather import *


### PR DESCRIPTION
This PR adds the Python code in `lsst.afw.coord` to the documentation build, and rearranges the documentation to conform to current guidelines.