### PR TITLE
DM-19366: afw unit tests do not run on some platforms

### DIFF
--- a/python/lsst/afw/geom/angle/__init__.py
+++ b/python/lsst/afw/geom/angle/__init__.py
@@ -1,2 +1,0 @@
-# provide backwards compatibility for pickle
-from .angle import *

--- a/python/lsst/afw/geom/angle/angle.py
+++ b/python/lsst/afw/geom/angle/angle.py
@@ -1,2 +1,0 @@
-# provide backwards compatibility for pickle
-from lsst.geom.angle import *  # noqa: F401, F403

--- a/python/lsst/afw/geom/coordinates/__init__.py
+++ b/python/lsst/afw/geom/coordinates/__init__.py
@@ -1,2 +1,0 @@
-# provide backwards compatibility for pickle
-from .coordinates import *

--- a/python/lsst/afw/geom/coordinates/coordinates.py
+++ b/python/lsst/afw/geom/coordinates/coordinates.py
@@ -1,2 +1,0 @@
-# provide backwards compatibility for pickle
-from lsst.geom.coordinates import *  # noqa: F401, F403

--- a/python/lsst/afw/geom/spherePoint/__init__.py
+++ b/python/lsst/afw/geom/spherePoint/__init__.py
@@ -1,2 +1,0 @@
-# provide backwards compatibility for pickle
-from .spherePoint import *

--- a/python/lsst/afw/geom/spherePoint/spherePoint.py
+++ b/python/lsst/afw/geom/spherePoint/spherePoint.py
@@ -1,2 +1,0 @@
-# provide backwards compatibility for pickle
-from lsst.geom.spherePoint import *  # noqa: F401, F403


### PR DESCRIPTION
This PR removes a number of aliases to `lsst.geom` that were causing problems . According to their comments, the aliases were used to support unpickling of old `lsst.afw.geom` objects; the separate aliases that let code refer to `lsst.geom` members as if they were in `lsst.afw.geom` has not been touched.