### PR TITLE
DM-16859: Convert afw.fits to numpydoc

### DIFF
--- a/doc/lsst.afw.fits/index.rst
+++ b/doc/lsst.afw.fits/index.rst
@@ -6,7 +6,7 @@
 lsst.afw.fits
 #############
 
-.. Paragraph that describes what this Python module does and links to related modules and frameworks.
+``lsst.afw.fits`` provides utilities for reading and writing FITS files. It includes support for pickling Python objects as FITS.
 
 .. _lsst.afw.fits-contributing:
 
@@ -15,3 +15,13 @@ Contributing
 
 ``lsst.afw.fits`` is developed at https://github.com/lsst/afw.
 You can find Jira issues for this module under the `afw <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.
+
+.. _lsst.afw.fits-pyapi:
+
+Python API reference
+====================
+
+.. automodapi:: lsst.afw.fits
+   :no-main-docstr:
+   :no-inheritance-diagram:
+   :skip: FitsError

--- a/python/lsst/afw/fits/compression.py
+++ b/python/lsst/afw/fits/compression.py
@@ -6,6 +6,10 @@ from .fits import getAllowImageCompression, setAllowImageCompression
 
 @contextmanager
 def imageCompressionDisabled():
+    """Create a context where FITS image compression is disabled.
+
+    The previous compression setting is restored on successful exit.
+    """
     old = getAllowImageCompression()
     setAllowImageCompression(False)
     yield

--- a/python/lsst/afw/fits/compression.py
+++ b/python/lsst/afw/fits/compression.py
@@ -8,9 +8,11 @@ from .fits import getAllowImageCompression, setAllowImageCompression
 def imageCompressionDisabled():
     """Create a context where FITS image compression is disabled.
 
-    The previous compression setting is restored on successful exit.
+    The previous compression setting is restored on exit.
     """
     old = getAllowImageCompression()
-    setAllowImageCompression(False)
-    yield
-    setAllowImageCompression(old)
+    try:
+        setAllowImageCompression(False)
+        yield
+    finally:
+        setAllowImageCompression(old)

--- a/python/lsst/afw/fits/pickleFits.py
+++ b/python/lsst/afw/fits/pickleFits.py
@@ -4,9 +4,19 @@ from lsst.afw.fits.fitsLib import MemFileManager, ImageWriteOptions, ImageCompre
 def reduceToFits(obj):
     """Pickle to FITS
 
-    Intended to be used by the __reduce__ method of a class.
+    Intended to be used by the ``__reduce__`` method of a class.
 
-    Assumes the existence of a "writeFits" method on the object.
+    Parameters
+    ----------
+    obj
+        any object with a ``writeFits`` method taking a
+        `~lsst.afw.fits.MemFileManager` and possibly an
+        `~lsst.afw.fits.ImageWriteOptions`.
+
+    Returns
+    -------
+    reduced : `tuple` [callable, `tuple`]
+        a tuple in the format returned by `~object.__reduce__`
     """
     manager = MemFileManager()
     options = ImageWriteOptions(ImageCompressionOptions(ImageCompressionOptions.NONE))
@@ -22,9 +32,24 @@ def reduceToFits(obj):
 def unreduceFromFits(cls, data, size):
     """Unpickle from FITS
 
-    Unpacks data produced by reduceToFits.
+    Unpack data produced by `reduceToFits`. This method is used by the
+    pickling framework and should not need to be called from user code.
 
-    Assumes the existence of a "readFits" method on the object.
+    Parameters
+    ----------
+    cls : `type`
+        the class of object to unpickle. Must have a class-level ``readFits``
+        method taking a `~lsst.afw.fits.MemFileManager`.
+    data : `bytes`
+        an in-memory representation of the object, compatible with
+        `~lsst.afw.fits.MemFileManager`
+    size : `int`
+        the length of `data`
+
+    Returns
+    -------
+    unpickled : ``cls``
+        the object represented by ``data``
     """
     manager = MemFileManager(size)
     manager.setData(data, size)

--- a/tests/test_imageIo1.py
+++ b/tests/test_imageIo1.py
@@ -138,6 +138,21 @@ class ReadFitsTestCase(lsst.utils.tests.TestCase):
                 im = afwImage.ImageF(tmpFile, hdu)
                 self.assertEqual(im[0, 0, afwImage.LOCAL], 100*hdu)
 
+    # TODO: neither this test nor the one above it is thread-safe because
+    # image compression is a global flag
+    def testImageCompressionDisabled(self):
+        """Test that imageCompressionDisabled handles errors correctly.
+        """
+        for initState in [True, False]:
+            afwFits.setAllowImageCompression(initState)
+            try:
+                with afwFits.imageCompressionDisabled():
+                    self.assertFalse(afwFits.getAllowImageCompression())
+                    raise RuntimeError("Processing failed; abort!")
+            except RuntimeError:
+                pass
+            self.assertEqual(afwFits.getAllowImageCompression(), initState)
+
     def testWriteBool(self):
         """Test that we can read and write bools"""
         with lsst.utils.tests.getTempFilePath(".fits") as tmpFile:


### PR DESCRIPTION
This PR ensures all public Python functions in `lsst.afw.fits` conform to the style guide, and adds some stub documentation (I couldn't find anything about `lsst::afw::fits` in the Doxygen docs). It also fixes an unintended side effect in one of the documented functions.