### PR TITLE
DM-16860: Enable lsst.afw.formatters documentation.

### DIFF
--- a/doc/lsst.afw.formatters/index.rst
+++ b/doc/lsst.afw.formatters/index.rst
@@ -11,4 +11,6 @@ lsst.afw.formatters
 Python API reference
 ====================
 
-.. .. automodapi:: lsst.afw.formatters
+.. automodapi:: lsst.afw.formatters
+   :no-main-docstr:
+   :no-inheritance-diagram:

--- a/python/lsst/afw/formatters/__init__.py
+++ b/python/lsst/afw/formatters/__init__.py
@@ -1,9 +1,10 @@
+# This file is part of afw.
 #
-# LSST Data Management System
-# Copyright 2008, 2009, 2010 LSST Corporation.
-#
-# This product includes software developed by the
-# LSST Project (http://www.lsst.org/).
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,10 +16,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the LSST License Statement and
-# the GNU General Public License along with this program.  If not,
-# see <http://www.lsstcorp.org/LegalNotices/>.
-#
-"""lsst.afw.formatters
-"""
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 from .utils import *


### PR DESCRIPTION
There are no docstrings to convert on this ticket, so I just added the subpackage to the build and confirmed that the pybind11 functions show up.