### PR TITLE
Add helper method for IdFactory.

### DIFF
--- a/include/lsst/afw/table/IdFactory.h
+++ b/include/lsst/afw/table/IdFactory.h
@@ -48,6 +48,17 @@ public:
      */
     static std::shared_ptr<IdFactory> makeSource(RecordId expId, int reserved);
 
+    /**
+     * Return the number to pass as the 'reserved' argument to makeSource for
+     * an exposure ID with the given maximum number of bits.
+     *
+     * @param[in]  maxBits  The maximum number of bits an exposure ID can have.
+     */
+    static int computeReservedFromMaxBits(int maxBits) {
+        // Subtract one for signed integers to avoid the sign bit.
+        return sizeof(RecordId)*8 - std::is_signed<RecordId>::value - maxBits;
+    }
+
     IdFactory() = default;
     IdFactory(IdFactory const &) = default;
     IdFactory(IdFactory &&) = default;

--- a/python/lsst/afw/table/idFactory.cc
+++ b/python/lsst/afw/table/idFactory.cc
@@ -41,6 +41,7 @@ PYBIND11_MODULE(idFactory, mod) {
     cls.def("clone", &IdFactory::clone);
     cls.def_static("makeSimple", IdFactory::makeSimple);
     cls.def_static("makeSource", IdFactory::makeSource, "expId"_a, "reserved"_a);
+    cls.def_static("computeReservedFromMaxBits", IdFactory::computeReservedFromMaxBits, "maxBits"_a);
 }
 }
 }


### PR DESCRIPTION
This encapsulates the number of (usable) bits in a record ID in order to avoid having "64" or "63" magic numbers strewn about downstream code.