### PR TITLE
DM-19300: fits: ignore ZQUANTIZ keyword

### DIFF
--- a/src/fits.cc
+++ b/src/fits.cc
@@ -149,7 +149,7 @@ static std::unordered_set<std::string> const ignoreKeys = {
         // FITS core keywords
         "SIMPLE", "BITPIX", "NAXIS", "EXTEND", "GCOUNT", "PCOUNT", "XTENSION", "TFIELDS", "BSCALE", "BZERO",
         // FITS compression keywords
-        "ZBITPIX", "ZIMAGE", "ZCMPTYPE", "ZSIMPLE", "ZEXTEND", "ZBLANK", "ZDATASUM", "ZHECKSUM",
+        "ZBITPIX", "ZIMAGE", "ZCMPTYPE", "ZSIMPLE", "ZEXTEND", "ZBLANK", "ZDATASUM", "ZHECKSUM", "ZQUANTIZ",
         // Not essential, but will prevent fitsverify warnings
         "DATASUM", "CHECKSUM"};
 

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -94,7 +94,7 @@ class FitsTestCase(lsst.utils.tests.TestCase):
             "GCOUNT", "PCOUNT", "XTENSION", "BSCALE", "BZERO", "TZERO", "TSCAL",
             # FITS compression keywords
             "ZBITPIX", "ZIMAGE", "ZCMPTYPE", "ZSIMPLE", "ZEXTEND", "ZBLANK", "ZDATASUM", "ZHECKSUM",
-            "ZNAXIS", "ZTILE", "ZNAME", "ZVAL",
+            "ZNAXIS", "ZTILE", "ZNAME", "ZVAL", "ZQUANTIZ",
             # Not essential these be excluded, but will prevent fitsverify warnings
             "DATASUM", "CHECKSUM",
         ]


### PR DESCRIPTION
Sogo Mineo has pointed out that afw can write a ZQUANTIZ header
keyword (e.g., it is picked up when we read a compressed FITS
header we wrote, and then that header is transferred to a new
file), which can break ds9's handling of mask extensions.

ZQUANTIZ is related to how FITS tile compression is done, and
so we should never read or write it (we leave it up to cfitsio).