### PR TITLE
DM-10155: Implement in-place SourceCatalog operators in PhotoCalib

### DIFF
--- a/include/lsst/afw/image/PhotoCalib.h
+++ b/include/lsst/afw/image/PhotoCalib.h
@@ -339,7 +339,7 @@ public:
     /**
      * Return a flux calibrated image, with pixel values in nJy.
      *
-     * Mask pixels are propogated directly from the input image.
+     * Mask pixels are propagated directly from the input image.
      *
      * @param maskedImage The masked image to calibrate.
      * @param includeScaleUncertainty Include the uncertainty on the calibration in the resulting variance?

--- a/include/lsst/afw/image/PhotoCalib.h
+++ b/include/lsst/afw/image/PhotoCalib.h
@@ -554,7 +554,12 @@ private:
     /**
      * Return the calibration evaluated at a sequence of points.
      */
-    ndarray::Array<double, 1> evaluateArray(ndarray::Array<double, 1> xx, ndarray::Array<double, 1> yy) const;
+    ndarray::Array<double, 1> evaluateArray(ndarray::Array<double, 1> const &xx,
+                                            ndarray::Array<double, 1> const &yy) const;
+    /**
+     * Return the calibration evaluated at the centroids of a SourceCatalog.
+     */
+    ndarray::Array<double, 1> evaluateCatalog(afw::table::SourceCatalog const &sourceCatalog) const;
 
     /// Returns the spatially-constant calibration (for setting _calibrationMean)
     double computeCalibrationMean(std::shared_ptr<afw::math::BoundedField> calibration) const;
@@ -589,8 +594,8 @@ std::shared_ptr<PhotoCalib> makePhotoCalibFromMetadata(daf::base::PropertySet &m
  *
  * @param instFluxMag0 The instrumental flux at zero magnitude. If 0, the resulting `PhotoCalib` will have
  *                     infinite calibrationMean and non-finite (inf or NaN) calibrationErr.
- * @param instFluxMag0Err The instrumental flux at zero magnitude error. If 0, the resulting `PhotoCalib` will
- *                        have 0 calibrationErr.
+ * @param instFluxMag0Err The instrumental flux at zero magnitude error. If 0, the resulting `PhotoCalib`
+ * will have 0 calibrationErr.
  *
  * @returns Pointer to the constructed PhotoCalib.
  */

--- a/include/lsst/afw/image/PhotoCalib.h
+++ b/include/lsst/afw/image/PhotoCalib.h
@@ -551,6 +551,10 @@ private:
      * Helper function to manage constant vs. non-constant PhotoCalibs
      */
     double evaluate(lsst::geom::Point<double, 2> const &point) const;
+    /**
+     * Return the calibration evaluated at a sequence of points.
+     */
+    ndarray::Array<double, 1> evaluateArray(ndarray::Array<double, 1> xx, ndarray::Array<double, 1> yy) const;
 
     /// Returns the spatially-constant calibration (for setting _calibrationMean)
     double computeCalibrationMean(std::shared_ptr<afw::math::BoundedField> calibration) const;

--- a/include/lsst/afw/image/PhotoCalib.h
+++ b/include/lsst/afw/image/PhotoCalib.h
@@ -250,8 +250,6 @@ public:
      *                            "PsfFlux_instFluxErr"
      * @param[in]  outField       The field to write the nJy and magnitude errors to.
      *                            Keys of the form "*_instFlux" and "*_instFluxErr" must exist in the schema.
-     *
-     * @warning Not implemented yet: See DM-10155.
      */
     void instFluxToNanojansky(afw::table::SourceCatalog &sourceCatalog, std::string const &instFluxField,
                               std::string const &outField) const;
@@ -330,8 +328,6 @@ public:
      * @param[in]  outField       The field to write the magnitudes and magnitude errors to.
      *                            Keys of the form "*_instFlux", "*_instFluxErr", *_mag", and "*_magErr"
      *                            must exist in the schema.
-     *
-     * @warning Not implemented yet: See DM-10155.
      */
     void instFluxToMagnitude(afw::table::SourceCatalog &sourceCatalog, std::string const &instFluxField,
                              std::string const &outField) const;

--- a/include/lsst/afw/image/PhotoCalib.h
+++ b/include/lsst/afw/image/PhotoCalib.h
@@ -346,6 +346,29 @@ public:
                                       bool includeScaleUncertainty = true) const;
 
     /**
+     * Return a flux calibrated catalog, with new `_flux`, `_fluxErr`, `_mag`, and `_magErr` fields.
+     *
+     * If the input catalog already has `*_flux` and `*_mag` fields matching `instFluxFields`, they will be
+     * replaced with the new fields.
+     *
+     * @param catalog The catalog to compute calibrated fluxes of. This catalog is exactly reproduced in the
+     * output catalog.
+     * @param instFluxFields The fields to calibrate. If empty, every field ending with `_instFlux` will have
+     * its corresponding calibrated fields produced in the output catalog. If `_instFluxErr` also exists, it
+     * will be used to compute the `_fluxErr` and `_magErr` fields too.
+     *
+     * @return The calibrated catalog, with new flux and magnitude (and their errors) fields.
+     *
+     * @throws lsst::pex::exceptions::NotFoundError if any item in `instfluxFields` does not have a
+     * corresponding `*_instFlux` field in catalog.schema.
+     */
+    afw::table::SourceCatalog calibrateCatalog(afw::table::SourceCatalog const &catalog,
+                                               std::vector<std::string> const &instFluxFields) const;
+
+    /// @overload calibrateCatalog(table::SourceCatalog const &, std::vector<std::string> const &) const;
+    afw::table::SourceCatalog calibrateCatalog(afw::table::SourceCatalog const &catalog) const;
+
+    /**
      * Convert AB magnitude to instFlux (ADU).
      *
      * If passed point, use the exact calculation at that point, otherwise, use the mean scaling factor.
@@ -358,6 +381,7 @@ public:
      * @returns    Source instFlux in ADU.
      */
     double magnitudeToInstFlux(double magnitude, lsst::geom::Point<double, 2> const &point) const;
+
     /// @overload magnitudeToInstFlux(double, lsst::geom::Point<double, 2> const &) const;
     double magnitudeToInstFlux(double magnitude) const;
 

--- a/python/lsst/afw/image/photoCalib.cc
+++ b/python/lsst/afw/image/photoCalib.cc
@@ -159,6 +159,14 @@ PYBIND11_MODULE(photoCalib, mod) {
     cls.def("calibrateImage", &PhotoCalib::calibrateImage, "maskedImage"_a,
             "includeScaleUncertainty"_a = true);
 
+    cls.def("calibrateCatalog",
+            py::overload_cast<afw::table::SourceCatalog const &, std::vector<std::string> const &>(
+                    &PhotoCalib::calibrateCatalog, py::const_),
+            "maskedImage"_a, "fluxFields"_a);
+    cls.def("calibrateCatalog",
+            py::overload_cast<afw::table::SourceCatalog const &>(&PhotoCalib::calibrateCatalog, py::const_),
+            "maskedImage"_a);
+
     /* Operators */
     cls.def("__eq__", &PhotoCalib::operator==, py::is_operator());
     cls.def("__ne__", &PhotoCalib::operator!=, py::is_operator());

--- a/src/image/PhotoCalib.cc
+++ b/src/image/PhotoCalib.cc
@@ -465,38 +465,77 @@ double PhotoCalib::evaluate(lsst::geom::Point<double, 2> const &point) const {
         return _calibration->evaluate(point);
 }
 
+ndarray::Array<double, 1> PhotoCalib::evaluateArray(ndarray::Array<double, 1> xx,
+                                                    ndarray::Array<double, 1> yy) const {
+    if (_isConstant) {
+        ndarray::Array<double, 1> result = ndarray::allocate(ndarray::makeVector(xx.size()));
+        result.deep() = _calibrationMean;
+        return result;
+    } else {
+        return _calibration->evaluate(xx, yy);
+    }
+}
+
 void PhotoCalib::instFluxToNanojanskyArray(afw::table::SourceCatalog const &sourceCatalog,
                                            std::string const &instFluxField,
                                            ndarray::Array<double, 2, 2> result) const {
-    double instFlux, instFluxErr, nanojansky, calibration;
+    double instFlux, instFluxErr, nanojansky;  //, calibration;
     auto instFluxKey = sourceCatalog.getSchema().find<double>(instFluxField + "_instFlux").key;
     auto instFluxErrKey = sourceCatalog.getSchema().find<double>(instFluxField + "_instFluxErr").key;
+
+    ndarray::Array<double, 1> xx = ndarray::allocate(ndarray::makeVector(sourceCatalog.size()));
+    ndarray::Array<double, 1> yy = ndarray::allocate(ndarray::makeVector(sourceCatalog.size()));
+    size_t i = 0;
+    for (auto const &rec : sourceCatalog) {
+        auto point = rec.getCentroid();
+        xx[i] = point.getX();
+        yy[i] = point.getY();
+        ++i;
+    }
+    auto calibration = evaluateArray(xx, yy);
+
+    i = 0;
     auto iter = result.begin();
     for (auto const &rec : sourceCatalog) {
         instFlux = rec.get(instFluxKey);
         instFluxErr = rec.get(instFluxErrKey);
-        calibration = evaluate(rec.getCentroid());
-        nanojansky = toNanojansky(instFlux, calibration);
+        // calibration = evaluate(rec.getCentroid());
+        nanojansky = toNanojansky(instFlux, calibration[i]);
         (*iter)[0] = nanojansky;
-        (*iter)[1] = toNanojanskyErr(instFlux, instFluxErr, calibration, _calibrationErr, nanojansky);
-        iter++;
+        (*iter)[1] = toNanojanskyErr(instFlux, instFluxErr, calibration[i], _calibrationErr, nanojansky);
+        ++iter;
+        ++i;
     }
 }
 
 void PhotoCalib::instFluxToMagnitudeArray(afw::table::SourceCatalog const &sourceCatalog,
                                           std::string const &instFluxField,
                                           ndarray::Array<double, 2, 2> result) const {
-    double instFlux, instFluxErr, calibration;
+    double instFlux, instFluxErr;  //, calibration;
     auto instFluxKey = sourceCatalog.getSchema().find<double>(instFluxField + "_instFlux").key;
     auto instFluxErrKey = sourceCatalog.getSchema().find<double>(instFluxField + "_instFluxErr").key;
+
+    ndarray::Array<double, 1> xx = ndarray::allocate(ndarray::makeVector(sourceCatalog.size()));
+    ndarray::Array<double, 1> yy = ndarray::allocate(ndarray::makeVector(sourceCatalog.size()));
+    size_t i = 0;
+    for (auto const &rec : sourceCatalog) {
+        auto point = rec.getCentroid();
+        xx[i] = point.getX();
+        yy[i] = point.getY();
+        ++i;
+    }
+    auto calibration = evaluateArray(xx, yy);
+    // std::iota(xx.begin(), xx.end(), .getBeginX());
     auto iter = result.begin();
+    i = 0;
     for (auto const &rec : sourceCatalog) {
         instFlux = rec.get(instFluxKey);
         instFluxErr = rec.get(instFluxErrKey);
-        calibration = evaluate(rec.getCentroid());
-        (*iter)[0] = toMagnitude(instFlux, calibration);
-        (*iter)[1] = toMagnitudeErr(instFlux, instFluxErr, calibration, _calibrationErr);
-        iter++;
+        // calibration = evaluate(rec.getCentroid());
+        (*iter)[0] = toMagnitude(instFlux, calibration[i]);
+        (*iter)[1] = toMagnitudeErr(instFlux, instFluxErr, calibration[i], _calibrationErr);
+        ++iter;
+        ++i;
     }
 }
 

--- a/tests/test_photoCalib.py
+++ b/tests/test_photoCalib.py
@@ -654,10 +654,9 @@ class PhotoCalibTestCase(lsst.utils.tests.TestCase):
         self.assertFloatsAlmostEqual(photoCalib.getCalibrationErr(), calibrationErr)
 
     def checkDeprecatedCalibInterface(self, photoCalib):
-        """Check the backwards compatibility Calib interface."""
-
-        # These are now no-ops, but we've added a deprecated interface for backwards compatibility.
-        # TODO DM-18544: test that a deprecation warning is raised.
+        """Check the backwards compatibility Calib interface.
+        These are now no-ops, but we've added a deprecated interface for backwards compatibility.
+        """
         try:
             with self.assertWarns(FutureWarning):
                 lsst.afw.image.PhotoCalib.setThrowOnNegativeFlux(True)

--- a/tests/test_photoCalib.py
+++ b/tests/test_photoCalib.py
@@ -100,17 +100,23 @@ class PhotoCalibTestCase(lsst.utils.tests.TestCase):
         self.schema = lsst.afw.table.SourceTable.makeMinimalSchema()
         self.instFluxKeyName = "SomeFlux"
         lsst.afw.table.Point2DKey.addFields(self.schema, "centroid", "centroid", "pixels")
-        self.schema.addField(self.instFluxKeyName+"_instFlux", type="D", doc="post-ISR instrumental Flux")
-        self.schema.addField(self.instFluxKeyName+"_instFluxErr", type="D",
-                             doc="post-ISR instrumental flux stddev")
-        self.schema.addField(self.instFluxKeyName+"_flux", type="D",
-                             doc="calibrated flux (nJy)")
-        self.schema.addField(self.instFluxKeyName+"_fluxErr", type="D",
-                             doc="calibrated flux stddev (nJy)")
+        self.schema.addField(self.instFluxKeyName+"_instFlux", type="D", units="count",
+                             doc="post-ISR instrumental Flux")
+        self.schema.addField(self.instFluxKeyName+"_instFluxErr", type="D", units="count",
+                             doc="post-ISR instrumental flux error")
+        self.schema.addField(self.instFluxKeyName+"_flux", type="D", units="nJy",
+                             doc="calibrated flux")
+        self.schema.addField(self.instFluxKeyName+"_fluxErr", type="D", units="nJy",
+                             doc="calibrated flux error")
         self.schema.addField(self.instFluxKeyName+"_mag", type="D",
                              doc="calibrated magnitude")
         self.schema.addField(self.instFluxKeyName+"_magErr", type="D",
-                             doc="calibrated magnitude stddev")
+                             doc="calibrated magnitude error")
+        self.otherInstFluxKeyName = "OtherFlux"
+        self.schema.addField(self.otherInstFluxKeyName+"_instFlux", type="D", units="count",
+                             doc="another instrumental Flux")
+        self.schema.addField(self.otherInstFluxKeyName+"_instFluxErr", type="D", units="count",
+                             doc="another instrumental flux error")
         self.table = lsst.afw.table.SourceTable.make(self.schema)
         self.table.defineCentroid('centroid')
         self.catalog = lsst.afw.table.SourceCatalog(self.table)
@@ -120,12 +126,16 @@ class PhotoCalibTestCase(lsst.utils.tests.TestCase):
         record.set('centroid_y', self.point0[1])
         record.set(self.instFluxKeyName+'_instFlux', self.instFlux1)
         record.set(self.instFluxKeyName+'_instFluxErr', self.instFluxErr1)
+        record.set(self.otherInstFluxKeyName+'_instFlux', self.instFlux1)
+        record.set(self.otherInstFluxKeyName+'_instFluxErr', self.instFluxErr1)
         record = self.catalog.addNew()
         record.set('id', 2)
         record.set('centroid_x', self.pointYShift[0])
         record.set('centroid_y', self.pointYShift[1])
         record.set(self.instFluxKeyName+'_instFlux', self.instFlux2)
         record.set(self.instFluxKeyName+'_instFluxErr', self.instFluxErr1)
+        record.set(self.otherInstFluxKeyName+'_instFlux', self.instFlux2)
+        record.set(self.otherInstFluxKeyName+'_instFluxErr', self.instFluxErr1)
 
         self.constantCalibration = lsst.afw.math.ChebyshevBoundedField(self.bbox,
                                                                        np.array([[self.calibration]]))

--- a/tests/test_photoCalib.py
+++ b/tests/test_photoCalib.py
@@ -117,6 +117,9 @@ class PhotoCalibTestCase(lsst.utils.tests.TestCase):
                              doc="another instrumental Flux")
         self.schema.addField(self.otherInstFluxKeyName+"_instFluxErr", type="D", units="count",
                              doc="another instrumental flux error")
+        self.noErrInstFluxKeyName = "NoErrFlux"
+        self.schema.addField(self.noErrInstFluxKeyName+"_instFlux", type="D", units="count",
+                             doc="instrumental Flux with no error")
         self.table = lsst.afw.table.SourceTable.make(self.schema)
         self.table.defineCentroid('centroid')
         self.catalog = lsst.afw.table.SourceCatalog(self.table)
@@ -128,6 +131,7 @@ class PhotoCalibTestCase(lsst.utils.tests.TestCase):
         record.set(self.instFluxKeyName+'_instFluxErr', self.instFluxErr1)
         record.set(self.otherInstFluxKeyName+'_instFlux', self.instFlux1)
         record.set(self.otherInstFluxKeyName+'_instFluxErr', self.instFluxErr1)
+        record.set(self.noErrInstFluxKeyName+'_instFlux', self.instFlux1)
         record = self.catalog.addNew()
         record.set('id', 2)
         record.set('centroid_x', self.pointYShift[0])
@@ -136,6 +140,7 @@ class PhotoCalibTestCase(lsst.utils.tests.TestCase):
         record.set(self.instFluxKeyName+'_instFluxErr', self.instFluxErr1)
         record.set(self.otherInstFluxKeyName+'_instFlux', self.instFlux2)
         record.set(self.otherInstFluxKeyName+'_instFluxErr', self.instFluxErr1)
+        record.set(self.noErrInstFluxKeyName+'_instFlux', self.instFlux2)
 
         self.constantCalibration = lsst.afw.math.ChebyshevBoundedField(self.bbox,
                                                                        np.array([[self.calibration]]))
@@ -257,7 +262,7 @@ class PhotoCalibTestCase(lsst.utils.tests.TestCase):
         self.checkDeprecatedCalibInterface(photoCalib)
 
     def _testSourceCatalog(self, photoCalib, catalog, expectNanojansky, expectMag):
-        """Test passing in a sourceCatalog."""
+        """Test instFluxTo*(sourceCatalog, ...), and calibrateCatalog()."""
 
         # test calculations on a sourceCatalog, returning the array
         result = photoCalib.instFluxToNanojansky(catalog, self.instFluxKeyName)
@@ -265,20 +270,52 @@ class PhotoCalibTestCase(lsst.utils.tests.TestCase):
         result = photoCalib.instFluxToMagnitude(catalog, self.instFluxKeyName)
         self.assertFloatsAlmostEqual(expectMag, result)
 
-        # modify the catalog in-place.
-        photoCalib.instFluxToMagnitude(catalog, self.instFluxKeyName, self.instFluxKeyName)
-        self.assertFloatsAlmostEqual(catalog[self.instFluxKeyName+'_mag'], expectMag[:, 0])
-        self.assertFloatsAlmostEqual(catalog[self.instFluxKeyName+'_magErr'], expectMag[:, 1])
-
-        # modify the catalog in-place
+        # Test modifying the catalog in-place with instFluxToNanojansky/instFluxToMagnitude
         # The original instFluxes shouldn't change: save them to test that.
-        origFlux = catalog[self.instFluxKeyName+'_instFlux'].copy()
-        origFluxErr = catalog[self.instFluxKeyName+'_instFluxErr'].copy()
-        photoCalib.instFluxToNanojansky(catalog, self.instFluxKeyName, self.instFluxKeyName)
-        self.assertFloatsAlmostEqual(catalog[self.instFluxKeyName+'_fluxErr'], expectNanojansky[:, 1])
-        self.assertFloatsAlmostEqual(catalog[self.instFluxKeyName+'_flux'], expectNanojansky[:, 0])
-        self.assertFloatsAlmostEqual(catalog[self.instFluxKeyName+'_instFlux'], origFlux)
-        self.assertFloatsAlmostEqual(catalog[self.instFluxKeyName+'_instFluxErr'], origFluxErr)
+        origInstFlux = catalog[self.instFluxKeyName+'_instFlux'].copy()
+        origInstFluxErr = catalog[self.instFluxKeyName+'_instFluxErr'].copy()
+
+        def checkCatalog(catalog, expect, keyName, outField):
+            """Test that the fields in the catalog are correct."""
+            self.assertFloatsAlmostEqual(catalog[keyName+'_%s' % outField], expect[:, 0])
+            self.assertFloatsAlmostEqual(catalog[keyName+'_%sErr' % outField], expect[:, 1])
+            self.assertFloatsAlmostEqual(catalog[keyName+'_instFlux'], origInstFlux)
+            self.assertFloatsAlmostEqual(catalog[keyName+'_instFluxErr'], origInstFluxErr)
+
+        testCat = catalog.copy(deep=True)
+        photoCalib.instFluxToMagnitude(testCat, self.instFluxKeyName, self.instFluxKeyName)
+        checkCatalog(testCat, expectMag, self.instFluxKeyName, "mag")
+
+        testCat = catalog.copy(deep=True)
+        photoCalib.instFluxToNanojansky(testCat, self.instFluxKeyName, self.instFluxKeyName)
+        checkCatalog(testCat, expectNanojansky, self.instFluxKeyName, "flux")
+
+        testCat = catalog.copy(deep=True)
+        photoCalib.instFluxToMagnitude(testCat, self.instFluxKeyName, self.instFluxKeyName)
+        checkCatalog(testCat, expectMag, self.instFluxKeyName, "mag")
+
+        # test returning a calibrated catalog with calibrateCatalog
+
+        # test that trying to calibrate a non-existent flux field raises
+        with self.assertRaises(lsst.pex.exceptions.NotFoundError):
+            photoCalib.calibrateCatalog(testCat, ["NotARealFluxFieldName"])
+
+        # test calibrating just one flux field
+        testCat = catalog.copy(deep=True)
+        result = photoCalib.calibrateCatalog(testCat, [self.otherInstFluxKeyName])
+        checkCatalog(result, expectNanojansky, self.otherInstFluxKeyName, "flux")
+        checkCatalog(result, expectMag, self.otherInstFluxKeyName, "mag")
+
+        # test calibrating all of the flux fields
+        testCat = catalog.copy(deep=True)
+        result = photoCalib.calibrateCatalog(testCat)
+        checkCatalog(result, expectNanojansky, self.instFluxKeyName, "flux")
+        checkCatalog(result, expectMag, self.instFluxKeyName, "mag")
+        checkCatalog(result, expectNanojansky, self.otherInstFluxKeyName, "flux")
+        checkCatalog(result, expectMag, self.otherInstFluxKeyName, "mag")
+        self.assertFloatsAlmostEqual(result[self.noErrInstFluxKeyName+'_flux'], expectNanojansky[:, 0])
+        self.assertFloatsAlmostEqual(result[self.noErrInstFluxKeyName+'_mag'], expectMag[:, 0])
+        self.assertFloatsAlmostEqual(result[self.noErrInstFluxKeyName+'_instFlux'], origInstFlux)
 
     def testNonVarying(self):
         """Test constructing with a constant calibration factor."""


### PR DESCRIPTION
Also vectorize catalog array operations for a big speedup on AST-backed BoundedFields.