### PR TITLE
DM-17981: Create type-safe heterogenous map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,6 +166,7 @@ tests/testEigenLib.py
 tests/test_tableArchives
 tests/ramFitsIO_fpC-005902-r6-0677_sub.fits_imageRamOut.fit
 tests/test_simpleTable
+tests/test_simpleGenericMap
 tests/test_distortion
 tests/test_schema
 tests/test_span

--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,7 @@ tests/ramFitsIO_fpC-002570-r6-0199_sub.fits_imageRamOut.fit
 tests/testEigenLib.py
 tests/test_tableArchives
 tests/ramFitsIO_fpC-005902-r6-0677_sub.fits_imageRamOut.fit
+tests/test_polymorphicValue
 tests/test_simpleTable
 tests/test_simpleGenericMap
 tests/test_distortion

--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,7 @@ tests/test_imageHash
 tests/test_key
 tests/test_polygon
 tests/test_spherePoint
+tests/test_storable
 tests/test_transform
 tests/test_trapezoidalPacker
 tests/test_warpGpu

--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,7 @@ tests/test_cameraSys
 tests/test_coord
 tests/test_endpoint
 tests/test_functorKeys
+tests/test_genericmap
 tests/test_imageHash
 tests/test_key
 tests/test_polygon

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -20,5 +20,6 @@ afw documentation preview
    lsst.afw.image/index
    lsst.afw.math/index
    lsst.afw.table/index
+   lsst.afw.typehandling/index
    lsst.afw.multiband/index
 

--- a/doc/lsst.afw.typehandling/index.rst
+++ b/doc/lsst.afw.typehandling/index.rst
@@ -1,0 +1,32 @@
+.. py:currentmodule:: lsst.afw.typehandling
+
+.. _lsst.afw.typehandling:
+
+#####################
+lsst.afw.typehandling
+#####################
+
+``lsst.afw.typehandling`` provides tools for handling C++ objects of arbirary type.
+Capabilities include a generic collection that can store LSST types, including types not accessible to ``afw``.
+
+.. _lsst.afw.typehandling-contributing:
+
+Contributing
+============
+
+``lsst.afw.typehandling`` is developed at https://github.com/lsst/afw.
+You can find Jira issues for this module under the `afw <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.
+
+.. If there are topics related to developing this module (rather than using it), link to this from a toctree placed here.
+
+.. .. toctree::
+..    :maxdepth: 1
+
+.. _lsst.afw.typehandling-pyapi:
+
+Python API reference
+====================
+
+.. automodapi:: lsst.afw.typehandling
+   :no-main-docstr:
+   :skip: UnsupportedOperationException

--- a/include/lsst/afw/typehandling/GenericMap.h
+++ b/include/lsst/afw/typehandling/GenericMap.h
@@ -1,0 +1,193 @@
+// -*- LSST-C++ -*-
+/*
+ * This file is part of afw.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef LSST_AFW_TYPEHANDLING_GENERICMAP_H
+#define LSST_AFW_TYPEHANDLING_GENERICMAP_H
+
+#include <functional>
+#include <ostream>
+#include <typeinfo>
+#include <type_traits>
+
+namespace lsst {
+namespace afw {
+namespace typehandling {
+
+/**
+ * Key for type-safe lookup in a GenericMap.
+ *
+ * @tparam K the logical type of the key (e.g., a string)
+ * @tparam V the type of the value mapped to this key
+ *
+ * Key objects are equality-comparable, hashable, sortable, or printable if and only if `K` is comparable,
+ * hashable, sortable, or printable, respectively. Key can be used in compile-time expressions if and only
+ * if `K` can (in particular, `Key<std::string, V>` cannot).
+ *
+ * @note Objects of this type are immutable.
+ */
+template <typename K, typename V>
+class Key final {
+public:
+    using KeyType = K;
+    using ValueType = V;
+
+    /**
+     * Construct a new key.
+     *
+     * @param id
+     *          the identifier of the field. For most purposes, this value is
+     *          the actual key; it can be retrieved by calling getId().
+     *
+     * @exceptsafe Provides the same exception safety as the copy-constructor of `K`.
+     *
+     * @see makeKey
+     */
+    constexpr Key(K id) : id(id) {}
+
+    Key(Key const&) = default;
+    Key(Key&&) = default;
+    Key& operator=(Key const&) = delete;
+    Key& operator=(Key&&) = delete;
+
+    /**
+     * Return the identifier of this field.
+     *
+     * The identifier serves as the "key" for the map abstraction
+     * represented by GenericMap.
+     *
+     * @returns the unique key defining this field
+     */
+    constexpr K const& getId() const noexcept { return id; }
+
+    /**
+     * Test for key equality.
+     *
+     * A key is considered equal to another key if and only if their getId() are equal and their value
+     * types are exactly the same (including const/volatile qualifications).
+     *
+     * @{
+     */
+    constexpr bool operator==(Key<K, V> const& other) const noexcept { return this->id == other.id; }
+
+    template <typename U>
+    constexpr std::enable_if_t<!std::is_same<U, V>::value, bool> operator==(Key<K, U> const&) const noexcept {
+        return false;
+    }
+
+    template <typename U>
+    constexpr bool operator!=(Key<K, U> const& other) const noexcept {
+        return !(*this == other);
+    }
+
+    /** @} */
+
+    /**
+     * Define sort order for Keys.
+     *
+     * This must be expressed as `operator<` instead of std::less because only std::less<void> supports
+     * arguments of mixed types, and it cannot be specialized.
+     *
+     * @param other the key, possibly of a different type, to compare to
+     * @return equivalent to `this->getId() < other.getId()`
+     *
+     * @warning this comparison operator provides a strict weak ordering so long as `K` does, but is *not*
+     * consistent with equality. In particular, keys with the same value of `getId()` but different types will
+     * be equivalent but not equal.
+     */
+    template <typename U>
+    constexpr bool operator<(Key<K, U> const& other) const noexcept {
+        const std::less<K> comparator;
+        return comparator(this->getId(), other.getId());
+    }
+
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept { return std::hash<K>()(id); }
+
+private:
+    /** The logical key. */
+    K const id;
+};
+
+/**
+ * Factory function for Key, to enable type parameter inference.
+ *
+ * @param id the key ID to create.
+ *
+ * @returns a key of the desired type
+ *
+ * @exceptsafe Provides the same exception safety as the copy-constructor of `K`.
+ *
+ * @relatesalso Key
+ *
+ * Calling this function prevents you from having to explicitly name the key type:
+ *
+ *     auto key = makeKey<int>("foo");
+ */
+// template parameters must be reversed for inference to work correctly
+template <typename V, typename K>
+constexpr Key<K, V> makeKey(K const& id) {
+    return Key<K, V>(id);
+}
+
+/**
+ * Output operator for Key.
+ *
+ * The output will use C++ template notation for the key; for example, a key "foo" pointing to an `int` may
+ * print as `"foo<int>"`.
+ *
+ * @param os the desired output stream
+ * @param key the key to print
+ *
+ * @returns a reference to `os`
+ *
+ * @exceptsafe Provides basic exception safety if the output operator of `K` is exception-safe.
+ *
+ * @warning the type name is compiler-specific and may be mangled or unintuitive; for example, some compilers
+ * say "i" instead of "int"
+ *
+ * @relatesalso Key
+ */
+template <typename K, typename V>
+std::ostream& operator<<(std::ostream& os, Key<K, V> const& key) {
+    static const char* typeStr = typeid(V).name();
+    static const char* constStr = std::is_const<V>::value ? " const" : "";
+    static const char* volatileStr = std::is_volatile<V>::value ? " volatile" : "";
+    os << key.getId() << "<" << typeStr << constStr << volatileStr << ">";
+    return os;
+}
+
+}  // namespace typehandling
+}  // namespace afw
+}  // namespace lsst
+
+namespace std {
+template <typename K, typename V>
+struct hash<typename lsst::afw::typehandling::Key<K, V>> {
+    using argument_type = typename lsst::afw::typehandling::Key<K, V>;
+    using result_type = size_t;
+    size_t operator()(argument_type const& obj) const noexcept { return obj.hash_value(); }
+};
+}  // namespace std
+
+#endif

--- a/include/lsst/afw/typehandling/GenericMap.h
+++ b/include/lsst/afw/typehandling/GenericMap.h
@@ -30,6 +30,8 @@
 #include <typeinfo>
 #include <type_traits>
 
+#include "boost/core/demangle.hpp"
+
 namespace lsst {
 namespace afw {
 namespace typehandling {
@@ -170,9 +172,9 @@ constexpr Key<K, V> makeKey(K const& id) {
  */
 template <typename K, typename V>
 std::ostream& operator<<(std::ostream& os, Key<K, V> const& key) {
-    static const char* typeStr = typeid(V).name();
-    static const char* constStr = std::is_const<V>::value ? " const" : "";
-    static const char* volatileStr = std::is_volatile<V>::value ? " volatile" : "";
+    static const std::string typeStr = boost::core::demangle(typeid(V).name());
+    static const std::string constStr = std::is_const<V>::value ? " const" : "";
+    static const std::string volatileStr = std::is_volatile<V>::value ? " volatile" : "";
     os << key.getId() << "<" << typeStr << constStr << volatileStr << ">";
     return os;
 }

--- a/include/lsst/afw/typehandling/GenericMap.h
+++ b/include/lsst/afw/typehandling/GenericMap.h
@@ -449,8 +449,6 @@ public:
 
     /** @} */
 
-    // TODO: still need an API to support RTTI queries from Python
-
     /**
      * Return the set of all keys, without type information.
      *

--- a/include/lsst/afw/typehandling/PolymorphicValue.h
+++ b/include/lsst/afw/typehandling/PolymorphicValue.h
@@ -1,0 +1,135 @@
+// -*- LSST-C++ -*-
+/*
+ * This file is part of afw.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef LSST_AFW_TYPEHANDLING_POLYMORPHICVALUE_H
+#define LSST_AFW_TYPEHANDLING_POLYMORPHICVALUE_H
+
+#include <memory>
+
+#include "lsst/pex/exceptions.h"
+#include "lsst/afw/typehandling/Storable.h"
+
+namespace lsst {
+namespace afw {
+namespace typehandling {
+
+/**
+ * Container that passes Storable objects by value while preserving type.
+ *
+ * This class is implicitly convertible to and from a reference to Storable,
+ * but behaves like a value: changing the internal Storable changes the
+ * object's state, and copying the object creates a new Storable.
+ *
+ * @note While a PolymorphicValue is always initialized with a Storable, it
+ * may become empty if it is the source of a move-construction or
+ * move-assignment. Conversion of an empty value to Storable& throws.
+ */
+/*
+ * Note: I would like to disallow the empty state, as it serves no purpose,
+ * but I can't think of any other sensible post-move state.
+ */
+class PolymorphicValue final {
+public:
+    /**
+     * Create a new object containing a copy of a Storable.
+     *
+     * @param value the value to copy into a PolymorphicValue
+     */
+    PolymorphicValue(Storable const& value);
+    ~PolymorphicValue() noexcept;
+
+    PolymorphicValue(PolymorphicValue const& other);
+    PolymorphicValue(PolymorphicValue&& other);
+
+    PolymorphicValue& operator=(PolymorphicValue const& other);
+    PolymorphicValue& operator=(PolymorphicValue&& other);
+
+    /**
+     * Check whether this object contains a Storable.
+     *
+     * @return `true` if this object has no Storable, `false` otherwise
+     */
+    bool empty() const noexcept;
+
+    /**
+     * Return a reference to the internal Storable, if one exists.
+     *
+     * @returns a reference to the internal object
+     * @throws pex::exceptions::LogicError Thrown if this object is empty.
+     *
+     * @{
+     */
+    operator Storable&();
+    operator Storable const&() const;
+    Storable& get();
+    Storable const& get() const;
+
+    /** @} */
+
+    /**
+     * Test whether the contained Storables are equal.
+     *
+     * Empty PolymorphicValues compare equal to each other and unequal to any
+     * non-empty PolymorphicValue.
+     *
+     * @{
+     */
+    bool operator==(PolymorphicValue const& other) const noexcept;
+    bool operator!=(PolymorphicValue const& other) const noexcept { return !(*this == other); }
+
+    /** @} */
+
+    /**
+     * Return a hash of this object (optional operation).
+     *
+     * @throws UnsupportedOperationException Thrown if the internal Storable
+     *      is not hashable.
+     */
+    std::size_t hash_value() const;
+
+private:
+    std::unique_ptr<Storable> _value;
+};
+
+}  // namespace typehandling
+}  // namespace afw
+}  // namespace lsst
+
+namespace std {
+/**
+ * Hash specialization for PolymorphicValue.
+ *
+ * @returns the hash of the Storable inside the PolymorphicValue, or an
+ *          arbitrary value if it is empty
+ * @throws UnsupportedOperationException Thrown if the Storable is not hashable.
+ */
+template <>
+struct hash<lsst::afw::typehandling::PolymorphicValue> {
+    using argument_type = lsst::afw::typehandling::PolymorphicValue;
+    using result_type = size_t;
+    size_t operator()(argument_type const& obj) const { return obj.hash_value(); }
+};
+}  // namespace std
+
+#endif

--- a/include/lsst/afw/typehandling/SimpleGenericMap.h
+++ b/include/lsst/afw/typehandling/SimpleGenericMap.h
@@ -1,0 +1,145 @@
+// -*- LSST-C++ -*-
+/*
+ * This file is part of afw.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef LSST_AFW_TYPEHANDLING_SIMPLEGENERICMAP_H
+#define LSST_AFW_TYPEHANDLING_SIMPLEGENERICMAP_H
+
+#include <exception>
+#include <sstream>
+#include <unordered_map>
+#include <utility>
+
+#include "boost/variant.hpp"
+
+#include "lsst/afw/typehandling/GenericMap.h"
+
+namespace lsst {
+namespace afw {
+namespace typehandling {
+
+/**
+ * A GenericMap that allows insertion and deletion of arbitrary values.
+ *
+ * In Python, a SimpleGenericMap behaves like a `dict`.
+ *
+ * @tparam K the key type of the map. Must be hashable.
+ *
+ * @note This class offers no guarantees, such as thread-safety, beyond those
+ *       provided by MutableGenericMap.
+ */
+template <typename K>
+class SimpleGenericMap final : public MutableGenericMap<K> {
+protected:
+    using typename GenericMap<K>::StorableType;
+    using typename GenericMap<K>::ValueReference;
+
+public:
+    SimpleGenericMap() = default;
+    SimpleGenericMap(SimpleGenericMap const& other) : _storage() {
+        for (auto const& keyValue : other._storage) {
+            auto const& key = keyValue.first;
+            auto const& value = keyValue.second;
+            _storage.insert(std::make_pair(key, _proxyCopy(value)));
+        }
+    }
+    SimpleGenericMap(SimpleGenericMap&&) = default;
+    virtual ~SimpleGenericMap() noexcept = default;
+
+    SimpleGenericMap& operator=(SimpleGenericMap const& other) {
+        std::unordered_map<K, StorableType> copy;
+        for (auto const& keyValue : other._storage) {
+            auto const& key = keyValue.first;
+            auto const& value = keyValue.second;
+            copy.insert(std::make_pair(key, _proxyCopy(value)));
+        }
+        std::swap(_storage, copy);
+        return *this;
+    };
+    SimpleGenericMap& operator=(SimpleGenericMap&&) = default;
+
+    typename GenericMap<K>::size_type size() const noexcept override { return _storage.size(); }
+
+    bool empty() const noexcept override { return _storage.empty(); }
+
+    typename GenericMap<K>::size_type max_size() const noexcept override { return _storage.max_size(); }
+
+    bool contains(K const& key) const override { return _storage.count(key) > 0; }
+
+    std::vector<K> keys() const override {
+        std::vector<K> keySnapshot;
+        keySnapshot.reserve(_storage.size());
+        for (auto const& pair : _storage) {
+            keySnapshot.push_back(pair.first);
+        }
+        return keySnapshot;
+    }
+
+    void clear() noexcept override { _storage.clear(); }
+
+protected:
+    ValueReference unsafeLookup(K key) const override {
+        try {
+            return _storage.at(key);
+        } catch (std::out_of_range& e) {
+            std::stringstream message;
+            message << "Key not found: " << key;
+            std::throw_with_nested(LSST_EXCEPT(pex::exceptions::OutOfRangeError, message.str()));
+        }
+    }
+
+    bool unsafeInsert(K key, StorableType&& value) override {
+        return _storage.insert(std::make_pair(key, std::move(value))).second;
+    }
+
+    bool unsafeErase(K key) override { return _storage.erase(key); }
+
+private:
+    // StorableType is a value, so we might as well use it in the implementation
+    std::unordered_map<K, StorableType> _storage;
+
+    class _ProxyCopier {
+    public:
+        template <typename T>
+        StorableType operator()(T const& value) const {
+            return value;
+        }
+        StorableType operator()(std::unique_ptr<Storable> const& pointer) const { return pointer->clone(); }
+    };
+
+    /**
+     * Make a copy of any value stored in StorableType.
+     *
+     * @param value The value to copy.
+     * @returns If `value` is a unique_ptr to Storable, returns a unique_ptr
+     *          to a copy of the original value. Otherwise, returns an
+     *          ordinary copy.
+     */
+    StorableType _proxyCopy(StorableType const& value) { return boost::apply_visitor(_ProxyCopier(), value); }
+};
+
+}  // namespace typehandling
+}  // namespace afw
+}  // namespace lsst
+
+#endif

--- a/include/lsst/afw/typehandling/SimpleGenericMap.h
+++ b/include/lsst/afw/typehandling/SimpleGenericMap.h
@@ -56,26 +56,11 @@ protected:
 
 public:
     SimpleGenericMap() = default;
-    SimpleGenericMap(SimpleGenericMap const& other) : _storage() {
-        for (auto const& keyValue : other._storage) {
-            auto const& key = keyValue.first;
-            auto const& value = keyValue.second;
-            _storage.insert(std::make_pair(key, _proxyCopy(value)));
-        }
-    }
+    SimpleGenericMap(SimpleGenericMap const& other) = default;
     SimpleGenericMap(SimpleGenericMap&&) = default;
     virtual ~SimpleGenericMap() noexcept = default;
 
-    SimpleGenericMap& operator=(SimpleGenericMap const& other) {
-        std::unordered_map<K, StorableType> copy;
-        for (auto const& keyValue : other._storage) {
-            auto const& key = keyValue.first;
-            auto const& value = keyValue.second;
-            copy.insert(std::make_pair(key, _proxyCopy(value)));
-        }
-        std::swap(_storage, copy);
-        return *this;
-    };
+    SimpleGenericMap& operator=(SimpleGenericMap const& other) = default;
     SimpleGenericMap& operator=(SimpleGenericMap&&) = default;
 
     typename GenericMap<K>::size_type size() const noexcept override { return _storage.size(); }
@@ -117,25 +102,6 @@ protected:
 private:
     // StorableType is a value, so we might as well use it in the implementation
     std::unordered_map<K, StorableType> _storage;
-
-    class _ProxyCopier {
-    public:
-        template <typename T>
-        StorableType operator()(T const& value) const {
-            return value;
-        }
-        StorableType operator()(std::unique_ptr<Storable> const& pointer) const { return pointer->clone(); }
-    };
-
-    /**
-     * Make a copy of any value stored in StorableType.
-     *
-     * @param value The value to copy.
-     * @returns If `value` is a unique_ptr to Storable, returns a unique_ptr
-     *          to a copy of the original value. Otherwise, returns an
-     *          ordinary copy.
-     */
-    StorableType _proxyCopy(StorableType const& value) { return boost::apply_visitor(_ProxyCopier(), value); }
 };
 
 }  // namespace typehandling

--- a/include/lsst/afw/typehandling/Storable.h
+++ b/include/lsst/afw/typehandling/Storable.h
@@ -1,0 +1,149 @@
+// -*- LSST-C++ -*-
+/*
+ * This file is part of afw.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef LSST_AFW_TYPEHANDLING_STORABLE_H
+#define LSST_AFW_TYPEHANDLING_STORABLE_H
+
+#include <functional>
+#include <memory>
+#include <ostream>
+#include <string>
+
+#include "lsst/pex/exceptions.h"
+#include "lsst/afw/table/io/Persistable.h"
+
+namespace lsst {
+namespace afw {
+namespace typehandling {
+
+/**
+ * Exception thrown by Storable operations for unimplemented operations.
+ *
+ * As with all RuntimeError, callers should assume that this exception may be thrown at any time.
+ */
+LSST_EXCEPTION_TYPE(UnsupportedOperationException, pex::exceptions::RuntimeError,
+                    lsst::afw::typehandling::UnsupportedOperationException)
+
+/**
+ * Interface supporting iteration over heterogenous containers.
+ *
+ * Many operations defined by Storable are optional, and may throw UnsupportedOperationException if they are
+ * not defined.
+ *
+ * @note All Storables are equality-comparable through operator==(Storable const&, Storable const&). This may
+ * cause inconsistent behavior when Storable is used as a mixin in a class hierarchy with an existing equality
+ * operator. Developers should take care to ensure the result is the same no matter which operator is called;
+ * disambiguating calls may require adding an explicit overload for the derived class.
+ */
+class Storable : public table::io::Persistable {
+public:
+    virtual ~Storable() noexcept = 0;
+
+    /**
+     * Create a new object that is a copy of this one (optional operation).
+     *
+     * @throws UnsupportedOperationException Thrown if this object is not cloneable.
+     */
+    virtual std::unique_ptr<Storable> clone() const {
+        throw LSST_EXCEPT(UnsupportedOperationException, "Cloning is not supported.");
+    }
+
+    /**
+     * Create a string representation of this object (optional operation).
+     *
+     * @throws UnsupportedOperationException Thrown if this object does not have a string representation.
+     */
+    virtual std::string toString() const {
+        throw LSST_EXCEPT(UnsupportedOperationException, "No string representation available.");
+    }
+
+    /**
+     * Return a hash of this object (optional operation).
+     *
+     * @throws UnsupportedOperationException Thrown if this object is not hashable.
+     *
+     * @note Subclass authors are responsible for any associated specializations of std::hash.
+     */
+    virtual std::size_t hash_value() const {
+        throw LSST_EXCEPT(UnsupportedOperationException, "Hashes are not supported.");
+    }
+
+    /**
+     * Compare this object to another Storable.
+     *
+     * Subclasses that implement equality comparison must override this
+     * method to give results consistent with `operator==` for all inputs that
+     * are accepted by both.
+     *
+     * @return This implementation always returns `false`.
+     *
+     * @warning This method compares an object to any type of Storable,
+     * although cross-class comparisons should usually return `false`. If
+     * cross-class comparisons are valid, implementers should take care that
+     * they are symmetric and will give the same result no matter what the
+     * compile-time types of the left- and right-hand sides are.
+     */
+    virtual bool equals(Storable const& other) const noexcept { return false; }
+};
+
+inline Storable::~Storable() {}
+
+/** @} */
+
+/**
+ * Output operator for Storable.
+ *
+ * @param os the desired output stream
+ * @param storable the object to print
+ *
+ * @returns a reference to `os`
+ *
+ * @throws UnsupportedOperationException Thrown if `storable` does not have an implementation of
+ *      Storable::toString.
+ *
+ * @relatesalso Storable
+ */
+inline std::ostream& operator<<(std::ostream& os, Storable const& storable) {
+    return os << storable.toString();
+}
+
+}  // namespace typehandling
+}  // namespace afw
+}  // namespace lsst
+
+namespace std {
+/**
+ * Generic hash to allow polymorphic access to Storable
+ *
+ * @throws UnsupportedOperationException Thrown if the argument is not hashable.
+ */
+template <>
+struct hash<lsst::afw::typehandling::Storable> {
+    using argument_type = lsst::afw::typehandling::Storable;
+    using result_type = size_t;
+    size_t operator()(argument_type const& obj) const { return obj.hash_value(); }
+};
+}  // namespace std
+
+#endif

--- a/include/lsst/afw/typehandling/Storable.h
+++ b/include/lsst/afw/typehandling/Storable.h
@@ -48,8 +48,10 @@ LSST_EXCEPTION_TYPE(UnsupportedOperationException, pex::exceptions::RuntimeError
 /**
  * Interface supporting iteration over heterogenous containers.
  *
- * Many operations defined by Storable are optional, and may throw UnsupportedOperationException if they are
- * not defined.
+ * Storable may be subclassed by either C++ or Python classes. Many operations defined by Storable are
+ * optional, and may throw UnsupportedOperationException if they are not defined.
+ *
+ * @see StorableHelper
  *
  * @note All Storables are equality-comparable through operator==(Storable const&, Storable const&). This may
  * cause inconsistent behavior when Storable is used as a mixin in a class hierarchy with an existing equality

--- a/include/lsst/afw/typehandling/python.h
+++ b/include/lsst/afw/typehandling/python.h
@@ -1,0 +1,70 @@
+/*
+ * This file is part of afw.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef LSST_AFW_TYPEHANDLING_PYTHON_H
+#define LSST_AFW_TYPEHANDLING_PYTHON_H
+
+#include "pybind11/pybind11.h"
+
+#include "lsst/afw/typehandling/Storable.h"
+
+namespace lsst {
+namespace afw {
+namespace typehandling {
+
+/**
+ * "Trampoline" for Storable to let it be used as a base class in Python.
+ *
+ * Subclasses of Storable that are wrapped in %pybind11 should have a similar
+ * helper that subclasses `StorableHelper<subclass>`. This helper can be
+ * skipped if the subclass neither adds any virtual methods nor implements
+ * any abstract methods.
+ *
+ * @tparam Base the exact (most specific) class being wrapped
+ *
+ * @see [pybind11 documentation](https://pybind11.readthedocs.io/en/stable/advanced/classes.html)
+ */
+template <class Base = Storable>
+class StorableHelper : public Base {
+public:
+    // Can't wrap clone(); PYBIND11_OVERLOAD chokes on unique_ptr return type
+
+    std::string toString() const override {
+        PYBIND11_OVERLOAD_NAME(std::string, Base, "__repr__", toString, );
+    }
+
+    std::size_t hash_value() const override {
+        PYBIND11_OVERLOAD_NAME(std::size_t, Base, "__hash__", hash_value, );
+    }
+
+protected:
+    bool equals(Base const& other) const noexcept override {
+        PYBIND11_OVERLOAD_NAME(bool, Base, "__eq__", equals, other);
+    }
+};
+
+}  // namespace typehandling
+}  // namespace afw
+}  // namespace lsst
+
+#endif

--- a/include/lsst/afw/typehandling/python.h
+++ b/include/lsst/afw/typehandling/python.h
@@ -26,6 +26,8 @@
 
 #include "pybind11/pybind11.h"
 
+#include <string>
+
 #include "lsst/afw/typehandling/Storable.h"
 
 namespace lsst {
@@ -62,6 +64,8 @@ protected:
         PYBIND11_OVERLOAD_NAME(bool, Base, "__eq__", equals, other);
     }
 };
+
+std::string declareGenericMapRestrictions(std::string const& className, std::string const& keyName);
 
 }  // namespace typehandling
 }  // namespace afw

--- a/include/lsst/afw/typehandling/test.h
+++ b/include/lsst/afw/typehandling/test.h
@@ -63,11 +63,12 @@ public:
 
     std::string toString() const override { return "Simplest possible representation"; }
 
-protected:
     bool equals(Storable const& other) const noexcept override {
         auto simpleOther = dynamic_cast<SimpleStorable const*>(&other);
         return simpleOther != nullptr;
     }
+    virtual bool operator==(SimpleStorable const& other) const { return true; }
+    bool operator!=(SimpleStorable const& other) const { return !(*this == other); }
 };
 
 class ComplexStorable final : public SimpleStorable {
@@ -80,7 +81,6 @@ public:
 
     std::size_t hash_value() const noexcept override { return std::hash<double>()(storage); }
 
-protected:
     // Warning: violates both substitution and equality symmetry!
     bool equals(Storable const& other) const noexcept override {
         auto complexOther = dynamic_cast<ComplexStorable const*>(&other);
@@ -90,6 +90,7 @@ protected:
             return false;
         }
     }
+    bool operator==(SimpleStorable const& other) const override { return this->equals(other); }
 
 private:
     double storage;
@@ -108,10 +109,8 @@ auto const KEY3 = makeKey<std::string>(3);
 std::string const VALUE3 = "How many roads must a man walk down?";
 auto const KEY4 = makeKey<std::shared_ptr<SimpleStorable>>(4);
 auto const VALUE4 = SimpleStorable();
-auto const KEY5 = makeKey<ComplexStorable const>(5);
+auto const KEY5 = makeKey<ComplexStorable>(5);
 auto const VALUE5 = ComplexStorable(-100.0);
-auto const KEY6 = makeKey<ComplexStorable>(6);
-auto const VALUE6 = VALUE5;
 }  // namespace
 
 /**
@@ -169,33 +168,74 @@ BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestAt, GenericMapFactory) {
     demoMap->at(KEY2) = 0.0;
     BOOST_TEST(demoMap->at(KEY2) == 0.0);
     // VALUE2 is of a different type than KEY2, check that alternate key is absent
-    BOOST_CHECK_THROW(demoMap->at(makeKey<decltype(VALUE2)>(KEY2.getId())), pex::exceptions::OutOfRangeError);
+    using Type2 = std::remove_const_t<decltype(VALUE2)>;
+    BOOST_CHECK_THROW(demoMap->at(makeKey<Type2>(KEY2.getId())), pex::exceptions::OutOfRangeError);
 
     BOOST_TEST(demoMap->at(KEY3) == VALUE3);
     demoMap->at(KEY3).append(" Oops, wrong question."s);
     BOOST_TEST(demoMap->at(KEY3) == VALUE3 + " Oops, wrong question."s);
 
     BOOST_TEST(*(demoMap->at(KEY4)) == VALUE4);
-    demoMap->at(KEY4).reset();
-    BOOST_TEST(demoMap->at(KEY4).use_count() == 0);
     // VALUE4 is of a different type than KEY4, check that alternate key is absent
-    BOOST_CHECK_THROW(demoMap->at(makeKey<decltype(VALUE4)>(KEY4.getId())), pex::exceptions::OutOfRangeError);
+    using Type4 = std::remove_const_t<decltype(VALUE4)>;
+    BOOST_CHECK_THROW(demoMap->at(makeKey<Type4>(KEY4.getId())), pex::exceptions::OutOfRangeError);
 
     BOOST_TEST(demoMap->at(KEY5) == VALUE5);
     BOOST_TEST(demoMap->at(makeKey<SimpleStorable>(KEY5.getId())) == VALUE5);
-    // Use BOOST_CHECK_EQUAL to avoid BOOST_TEST bug from Storable being abstract
-    BOOST_CHECK_EQUAL(demoMap->at(makeKey<Storable>(KEY5.getId())), VALUE5);
 
-    BOOST_TEST(demoMap->at(KEY6) == VALUE6);
-    demoMap->at(KEY6) = ComplexStorable(5.0);
-    BOOST_TEST(demoMap->at(KEY6) == ComplexStorable(5.0));
+    ComplexStorable newValue(5.0);
+    demoMap->at(KEY5) = newValue;
+    BOOST_TEST(demoMap->at(KEY5) == newValue);
+}
+
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestEquals, GenericMapFactory) {
+    static GenericMapFactory const factory;
+    auto map1 = factory.makeGenericMap();
+
+    // Use BOOST_CHECK to avoid BOOST_TEST bug from GenericMap being unprintable
+    BOOST_CHECK(*map1 == *map1);
+    // Maps are unequal because shared_ptr members point to different objects
+    BOOST_CHECK(*map1 != *(factory.makeGenericMap()));
+}
+
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestMutableEquals, GenericMapFactory) {
+    using namespace std::string_literals;
+
+    static GenericMapFactory const factory;
+    auto map1 = factory.makeMutableGenericMap();
+    auto map2 = factory.makeMutableGenericMap();
+
+    // Use BOOST_CHECK to avoid BOOST_TEST bug from GenericMap being unprintable
+    BOOST_CHECK(*map1 == *map2);
+
+    auto primitiveKey = makeKey<int>("primitive"s);
+    map1->insert(primitiveKey, 42);
+    BOOST_CHECK(*map1 != *map2);
+    map2->insert(primitiveKey, 42);
+    BOOST_CHECK(*map1 == *map2);
+
+    auto sharedKey = makeKey<std::shared_ptr<SimpleStorable>>("shared"s);
+    auto common = std::make_shared<SimpleStorable>(VALUE4);
+    map1->insert(sharedKey, common);
+    BOOST_CHECK(*map1 != *map2);
+    map2->insert(sharedKey, std::make_shared<SimpleStorable>(VALUE4));
+    BOOST_CHECK(*map1 != *map2);
+    map2->erase(sharedKey);
+    map2->insert(sharedKey, common);
+    BOOST_CHECK(*map1 == *map2);
+
+    auto storableKey = makeKey<ComplexStorable>("storable"s);
+    map1->insert(storableKey, VALUE5);
+    BOOST_CHECK(*map1 != *map2);
+    map2->insert(storableKey, VALUE5);
+    BOOST_CHECK(*map1 == *map2);
 }
 
 BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestSize, GenericMapFactory) {
     static GenericMapFactory const factory;
     std::unique_ptr<GenericMap<int>> demoMap = factory.makeGenericMap();
 
-    BOOST_TEST(demoMap->size() == 7);
+    BOOST_TEST(demoMap->size() == 6);
     BOOST_TEST(!demoMap->empty());
 }
 
@@ -229,7 +269,7 @@ BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestWeakContains, GenericMapFactory) {
     BOOST_TEST(demoMap->contains(KEY3.getId()));
     BOOST_TEST(demoMap->contains(KEY4.getId()));
     BOOST_TEST(demoMap->contains(KEY5.getId()));
-    BOOST_TEST(!demoMap->contains(7));
+    BOOST_TEST(!demoMap->contains(6));
 }
 
 BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestContains, GenericMapFactory) {
@@ -403,9 +443,8 @@ BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestInsertStorable, GenericMapFactory) {
 
     ComplexStorable object(3.1416);
     BOOST_TEST(demoMap->insert<Storable>(makeKey<Storable>("foo"s), object) == true);
-    BOOST_TEST(demoMap->insert<std::shared_ptr<ComplexStorable const>>(
-                       makeKey<std::shared_ptr<ComplexStorable const>>("bar"s),
-                       std::make_shared<ComplexStorable>(3.141)) == true);
+    BOOST_TEST(demoMap->insert(makeKey<std::shared_ptr<ComplexStorable>>("bar"s),
+                               std::make_shared<ComplexStorable>(3.141)) == true);
     BOOST_TEST(demoMap->insert<Storable>(makeKey<Storable>("foo"s), SimpleStorable()) == false);
     BOOST_TEST(demoMap->insert(makeKey<std::shared_ptr<SimpleStorable>>("bar"s),
                                std::make_shared<SimpleStorable>()) == false);
@@ -414,15 +453,14 @@ BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestInsertStorable, GenericMapFactory) {
     BOOST_TEST(demoMap->size() == 2);
     BOOST_TEST(demoMap->contains("foo"s));
     BOOST_TEST(demoMap->contains(makeKey<Storable>("foo"s)));
-    BOOST_TEST(demoMap->contains(makeKey<std::shared_ptr<ComplexStorable const>>("bar"s)));
+    BOOST_TEST(demoMap->contains(makeKey<std::shared_ptr<ComplexStorable>>("bar"s)));
 
     // ComplexStorable::operator== is asymmetric
     // Use BOOST_CHECK_EQUAL to avoid BOOST_TEST bug from Storable being abstract
-    BOOST_CHECK_EQUAL(object, demoMap->at(makeKey<Storable>("foo"s)));
+    BOOST_TEST(object == demoMap->at(makeKey<SimpleStorable>("foo"s)));
     object = ComplexStorable(1.4);
-    BOOST_CHECK_NE(object, demoMap->at(makeKey<Storable>("foo"s)));
-    BOOST_CHECK_EQUAL(*(demoMap->at(makeKey<std::shared_ptr<ComplexStorable const>>("bar"s))),
-                      ComplexStorable(3.141));
+    BOOST_TEST(object != demoMap->at(makeKey<SimpleStorable>("foo"s)));
+    BOOST_TEST(*(demoMap->at(makeKey<std::shared_ptr<ComplexStorable>>("bar"s))) == ComplexStorable(3.141));
 }
 
 BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestInterleavedInserts, GenericMapFactory) {
@@ -447,11 +485,10 @@ BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestInterleavedInserts, GenericMapFactory) {
     BOOST_TEST(demoMap->size() == 6);
     BOOST_TEST(demoMap->at(makeKey<int>("key1"s)) == 3);
     BOOST_TEST(demoMap->at(makeKey<double>("key6"s)) == 42);
-    // Use BOOST_CHECK_EQUAL to avoid BOOST_TEST bug from Storable being abstract
-    BOOST_CHECK_EQUAL(demoMap->at(makeKey<Storable>("key2"s)), SimpleStorable());
-    BOOST_CHECK_EQUAL(demoMap->at(makeKey<std::string>("key3"s)), "Test value"s);
-    BOOST_CHECK_EQUAL(demoMap->at(makeKey<std::string>("key4"s)), "This is some text"s);
-    BOOST_CHECK_EQUAL(demoMap->at(makeKey<std::string>("key5"s)), message);
+    BOOST_TEST(demoMap->at(makeKey<SimpleStorable>("key2"s)) == SimpleStorable());
+    BOOST_TEST(demoMap->at(makeKey<std::string>("key3"s)) == "Test value"s);
+    BOOST_TEST(demoMap->at(makeKey<std::string>("key4"s)) == "This is some text"s);
+    BOOST_TEST(demoMap->at(makeKey<std::string>("key5"s)) == message);
 }
 
 BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestErase, GenericMapFactory) {
@@ -503,6 +540,7 @@ void addGenericMapTestCases(boost::unit_test::test_suite* const suite) {
 
     suite->add(BOOST_TEST_CASE_TEMPLATE(TestConstAt, factories));
     suite->add(BOOST_TEST_CASE_TEMPLATE(TestAt, factories));
+    suite->add(BOOST_TEST_CASE_TEMPLATE(TestEquals, factories));
     suite->add(BOOST_TEST_CASE_TEMPLATE(TestSize, factories));
     suite->add(BOOST_TEST_CASE_TEMPLATE(TestWeakContains, factories));
     suite->add(BOOST_TEST_CASE_TEMPLATE(TestContains, factories));
@@ -524,6 +562,7 @@ void addMutableGenericMapTestCases(boost::unit_test::test_suite* const suite) {
 
     addGenericMapTestCases<GenericMapFactory>(suite);
 
+    suite->add(BOOST_TEST_CASE_TEMPLATE(TestMutableEquals, factories));
     suite->add(BOOST_TEST_CASE_TEMPLATE(TestMutableSize, factories));
     suite->add(BOOST_TEST_CASE_TEMPLATE(TestClear, factories));
     suite->add(BOOST_TEST_CASE_TEMPLATE(TestClearIdempotent, factories));

--- a/include/lsst/afw/typehandling/test.h
+++ b/include/lsst/afw/typehandling/test.h
@@ -75,6 +75,11 @@ class ComplexStorable final : public SimpleStorable {
 public:
     constexpr ComplexStorable(double storage) : SimpleStorable(), storage(storage) {}
 
+    ComplexStorable& operator=(double newValue) {
+        storage = newValue;
+        return *this;
+    }
+
     std::unique_ptr<Storable> clone() const override { return std::make_unique<ComplexStorable>(storage); }
 
     std::string toString() const override { return "ComplexStorable(" + std::to_string(storage) + ")"; }

--- a/include/lsst/afw/typehandling/test.h
+++ b/include/lsst/afw/typehandling/test.h
@@ -1,0 +1,570 @@
+// -*- LSST-C++ -*-
+/*
+ * This file is part of afw.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef LSST_AFW_TYPEHANDLING_TEST_H
+#define LSST_AFW_TYPEHANDLING_TEST_H
+
+#define BOOST_TEST_DYN_LINK
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
+#include "boost/test/unit_test.hpp"
+#pragma clang diagnostic pop
+
+#include <memory>
+#include <set>
+#include <string>
+
+#include <boost/mpl/list.hpp>
+
+#include "lsst/pex/exceptions.h"
+
+#include "lsst/afw/typehandling/GenericMap.h"
+#include "lsst/afw/typehandling/Storable.h"
+
+namespace lsst {
+namespace afw {
+namespace typehandling {
+namespace test {
+
+/*
+ * This include file defines tests that exercise the GenericMap and MutableGenericMap interfaces, and ensures
+ * that any implementation satisfies the requirements of these interfaces. Subclass authors should call either
+ * addGenericMapTestCases or addMutableGenericMapTestCases in a suitable entry point, such as a global fixture
+ * or a module initialization function.
+ */
+
+namespace {
+class SimpleStorable : public Storable {
+public:
+    virtual ~SimpleStorable() = default;
+
+    std::unique_ptr<Storable> clone() const override { return std::make_unique<SimpleStorable>(); }
+
+    std::string toString() const override { return "Simplest possible representation"; }
+
+protected:
+    bool equals(Storable const& other) const noexcept override {
+        auto simpleOther = dynamic_cast<SimpleStorable const*>(&other);
+        return simpleOther != nullptr;
+    }
+};
+
+class ComplexStorable final : public SimpleStorable {
+public:
+    constexpr ComplexStorable(double storage) : SimpleStorable(), storage(storage) {}
+
+    std::unique_ptr<Storable> clone() const override { return std::make_unique<ComplexStorable>(storage); }
+
+    std::string toString() const override { return "ComplexStorable(" + std::to_string(storage) + ")"; }
+
+    std::size_t hash_value() const noexcept override { return std::hash<double>()(storage); }
+
+protected:
+    // Warning: violates both substitution and equality symmetry!
+    bool equals(Storable const& other) const noexcept override {
+        auto complexOther = dynamic_cast<ComplexStorable const*>(&other);
+        if (complexOther) {
+            return this->storage == complexOther->storage;
+        } else {
+            return false;
+        }
+    }
+
+private:
+    double storage;
+};
+
+// Would make more sense as static constants in GenericFactory
+// but neither string nor Storable qualify as literal types
+// In anonymous namespace to ensure constants are internal to whatever test includes this header
+auto const KEY0 = makeKey<bool>(0);
+bool const VALUE0 = true;
+auto const KEY1 = makeKey<int>(1);
+int const VALUE1 = 42;
+auto const KEY2 = makeKey<double>(2);
+int const VALUE2 = VALUE1;
+auto const KEY3 = makeKey<std::string>(3);
+std::string const VALUE3 = "How many roads must a man walk down?";
+auto const KEY4 = makeKey<std::shared_ptr<SimpleStorable>>(4);
+auto const VALUE4 = SimpleStorable();
+auto const KEY5 = makeKey<ComplexStorable const>(5);
+auto const VALUE5 = ComplexStorable(-100.0);
+auto const KEY6 = makeKey<ComplexStorable>(6);
+auto const VALUE6 = VALUE5;
+}  // namespace
+
+/**
+ * Abstract factory that creates GenericMap and MutableGenericMap instances as needed.
+ */
+class GenericFactory {
+public:
+    virtual ~GenericFactory() = default;
+
+    /**
+     * Create a map containing the following state:
+     *
+     * * `KEY0: VALUE0`
+     * * `KEY1: VALUE1`
+     * * `KEY2: VALUE2`
+     * * `KEY3: VALUE3`
+     * * `KEY4: std::shared_ptr<>(VALUE4)`
+     * * `KEY5: VALUE5`
+     */
+    virtual std::unique_ptr<GenericMap<int>> makeGenericMap() const = 0;
+
+    /// Create an empty map.
+    virtual std::unique_ptr<MutableGenericMap<std::string>> makeMutableGenericMap() const = 0;
+};
+
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestConstAt, GenericMapFactory) {
+    static GenericMapFactory const factory;
+    std::unique_ptr<GenericMap<int> const> demoMap = factory.makeGenericMap();
+
+    BOOST_TEST(demoMap->at(KEY0) == VALUE0);
+    BOOST_TEST(demoMap->at(KEY1) == VALUE1);
+    BOOST_TEST(demoMap->at(KEY2) == VALUE2);
+    BOOST_TEST(demoMap->at(KEY3) == VALUE3);
+    BOOST_TEST(*(demoMap->at(KEY4)) == VALUE4);
+    BOOST_TEST(demoMap->at(KEY5) == VALUE5);
+}
+
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestAt, GenericMapFactory) {
+    using namespace std::string_literals;
+
+    static GenericMapFactory const factory;
+    std::unique_ptr<GenericMap<int>> demoMap = factory.makeGenericMap();
+
+    BOOST_TEST(demoMap->at(KEY0) == VALUE0);
+    demoMap->at(KEY0) = false;
+    BOOST_TEST(demoMap->at(KEY0) == false);
+    BOOST_CHECK_THROW(demoMap->at(makeKey<int>(KEY0.getId())), pex::exceptions::OutOfRangeError);
+
+    BOOST_TEST(demoMap->at(KEY1) == VALUE1);
+    demoMap->at(KEY1)++;
+    BOOST_TEST(demoMap->at(KEY1) == VALUE1 + 1);
+    BOOST_CHECK_THROW(demoMap->at(makeKey<bool>(KEY1.getId())), pex::exceptions::OutOfRangeError);
+
+    BOOST_TEST(demoMap->at(KEY2) == VALUE2);
+    demoMap->at(KEY2) = 0.0;
+    BOOST_TEST(demoMap->at(KEY2) == 0.0);
+    // VALUE2 is of a different type than KEY2, check that alternate key is absent
+    BOOST_CHECK_THROW(demoMap->at(makeKey<decltype(VALUE2)>(KEY2.getId())), pex::exceptions::OutOfRangeError);
+
+    BOOST_TEST(demoMap->at(KEY3) == VALUE3);
+    demoMap->at(KEY3).append(" Oops, wrong question."s);
+    BOOST_TEST(demoMap->at(KEY3) == VALUE3 + " Oops, wrong question."s);
+
+    BOOST_TEST(*(demoMap->at(KEY4)) == VALUE4);
+    demoMap->at(KEY4).reset();
+    BOOST_TEST(demoMap->at(KEY4).use_count() == 0);
+    // VALUE4 is of a different type than KEY4, check that alternate key is absent
+    BOOST_CHECK_THROW(demoMap->at(makeKey<decltype(VALUE4)>(KEY4.getId())), pex::exceptions::OutOfRangeError);
+
+    BOOST_TEST(demoMap->at(KEY5) == VALUE5);
+    BOOST_TEST(demoMap->at(makeKey<SimpleStorable>(KEY5.getId())) == VALUE5);
+    // Use BOOST_CHECK_EQUAL to avoid BOOST_TEST bug from Storable being abstract
+    BOOST_CHECK_EQUAL(demoMap->at(makeKey<Storable>(KEY5.getId())), VALUE5);
+
+    BOOST_TEST(demoMap->at(KEY6) == VALUE6);
+    demoMap->at(KEY6) = ComplexStorable(5.0);
+    BOOST_TEST(demoMap->at(KEY6) == ComplexStorable(5.0));
+}
+
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestSize, GenericMapFactory) {
+    static GenericMapFactory const factory;
+    std::unique_ptr<GenericMap<int>> demoMap = factory.makeGenericMap();
+
+    BOOST_TEST(demoMap->size() == 7);
+    BOOST_TEST(!demoMap->empty());
+}
+
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestMutableSize, GenericMapFactory) {
+    using namespace std::string_literals;
+
+    static GenericMapFactory const factory;
+    std::unique_ptr<MutableGenericMap<std::string>> demoMap = factory.makeMutableGenericMap();
+
+    BOOST_TEST_REQUIRE(demoMap->size() == 0);
+    BOOST_TEST_REQUIRE(demoMap->empty());
+
+    demoMap->insert(makeKey<int>("Negative One"s), -1);
+    BOOST_TEST(demoMap->size() == 1);
+    BOOST_TEST(!demoMap->empty());
+
+    demoMap->erase(makeKey<int>("Negative One"s));
+    BOOST_TEST(demoMap->size() == 0);
+    BOOST_TEST(demoMap->empty());
+}
+
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestWeakContains, GenericMapFactory) {
+    using namespace std::string_literals;
+
+    static GenericMapFactory const factory;
+    std::unique_ptr<GenericMap<int> const> demoMap = factory.makeGenericMap();
+
+    BOOST_TEST(demoMap->contains(KEY0.getId()));
+    BOOST_TEST(demoMap->contains(KEY1.getId()));
+    BOOST_TEST(demoMap->contains(KEY2.getId()));
+    BOOST_TEST(demoMap->contains(KEY3.getId()));
+    BOOST_TEST(demoMap->contains(KEY4.getId()));
+    BOOST_TEST(demoMap->contains(KEY5.getId()));
+    BOOST_TEST(!demoMap->contains(7));
+}
+
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestContains, GenericMapFactory) {
+    static GenericMapFactory const factory;
+    std::unique_ptr<GenericMap<int> const> demoMap = factory.makeGenericMap();
+
+    BOOST_TEST(demoMap->contains(KEY0));
+    BOOST_TEST(!demoMap->contains(makeKey<int>(KEY0.getId())));
+
+    BOOST_TEST(demoMap->contains(KEY1));
+    BOOST_TEST(!demoMap->contains(makeKey<bool>(KEY1.getId())));
+
+    BOOST_TEST(demoMap->contains(KEY2));
+    // VALUE2 is of a different type than KEY2, check that alternate key is absent
+    BOOST_TEST(!demoMap->contains(makeKey<decltype(VALUE2)>(KEY2.getId())));
+
+    BOOST_TEST(demoMap->contains(KEY3));
+
+    BOOST_TEST(demoMap->contains(KEY4));
+    // VALUE4 is of a different type than KEY4, check that alternate key is absent
+    BOOST_TEST(!demoMap->contains(makeKey<decltype(VALUE4)>(KEY4.getId())));
+
+    BOOST_TEST(demoMap->contains(KEY5));
+    BOOST_TEST(demoMap->contains(makeKey<SimpleStorable>(KEY5.getId())));
+    BOOST_TEST(demoMap->contains(makeKey<Storable>(KEY5.getId())));
+}
+
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestKeys, GenericMapFactory) {
+    static GenericMapFactory const factory;
+    std::unique_ptr<GenericMap<int> const> demoMap = factory.makeGenericMap();
+    auto orderedKeys = demoMap->keys();
+    // GenericMaps don't have an iteration order yet
+    std::set<int> keys(orderedKeys.begin(), orderedKeys.end());
+
+    BOOST_TEST(keys == std::set<int>({KEY0.getId(), KEY1.getId(), KEY2.getId(), KEY3.getId(), KEY4.getId(),
+                                      KEY5.getId()}));
+}
+
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestClearIdempotent, GenericMapFactory) {
+    static GenericMapFactory const factory;
+    std::unique_ptr<MutableGenericMap<std::string>> demoMap = factory.makeMutableGenericMap();
+
+    BOOST_TEST_REQUIRE(demoMap->empty());
+    demoMap->clear();
+    BOOST_TEST(demoMap->empty());
+}
+
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestClear, GenericMapFactory) {
+    using namespace std::string_literals;
+
+    static GenericMapFactory const factory;
+    std::unique_ptr<MutableGenericMap<std::string>> demoMap = factory.makeMutableGenericMap();
+
+    demoMap->insert(makeKey<int>("prime"s), 3);
+    demoMap->insert(makeKey<std::string>("foo"s), "bar"s);
+
+    BOOST_TEST_REQUIRE(!demoMap->empty());
+    demoMap->clear();
+    BOOST_TEST(demoMap->empty());
+}
+
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestInsertInt, GenericMapFactory) {
+    using namespace std::string_literals;
+
+    static GenericMapFactory const factory;
+    std::unique_ptr<MutableGenericMap<std::string>> demoMap = factory.makeMutableGenericMap();
+
+    BOOST_TEST_REQUIRE(demoMap->empty());
+
+    int x = 27;
+    BOOST_TEST(demoMap->insert(makeKey<int>("cube"s), x) == true);
+    BOOST_TEST(demoMap->insert(makeKey<int>("cube"s), 0) == false);
+
+    BOOST_TEST(!demoMap->empty());
+    BOOST_TEST(demoMap->size() == 1);
+    BOOST_TEST(demoMap->contains("cube"s));
+    BOOST_TEST(demoMap->contains(makeKey<int>("cube"s)));
+    BOOST_TEST(!demoMap->contains(makeKey<double>("cube"s)));
+    BOOST_TEST(demoMap->at(makeKey<int>("cube"s)) == x);
+
+    x = 0;
+    BOOST_TEST(demoMap->at(makeKey<int>("cube"s)) != x);
+
+    demoMap->at(makeKey<int>("cube"s)) = 0;
+    BOOST_TEST(demoMap->at(makeKey<int>("cube"s)) == 0);
+}
+
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestWeakInsertInt, GenericMapFactory) {
+    using namespace std::string_literals;
+
+    static GenericMapFactory const factory;
+    std::unique_ptr<MutableGenericMap<std::string>> demoMap = factory.makeMutableGenericMap();
+
+    BOOST_TEST_REQUIRE(demoMap->empty());
+
+    auto insertResult = demoMap->insert("cube"s, 27);
+    BOOST_TEST(insertResult.second == true);
+    BOOST_TEST(demoMap->insert("cube"s, 0).second == false);
+
+    BOOST_TEST(!demoMap->empty());
+    BOOST_TEST(demoMap->size() == 1);
+    BOOST_TEST(demoMap->contains("cube"s));
+    BOOST_TEST(demoMap->contains(insertResult.first));
+    BOOST_TEST(demoMap->contains(makeKey<int>("cube"s)));
+    BOOST_TEST(!demoMap->contains(makeKey<double>("cube"s)));
+    BOOST_TEST(demoMap->at(insertResult.first) == 27);
+    BOOST_TEST(demoMap->at(makeKey<int>("cube"s)) == 27);
+
+    demoMap->at(insertResult.first) = 0;
+    BOOST_TEST(demoMap->at(insertResult.first) == 0);
+}
+
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestInsertString, GenericMapFactory) {
+    using namespace std::string_literals;
+
+    static GenericMapFactory const factory;
+    std::unique_ptr<MutableGenericMap<std::string>> demoMap = factory.makeMutableGenericMap();
+
+    BOOST_TEST_REQUIRE(demoMap->empty());
+
+    std::string answer(
+            "I have a most elegant and wonderful proof, but this string is too small to contain it."s);
+    BOOST_TEST(demoMap->insert(makeKey<std::string>("Ultimate answer"s), answer) == true);
+    BOOST_TEST(demoMap->insert(makeKey<std::string>("OK"s), "Ook!"s) == true);
+    BOOST_TEST(demoMap->insert(makeKey<std::string>("Ultimate answer"s), "Something philosophical"s) ==
+               false);
+
+    BOOST_TEST(!demoMap->empty());
+    BOOST_TEST(demoMap->size() == 2);
+    BOOST_TEST(demoMap->contains("OK"s));
+    BOOST_TEST(demoMap->contains(makeKey<std::string>("Ultimate answer"s)));
+    BOOST_TEST(demoMap->at(makeKey<std::string>("Ultimate answer"s)) == answer);
+    BOOST_TEST(demoMap->at(makeKey<std::string>("OK"s)) == "Ook!"s);
+
+    answer = "I don't know"s;
+    BOOST_TEST(demoMap->at(makeKey<std::string>("Ultimate answer"s)) != answer);
+}
+
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestWeakInsertString, GenericMapFactory) {
+    using namespace std::string_literals;
+
+    static GenericMapFactory const factory;
+    std::unique_ptr<MutableGenericMap<std::string>> demoMap = factory.makeMutableGenericMap();
+
+    BOOST_TEST_REQUIRE(demoMap->empty());
+
+    auto insertResult1 = demoMap->insert("Ultimate answer"s, "Something philosophical"s);
+    BOOST_TEST(insertResult1.second == true);
+    auto insertResult2 = demoMap->insert("OK"s, "Ook!"s);
+    BOOST_TEST(insertResult2.second == true);
+
+    BOOST_TEST(!demoMap->empty());
+    BOOST_TEST(demoMap->size() == 2);
+    BOOST_TEST(demoMap->contains(insertResult1.first));
+    BOOST_TEST(demoMap->contains(insertResult2.first));
+    BOOST_TEST(demoMap->contains("OK"s));
+    BOOST_TEST(demoMap->contains(makeKey<std::string>("Ultimate answer"s)));
+    BOOST_TEST(demoMap->at(insertResult1.first) == "Something philosophical"s);
+    BOOST_TEST(demoMap->at(makeKey<std::string>("Ultimate answer"s)) == "Something philosophical"s);
+    BOOST_TEST(demoMap->at(insertResult2.first) == "Ook!"s);
+    BOOST_TEST(demoMap->at(makeKey<std::string>("OK"s)) == "Ook!"s);
+}
+
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestInsertStorable, GenericMapFactory) {
+    using namespace std::string_literals;
+
+    static GenericMapFactory const factory;
+    std::unique_ptr<MutableGenericMap<std::string>> demoMap = factory.makeMutableGenericMap();
+
+    BOOST_TEST_REQUIRE(demoMap->empty());
+
+    ComplexStorable object(3.1416);
+    BOOST_TEST(demoMap->insert<Storable>(makeKey<Storable>("foo"s), object) == true);
+    BOOST_TEST(demoMap->insert<std::shared_ptr<ComplexStorable const>>(
+                       makeKey<std::shared_ptr<ComplexStorable const>>("bar"s),
+                       std::make_shared<ComplexStorable>(3.141)) == true);
+    BOOST_TEST(demoMap->insert<Storable>(makeKey<Storable>("foo"s), SimpleStorable()) == false);
+    BOOST_TEST(demoMap->insert(makeKey<std::shared_ptr<SimpleStorable>>("bar"s),
+                               std::make_shared<SimpleStorable>()) == false);
+
+    BOOST_TEST(!demoMap->empty());
+    BOOST_TEST(demoMap->size() == 2);
+    BOOST_TEST(demoMap->contains("foo"s));
+    BOOST_TEST(demoMap->contains(makeKey<Storable>("foo"s)));
+    BOOST_TEST(demoMap->contains(makeKey<std::shared_ptr<ComplexStorable const>>("bar"s)));
+
+    // ComplexStorable::operator== is asymmetric
+    // Use BOOST_CHECK_EQUAL to avoid BOOST_TEST bug from Storable being abstract
+    BOOST_CHECK_EQUAL(object, demoMap->at(makeKey<Storable>("foo"s)));
+    object = ComplexStorable(1.4);
+    BOOST_CHECK_NE(object, demoMap->at(makeKey<Storable>("foo"s)));
+    BOOST_CHECK_EQUAL(*(demoMap->at(makeKey<std::shared_ptr<ComplexStorable const>>("bar"s))),
+                      ComplexStorable(3.141));
+}
+
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestInterleavedInserts, GenericMapFactory) {
+    using namespace std::string_literals;
+
+    static GenericMapFactory const factory;
+    std::unique_ptr<MutableGenericMap<std::string>> demoMap = factory.makeMutableGenericMap();
+
+    BOOST_TEST_REQUIRE(demoMap->empty());
+
+    BOOST_TEST(demoMap->insert(makeKey<int>("key1"s), 3) == true);
+    BOOST_TEST(demoMap->insert(makeKey<double>("key1"s), 1.0) == false);
+    BOOST_TEST(demoMap->insert<Storable>(makeKey<Storable>("key2"s), SimpleStorable()) == true);
+    BOOST_TEST(demoMap->insert(makeKey<std::string>("key3"s), "Test value"s) == true);
+    BOOST_TEST(demoMap->insert(makeKey<std::string>("key4"s), "This is some text"s) == true);
+    std::string const message = "Unknown value for key5."s;
+    BOOST_TEST(demoMap->insert(makeKey<std::string>("key5"s), message) == true);
+    BOOST_TEST(demoMap->insert(makeKey<int>("key3"s), 20) == false);
+    BOOST_TEST(demoMap->insert<double>(makeKey<double>("key6"s), 42) == true);
+
+    BOOST_TEST(!demoMap->empty());
+    BOOST_TEST(demoMap->size() == 6);
+    BOOST_TEST(demoMap->at(makeKey<int>("key1"s)) == 3);
+    BOOST_TEST(demoMap->at(makeKey<double>("key6"s)) == 42);
+    // Use BOOST_CHECK_EQUAL to avoid BOOST_TEST bug from Storable being abstract
+    BOOST_CHECK_EQUAL(demoMap->at(makeKey<Storable>("key2"s)), SimpleStorable());
+    BOOST_CHECK_EQUAL(demoMap->at(makeKey<std::string>("key3"s)), "Test value"s);
+    BOOST_CHECK_EQUAL(demoMap->at(makeKey<std::string>("key4"s)), "This is some text"s);
+    BOOST_CHECK_EQUAL(demoMap->at(makeKey<std::string>("key5"s)), message);
+}
+
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestErase, GenericMapFactory) {
+    using namespace std::string_literals;
+
+    static GenericMapFactory const factory;
+    std::unique_ptr<MutableGenericMap<std::string>> demoMap = factory.makeMutableGenericMap();
+
+    demoMap->insert(makeKey<int>("Ultimate answer"s), 42);
+    BOOST_TEST_REQUIRE(demoMap->size() == 1);
+
+    BOOST_TEST(demoMap->erase(makeKey<std::string>("Ultimate answer"s)) == false);
+    BOOST_TEST(demoMap->size() == 1);
+    BOOST_TEST(demoMap->erase(makeKey<int>("Ultimate answer"s)) == true);
+    BOOST_TEST(demoMap->size() == 0);
+}
+
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestInsertEraseInsert, GenericMapFactory) {
+    using namespace std::string_literals;
+
+    static GenericMapFactory const factory;
+    std::unique_ptr<MutableGenericMap<std::string>> demoMap = factory.makeMutableGenericMap();
+
+    BOOST_TEST_REQUIRE(demoMap->empty());
+
+    BOOST_TEST(demoMap->insert(makeKey<int>("Ultimate answer"s), 42) == true);
+    BOOST_TEST(demoMap->insert(makeKey<int>("OK"s), 200) == true);
+    BOOST_TEST(demoMap->erase(makeKey<int>("Ultimate answer"s)) == true);
+    BOOST_TEST(demoMap->insert(makeKey<double>("Ultimate answer"s), 3.1415927) == true);
+
+    BOOST_TEST(!demoMap->empty());
+    BOOST_TEST(demoMap->size() == 2);
+    BOOST_TEST(demoMap->contains("OK"s));
+    BOOST_TEST(!demoMap->contains(makeKey<int>("Ultimate answer"s)));
+    BOOST_TEST(demoMap->contains(makeKey<double>("Ultimate answer"s)));
+    BOOST_TEST(demoMap->at(makeKey<double>("Ultimate answer"s)) == 3.1415927);
+}
+
+/**
+ * Create generic test cases for a specific GenericMap implementation.
+ *
+ * @tparam GenericMapFactory a subclass of GenericFactory that creates the
+ *      desired implementation. Must be default-constructible.
+ * @param suite the test suite to add the tests to.
+ */
+template <class GenericMapFactory>
+void addGenericMapTestCases(boost::unit_test::test_suite* const suite) {
+    using factories = boost::mpl::list<GenericMapFactory>;
+
+    suite->add(BOOST_TEST_CASE_TEMPLATE(TestConstAt, factories));
+    suite->add(BOOST_TEST_CASE_TEMPLATE(TestAt, factories));
+    suite->add(BOOST_TEST_CASE_TEMPLATE(TestSize, factories));
+    suite->add(BOOST_TEST_CASE_TEMPLATE(TestWeakContains, factories));
+    suite->add(BOOST_TEST_CASE_TEMPLATE(TestContains, factories));
+    suite->add(BOOST_TEST_CASE_TEMPLATE(TestKeys, factories));
+}
+
+/**
+ * Create generic test cases for a specific MutableGenericMap implementation.
+ *
+ * The tests will include all those added by addGenericMapTestCases.
+ *
+ * @tparam GenericMapFactory a subclass of GenericFactory that creates the
+ *      desired implementation. Must be default-constructible.
+ * @param suite the test suite to add the tests to.
+ */
+template <class GenericMapFactory>
+void addMutableGenericMapTestCases(boost::unit_test::test_suite* const suite) {
+    using factories = boost::mpl::list<GenericMapFactory>;
+
+    addGenericMapTestCases<GenericMapFactory>(suite);
+
+    suite->add(BOOST_TEST_CASE_TEMPLATE(TestMutableSize, factories));
+    suite->add(BOOST_TEST_CASE_TEMPLATE(TestClear, factories));
+    suite->add(BOOST_TEST_CASE_TEMPLATE(TestClearIdempotent, factories));
+    suite->add(BOOST_TEST_CASE_TEMPLATE(TestInsertInt, factories));
+    suite->add(BOOST_TEST_CASE_TEMPLATE(TestInsertString, factories));
+    suite->add(BOOST_TEST_CASE_TEMPLATE(TestInsertStorable, factories));
+    suite->add(BOOST_TEST_CASE_TEMPLATE(TestInterleavedInserts, factories));
+    suite->add(BOOST_TEST_CASE_TEMPLATE(TestErase, factories));
+    suite->add(BOOST_TEST_CASE_TEMPLATE(TestInsertEraseInsert, factories));
+}
+
+/**
+ * Create generic test cases for a specific GenericMap implementation.
+ *
+ * The tests will be added to the master test suite.
+ *
+ * @tparam GenericMapFactory a subclass of GenericFactory that creates the
+ *      desired implementation. Must be default-constructible.
+ */
+template <class GenericMapFactory>
+inline void addGenericMapTestCases() {
+    addGenericMapTestCases<GenericMapFactory>(&(boost::unit_test::framework::master_test_suite()));
+}
+
+/**
+ * Create generic test cases for a specific MutableGenericMap implementation.
+ *
+ * The tests will be added to the master test suite. They will include all
+ * tests added by addGenericMapTestCases.
+ *
+ * @tparam GenericMapFactory a subclass of GenericFactory that creates the
+ *      desired implementation. Must be default-constructible.
+ */
+template <class GenericMapFactory>
+inline void addMutableGenericMapTestCases() {
+    addMutableGenericMapTestCases<GenericMapFactory>(&(boost::unit_test::framework::master_test_suite()));
+}
+
+}  // namespace test
+}  // namespace typehandling
+}  // namespace afw
+}  // namespace lsst
+
+#endif

--- a/python/lsst/afw/typehandling/SConscript
+++ b/python/lsst/afw/typehandling/SConscript
@@ -1,0 +1,9 @@
+# -*- python -*-
+from lsst.sconsUtils import scripts
+scripts.BasicSConscript.pybind11(
+    ["_typehandling"],
+    extraSrc={
+        "_typehandling": ["_Storable.cc"],
+    },
+    addUnderscore=False
+)

--- a/python/lsst/afw/typehandling/SConscript
+++ b/python/lsst/afw/typehandling/SConscript
@@ -3,7 +3,7 @@ from lsst.sconsUtils import scripts
 scripts.BasicSConscript.pybind11(
     ["_typehandling"],
     extraSrc={
-        "_typehandling": ["_Storable.cc"],
+        "_typehandling": ["_GenericMap.cc", "_SimpleGenericMap.cc", "_Storable.cc"],
     },
     addUnderscore=False
 )

--- a/python/lsst/afw/typehandling/_GenericMap.cc
+++ b/python/lsst/afw/typehandling/_GenericMap.cc
@@ -1,0 +1,209 @@
+/*
+ * This file is part of afw.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "pybind11/pybind11.h"
+#include "pybind11/stl.h"
+
+#include <cstdint>
+#include <exception>
+#include <iostream>
+#include <utility>
+
+#include "lsst/utils/python.h"
+#include "lsst/pex/exceptions.h"
+
+#include "lsst/afw/typehandling/GenericMap.h"
+#include "lsst/afw/typehandling/python.h"
+
+namespace py = pybind11;
+using namespace py::literals;
+
+namespace lsst {
+namespace afw {
+namespace typehandling {
+
+namespace {
+
+// Type safety pointless in Python, use unsafe methods to avoid manual type checking
+// https://pybind11.readthedocs.io/en/stable/advanced/classes.html#binding-protected-member-functions
+template <typename K>
+class Publicist : public MutableGenericMap<K> {
+public:
+    using MutableGenericMap<K>::unsafeLookup;
+    using MutableGenericMap<K>::unsafeErase;
+};
+
+// This class lets us implement __getitem__ using GenericMap::unsafeLookup
+// Nonlocal class definition to let us use a method template for well-behaved types
+class VariantOneWayCaster {
+public:
+    template <typename T>
+    py::object operator()(T const& value) {
+        return py::cast(value);
+    }
+    // GenericMap::get returns the same reference, depend on RVP to avoid double-deletion
+    py::object operator()(std::unique_ptr<Storable> const& pointer) { return py::cast(*pointer); }
+};
+
+template <typename K>
+py::object get(GenericMap<K>& self, K const& key) {
+    auto callable = &Publicist<K>::unsafeLookup;
+    auto ref = (self.*callable)(key);
+    // Use visitor because py::type_caster for variant chokes on unique_ptr const&
+    py::object obj = boost::apply_visitor(VariantOneWayCaster(), ref);
+    return obj;
+};
+
+template <typename K>
+void declareGenericMap(utils::python::WrapperCollection& wrappers, std::string const& suffix,
+                       std::string const& key) {
+    using Class = GenericMap<K>;
+    using PyClass = py::class_<Class, std::shared_ptr<Class>>;
+
+    std::string className = "GenericMap" + suffix;
+    // Give the class a custom docstring to avoid confusing Python users
+    std::string docstring =
+            "An abstract `~collections.abc.Mapping` for use when sharing a map between C++ and Python.\n" +
+            declareGenericMapRestrictions(className, key);
+    wrappers.wrapType(PyClass(wrappers.module, className.c_str(), docstring.c_str()), [](auto& mod,
+                                                                                         auto& cls) {
+        // __str__ easier to implement in Python
+        // __repr__ easier to implement in Python
+        // __eq__ easier to implement in Python
+        // __ne__ easier to implement in Python
+        // For unknown reasons, overload_cast doesn't work
+        // cls.def("__contains__", py::overload_cast<K const&>(&Class::contains, py::const_), "key"_a);
+        cls.def("__contains__", static_cast<bool (Class::*)(K const&) const>(&Class::contains), "key"_a);
+
+        cls.def("__getitem__",
+                [](Class& self, K const& key) {
+                    try {
+                        return get(self, key);
+                    } catch (pex::exceptions::OutOfRangeError const& e) {
+                        // pybind11 doesn't seem to recognize chained exceptions
+                        std::stringstream buffer;
+                        buffer << "Unknown key: " << key;
+                        std::throw_with_nested(py::key_error(buffer.str()));
+                    }
+                },
+                // Prevent segfaults when assigning a key<Storable> to Python variable, then deleting from map
+                // No existing code depends on being able to modify an item stored by value
+                "key"_a, py::return_value_policy::copy);
+        cls.def("get",
+                [](Class& self, K const& key, py::object const& def) {
+                    try {
+                        return get(self, key);
+                    } catch (pex::exceptions::OutOfRangeError const& e) {
+                        return def;
+                    }
+                },
+                // Prevent segfaults when assigning a key<Storable> to Python variable, then deleting from map
+                // No existing code depends on being able to modify an item stored by value
+                "key"_a, "default"_a = py::none(), py::return_value_policy::copy);
+        // __iter__ easier to implement in Python
+        cls.def("__len__", &Class::size);
+        cls.def("__bool__", [](Class const& self) { return !self.empty(); });
+        cls.def("_keys", &Class::keys);  // Private to let a proper view be defined in Python
+        // keys easier to implement in Python
+        // items easier to implement in Python
+        // values easier to implement in Python
+    });
+}
+
+template <typename V, class PyClass>
+void declareMutableGenericMapTypedMethods(PyClass& cls) {
+    using Class = typename PyClass::type;
+    cls.def("__setitem__",
+            [](Class& self, typename Class::key_type const& key, V const& value) {
+                // Need to delete previous key, which may not be of type V
+                // TODO: this method provides only basic exception safety
+                if (self.contains(key)) {
+                    auto callable = &Publicist<typename Class::key_type>::unsafeErase;
+                    (self.*callable)(key);
+                }
+                self.insert(key, value);
+            },
+            "key"_a, "value"_a);
+    // setdefault easier to implement in Python
+    // pop easier to implement in Python
+}
+
+template <typename K>
+void declareMutableGenericMap(utils::python::WrapperCollection& wrappers, std::string const& suffix,
+                              std::string const& key) {
+    using Class = MutableGenericMap<K>;
+    using PyClass = py::class_<Class, std::shared_ptr<Class>, GenericMap<K>>;
+
+    std::string className = "MutableGenericMap" + suffix;
+    // Give the class a custom docstring to avoid confusing Python users
+    std::string docstring =
+            "An abstract `~collections.abc.MutableMapping` for use when sharing a map between C++ and "
+            "Python.\n" +
+            declareGenericMapRestrictions(className, key);
+    wrappers.wrapType(PyClass(wrappers.module, className.c_str(), docstring.c_str()),
+                      [](auto& mod, auto& cls) {
+                          // Don't rewrap members of GenericMap
+                          declareMutableGenericMapTypedMethods<std::shared_ptr<Storable>>(cls);
+                          declareMutableGenericMapTypedMethods<bool>(cls);
+                          declareMutableGenericMapTypedMethods<std::int32_t>(cls);
+                          declareMutableGenericMapTypedMethods<std::int64_t>(cls);
+                          declareMutableGenericMapTypedMethods<float>(cls);
+                          declareMutableGenericMapTypedMethods<double>(cls);
+                          declareMutableGenericMapTypedMethods<std::string>(cls);
+                          cls.def("__delitem__",
+                                  [](Class& self, K const& key) {
+                                      if (self.contains(key)) {
+                                          auto callable = &Publicist<K>::unsafeErase;
+                                          (self.*callable)(key);
+                                      } else {
+                                          std::stringstream buffer;
+                                          buffer << "Unknown key: " << key;
+                                          throw py::key_error(buffer.str());
+                                      }
+                                  },
+                                  "key"_a);
+                          cls.def("popitem", [](Class& self) {
+                              if (!self.empty()) {
+                                  K key = self.keys().back();
+                                  auto result = std::make_pair(key, get(self, key));
+                                  auto callable = &Publicist<K>::unsafeErase;
+                                  (self.*callable)(key);
+                                  return result;
+                              } else {
+                                  throw py::key_error("Cannot pop from empty GenericMap.");
+                              }
+                          });
+                          cls.def("clear", &Class::clear);
+                          // cls.def("update",, "other"_a);
+                      });
+}
+}  // namespace
+
+void wrapGenericMap(utils::python::WrapperCollection& wrappers) {
+    declareGenericMap<std::string>(wrappers, "S", "strings");
+    declareMutableGenericMap<std::string>(wrappers, "S", "strings");
+}
+
+}  // namespace typehandling
+}  // namespace afw
+}  // namespace lsst

--- a/python/lsst/afw/typehandling/_GenericMap.py
+++ b/python/lsst/afw/typehandling/_GenericMap.py
@@ -1,0 +1,79 @@
+# This file is part of afw.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = []
+
+from collections.abc import Mapping, MutableMapping
+
+from lsst.utils import continueClass
+from ._typehandling import GenericMapS, MutableGenericMapS
+
+Mapping.register(GenericMapS)
+
+@continueClass  # noqa F811
+class GenericMapS:
+    def __repr__(self):
+        className = type(self).__name__
+        return className + "({" + ", ".join("%r: %r" % (key, value) for key, value in self.items()) + "})"
+
+    def __iter__(self):
+        for key in self._keys():
+            yield key
+
+    # Support equality with any Mapping, including dict
+    # Not clear why Mapping.__eq__ doesn't work
+    def __eq__(self, other):
+        if len(self) != len(other):
+            return False
+
+        for key, value in self.items():
+            try:
+                if (value != other[key]):
+                    return False
+            except KeyError:
+                return False
+        return True
+
+    # Easier than making GenericMap actually inherit from Mapping
+    keys = Mapping.keys
+    values = Mapping.values
+    items = Mapping.items
+
+
+MutableMapping.register(MutableGenericMapS)
+
+@continueClass  # noqa F811
+class MutableGenericMapS:
+    # Easier than making MutableGenericMap actually inherit from MutableMapping
+    setdefault = MutableMapping.setdefault
+    update = MutableMapping.update
+
+    # MutableMapping.pop relies on implementation details of MutableMapping
+    def pop(self, key, default=None):
+        try:
+            value = self[key]
+            del self[key]
+            return value
+        except KeyError:
+            if default is not None:
+                return default
+            else:
+                raise

--- a/python/lsst/afw/typehandling/_SimpleGenericMap.cc
+++ b/python/lsst/afw/typehandling/_SimpleGenericMap.cc
@@ -1,0 +1,85 @@
+/*
+ * This file is part of afw.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <memory>
+
+#include "pybind11/pybind11.h"
+
+#include "lsst/utils/python.h"
+
+#include "lsst/afw/typehandling/SimpleGenericMap.h"
+#include "lsst/afw/typehandling/python.h"
+
+namespace py = pybind11;
+using namespace py::literals;
+
+namespace lsst {
+namespace afw {
+namespace typehandling {
+
+namespace {
+template <typename K>
+void declareSimpleGenericMap(utils::python::WrapperCollection& wrappers, std::string const& suffix,
+                             std::string const& key) {
+    using Class = SimpleGenericMap<K>;
+    using PyClass = py::class_<Class, std::shared_ptr<Class>, MutableGenericMap<K>>;
+
+    std::string className = "SimpleGenericMap" + suffix;
+    // Give the class a custom docstring to avoid confusing Python users
+    std::string docstring =
+            "A `dict`-like `~collections.abc.MutableMapping` for use when sharing a map between C++ and "
+            "Python.\n" +
+            declareGenericMapRestrictions(className, key) +
+            R"docstring(
+Parameters
+----------
+mapping : `collections.abc.Mapping`, optional
+iterable : iterable, optional
+**kwargs
+    A ``SimpleGenericMap`` takes the same input arguments as `dict`.
+)docstring";
+    wrappers.wrapType(PyClass(wrappers.module, className.c_str(), docstring.c_str()),
+                      [](auto& mod, auto& cls) {
+                          // Don't rewrap members of MutableGenericMap
+
+                          /* need __init__(**kw), __init__(mapping, **kw), __init__(iterable, **kw)
+                           * can't find a good way to insert a py::handle value from C++
+                           * can't call MutableGenericMap.__setitem__ without its class_ object, which
+                           *    is in a different pybind11 module but can't be imported (yet)
+                           */
+                          cls.def(py::init<>());
+                          cls.def("copy", [](Class const& self) { return Class(self); });
+
+                          // fromkeys easier to implement in Python
+                      });
+}
+
+}  // namespace
+
+void wrapSimpleGenericMap(utils::python::WrapperCollection& wrappers) {
+    declareSimpleGenericMap<std::string>(wrappers, "S", "strings");
+}
+
+}  // namespace typehandling
+}  // namespace afw
+}  // namespace lsst

--- a/python/lsst/afw/typehandling/_SimpleGenericMap.py
+++ b/python/lsst/afw/typehandling/_SimpleGenericMap.py
@@ -19,6 +19,27 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from ._typehandling import *
-from ._GenericMap import *
-from ._SimpleGenericMap import *
+__all__ = []
+
+from lsst.utils import continueClass
+from ._typehandling import SimpleGenericMapS
+
+
+# pybind11-generated constructor, can only create empty map
+_oldInit = SimpleGenericMapS.__init__
+
+
+@continueClass  # noqa F811
+class SimpleGenericMapS:
+    def __init__(self, source=None, **kwargs):
+        _oldInit(self)
+        if source:
+            self.update(source, **kwargs)
+        else:
+            self.update(**kwargs)
+
+    @classmethod
+    def fromkeys(cls, iterable, value=None):
+        mapping = cls()
+        mapping.update({key: value for key in iterable})
+        return mapping

--- a/python/lsst/afw/typehandling/_Storable.cc
+++ b/python/lsst/afw/typehandling/_Storable.cc
@@ -1,0 +1,61 @@
+/*
+ * This file is part of afw.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "pybind11/pybind11.h"
+
+#include "lsst/utils/python.h"
+
+#include "lsst/afw/typehandling/Storable.h"
+#include "lsst/afw/typehandling/python.h"
+
+namespace py = pybind11;
+using namespace py::literals;
+
+namespace lsst {
+namespace afw {
+namespace typehandling {
+
+using PyStorable = py::class_<Storable, std::shared_ptr<Storable>, table::io::Persistable, StorableHelper<>>;
+
+void wrapStorable(utils::python::WrapperCollection& wrappers) {
+    wrappers.addSignatureDependency("lsst.pex.exceptions");
+    wrappers.addInheritanceDependency("lsst.afw.table.io");
+
+    wrappers.wrapException<UnsupportedOperationException, pex::exceptions::RuntimeError>(
+            "UnsupportedOperationException", "RuntimeError");
+    wrappers.wrapType(PyStorable(wrappers.module, "Storable"), [](auto& mod, auto& cls) {
+        // Do not wrap methods inherited from Persistable
+        cls.def(py::init<>());  // Dummy constructor for pure-Python subclasses
+        cls.def("__copy__", &Storable::clone);
+        cls.def("__deepcopy__", [](Storable const& self, py::dict const& memo) { return self.clone(); },
+                "memo"_a = py::none());
+        cls.def("__repr__", &Storable::toString);
+        cls.def("__hash__", &Storable::hash_value);
+        cls.def("__eq__", [](Storable const& self, Storable const& other) { return self.equals(other); },
+                "other"_a);
+    });
+}
+
+}  // namespace typehandling
+}  // namespace afw
+}  // namespace lsst

--- a/python/lsst/afw/typehandling/__init__.py
+++ b/python/lsst/afw/typehandling/__init__.py
@@ -1,0 +1,22 @@
+# This file is part of afw.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from ._typehandling import *

--- a/python/lsst/afw/typehandling/_typehandling.cc
+++ b/python/lsst/afw/typehandling/_typehandling.cc
@@ -1,0 +1,47 @@
+/*
+ * This file is part of afw.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "pybind11/pybind11.h"
+
+#include "lsst/utils/python.h"
+
+namespace py = pybind11;
+using namespace pybind11::literals;
+
+namespace lsst {
+namespace afw {
+namespace typehandling {
+
+using utils::python::WrapperCollection;
+
+void wrapStorable(utils::python::WrapperCollection& wrappers);
+
+PYBIND11_MODULE(_typehandling, mod) {
+    WrapperCollection w(mod, "lsst.afw.typehandling");
+    wrapStorable(w);
+    w.finish();
+}
+
+}  // namespace typehandling
+}  // namespace afw
+}  // namespace lsst

--- a/python/lsst/afw/typehandling/testUtils.py
+++ b/python/lsst/afw/typehandling/testUtils.py
@@ -1,0 +1,752 @@
+# This file is part of afw.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = []
+
+from collections import Counter
+
+import numpy as np
+
+import lsst.utils.tests
+
+from lsst.afw.typehandling import Storable
+
+
+class GenericMapTestBaseClass(lsst.utils.tests.TestCase):
+    """Base class for unit tests of GenericMap.
+
+    Subclasses must call `GenericMapTestBaseClass.setUp(self)`
+    if they provide their own version.
+
+    This class is not *quite* a generic Mapping testbed, because it assumes
+    that the map being tested only accepts keys of a particular type.
+    """
+
+    class SimpleStorable(Storable):
+        """A subclass of Storable for testing purposes.
+        """
+        def __repr__(self):
+            return "Simplest possible representation"
+
+        def __hash__(self):
+            return 100
+
+        def __eq__(self, other):
+            """Warning: violates both  substitution and equality symmetry!
+            """
+            return self.__class__ == other.__class__
+
+    class ComplexStorable(SimpleStorable):
+        """A subclass of Storable for testing purposes.
+        """
+        def __init__(self, storage):
+            super().__init__()
+            self._storage = storage
+
+        def __repr__(self):
+            return "ComplexStorable(%r)" % self._storage
+
+        def __hash__(self):
+            return hash(self._storage)
+
+        def __eq__(self, other):
+            """Warning: violates both substitution and equality symmetry!
+            """
+            if self.__class__ == other.__class__:
+                return self._storage == other._storage
+            else:
+                return False
+
+    class NotAStorable:
+        """A class that should not be a legal value in a GenericMap.
+        """
+        def __str__(self):
+            return "Non-Storable"
+
+    _testData = {
+        0: True,
+        1: 42,
+        2: 42.0,
+        3: "How many roads must a man walk down?",
+        4: SimpleStorable(),
+        5: ComplexStorable(-100.0),
+        6: None,
+    }
+
+    @classmethod
+    def getTestData(cls, keyClass):
+        """Generic dataset for testing GenericMap classes that can handle it.
+
+        Parameters
+        ----------
+        keyClass : `type`
+            The type of key expected by the GenericMap.
+        """
+        return {keyClass(key): value for key, value in cls._testData.items()}
+
+    def setUp(self):
+        """Set up a test
+
+        Subclasses must call this method if they override setUp.
+        """
+        super().setUp()
+        # tell unittest to use the msg argument of asserts as a supplement
+        # to the error message, rather than as the whole error message
+        self.longMessage = True
+
+    # Mapping must have:
+    #   __str__
+    #   __repr__
+    #   __eq__
+    #   __ne__
+    #   __contains__
+    #   __getitem__
+    #   get
+    #   __iter__
+    #   __len__
+    #   __bool__
+    #   keys
+    #   items
+    #   values
+
+    def checkInitMapping(self, keyType, mapClass, contents, msg=""):
+        """Check initialization from a mapping.
+
+        Parameters
+        ----------
+        keyType : `type`
+            The type of key allowed by ``mapClass``.
+        mapClass : `lsst.afw.typehandling.GenericMap`-type
+            The class whose ``__init__`` method will be tested.
+        contents : `Mapping`
+            The key-value pairs to insert into the map
+        msg : `str`
+            Error message suffix describing test parameters
+        """
+        genericMap = mapClass(contents)
+        self.checkContents(keyType, genericMap, contents, msg=msg)
+
+        extraContents = {key: value for key, value in contents.items()}  # contents need not define copy()
+        extraKey = keyType(101)
+        extraValue = 'Extra value'
+        extraContents[extraKey] = extraValue
+        genericMap = mapClass(contents, **{keyType(101): extraValue})
+        self.checkContents(keyType, genericMap, extraContents, msg=msg)
+
+        with self.assertRaises(TypeError, msg=msg):
+            mapClass({keyType(0): GenericMapTestBaseClass.NotAStorable()})
+
+    def checkInitPairs(self, keyType, mapClass, contents, msg=""):
+        """Check initialization from an iterable of pairs.
+
+        Parameters
+        ----------
+        keyType : `type`
+            The type of key allowed by ``mapClass``.
+        mapClass: `lsst.afw.typehandling.GenericMap`-type
+            The class whose ``__init__`` method will be tested.
+        contents : `Mapping`
+            The key-value pairs to insert into the map
+        msg : `str`
+            Error message suffix describing test parameters
+        """
+        genericMap = mapClass(contents.items())
+        self.checkContents(keyType, genericMap, contents, msg=msg)
+
+        extraContents = {key: value for key, value in contents.items()}  # contents need not define copy()
+        extraKey = keyType(101)
+        extraValue = 'Extra value'
+        extraContents[extraKey] = extraValue
+        genericMap = mapClass(contents.items(), **{keyType(101): extraValue})
+        self.checkContents(keyType, genericMap, extraContents, msg=msg)
+
+        with self.assertRaises(TypeError, msg=msg):
+            mapClass([(keyType(0), GenericMapTestBaseClass.NotAStorable())])
+
+    def checkInitKwargs(self, mapClass, contents, msg=""):
+        """Check bulk insertion from keywords into a GenericMap.
+
+        Parameters
+        ----------
+        mapClass: `lsst.afw.typehandling.GenericMapS`-type
+            The class whose ``__init__`` method will be tested.
+            Must allow string keys.
+        contents : `Mapping`
+            The key-value pairs to insert into the map
+        msg : `str`
+            Error message suffix describing test parameters
+        """
+        genericMap = mapClass(**contents)
+        self.checkContents(str, genericMap, contents, msg=msg)
+
+        with self.assertRaises(TypeError, msg=msg):
+            mapClass(notAKey=GenericMapTestBaseClass.NotAStorable())
+
+    def checkFromKeysDefault(self, keyType, mapClass, keys, msg=""):
+        """Check initialization using the ``fromkeys`` factory.
+
+        Unlike `checkFromKeys`, this method lets ``fromkeys`` use its default
+        value (which may give different behavior, in nonconforming
+        implementations, from explicitly passing `None`).
+
+        Parameters
+        ----------
+        keyType : `type`
+            The type of key allowed by ``mapClass``.
+        mapClass: `lsst.afw.typehandling.GenericMap`-type
+            The class whose ``fromkeys`` method will be tested.
+        keys : `iterable`
+            The keys to insert into the map.
+        msg : `str`
+            Error message suffix describing test parameters
+        """
+        genericMap = mapClass.fromkeys(keys)
+        self.assertIsInstance(genericMap, mapClass, msg=msg)
+        self.checkContents(keyType, genericMap, dict.fromkeys(keys), msg=msg)
+
+    def checkFromKeys(self, keyType, mapClass, keys, value, msg=""):
+        """Check initialization using the ``fromkeys`` factory.
+
+        Parameters
+        ----------
+        keyType : `type`
+            The type of key allowed by ``mapClass``.
+        mapClass: `lsst.afw.typehandling.GenericMap`-type
+            The class whose ``fromkeys`` method will be tested.
+        keys : `iterable`
+            The keys to insert into the map.
+        value
+            A legal value for a GenericMap.
+        msg : `str`
+            Error message suffix describing test parameters
+        """
+        genericMap = mapClass.fromkeys(keys, value)
+        self.assertIsInstance(genericMap, mapClass, msg=msg)
+        self.checkContents(keyType, genericMap, dict.fromkeys(keys, value), msg=msg)
+
+    def checkContains(self, keyType, genericMap, contents, msg=""):
+        """Check the contents of a GenericMap.
+
+        Parameters
+        ----------
+        keyType : `type`
+            The type of key allowed by ``mapClass``.
+        genericMap : `lsst.afw.typehandling.GenericMap`
+            The map to test.
+        contents : `Mapping`
+            The key-value pairs that should be present in ``genericMap``
+        msg : `str`
+            Error message suffix describing test parameters
+        """
+        for key in contents:
+            self.assertIn(key, genericMap, msg=msg)
+
+        for key in range(30):
+            if keyType(key) not in contents:
+                self.assertNotIn(keyType(key), genericMap, msg=msg)
+
+        wrongType = float if keyType is not float else int
+        with self.assertRaises(TypeError):
+            wrongType(0) in genericMap
+
+    def checkContents(self, keyType, genericMap, contents, msg=""):
+        """Check the contents of a GenericMap.
+
+        Parameters
+        ----------
+        keyType : `type`
+            The type of key allowed by ``mapClass``.
+        genericMap : `lsst.afw.typehandling.GenericMap`
+            The map to test.
+        contents : `Mapping`
+            The key-value pairs that should be present in ``genericMap``
+        msg : `str`
+            Error message suffix describing test parameters
+        """
+        for key, value in contents.items():
+            self.assertEqual(genericMap[key], value, msg=msg)
+
+        for key in (keyType(key) for key in range(30) if keyType(key) not in contents):
+            with self.assertRaises(KeyError, msg=msg):
+                genericMap[key]
+
+        wrongType = float if keyType is not float else int
+        with self.assertRaises(TypeError):
+            genericMap[wrongType(0)]
+
+    def checkGet(self, keyType, genericMap, contents, msg=""):
+        """Check that GenericMap.get works correctly.
+
+        Parameters
+        ----------
+        keyType : `type`
+            The type of key allowed by ``mapClass``.
+        genericMap : `lsst.afw.typehandling.GenericMap`
+            The map to test.
+        contents : `Mapping`
+            The key-value pairs that should be present in ``genericMap``
+        msg : `str`
+            Error message suffix describing test parameters
+        """
+        default = "Not a default value"
+        for key, value in contents.items():
+            self.assertEqual(genericMap.get(key), value, msg=msg)
+            self.assertEqual(genericMap.get(key, default), value, msg=msg)
+
+        for key in (keyType(key) for key in range(30) if keyType(key) not in contents):
+            self.assertEqual(genericMap.get(key), None, msg=msg)
+            self.assertEqual(genericMap.get(key, default), default, msg=msg)
+
+        wrongType = float if keyType is not float else int
+        with self.assertRaises(TypeError):
+            genericMap.get(wrongType(0))
+
+    def checkIteration(self, genericMap, contents, msg=""):
+        """Check the result of iterating over a GenericMap.
+
+        Parameters
+        ----------
+        genericMap : `lsst.afw.typehandling.GenericMap`
+            The map to test.
+        contents : `Mapping`
+            The key-value pairs that should be present in ``genericMap``
+        msg : `str`
+            Error message suffix describing test parameters
+        """
+        self.assertEqual({key: genericMap[key] for key in genericMap}, dict(contents), msg=msg)
+
+    def checkViews(self, genericMap, contents, msg=""):
+        """Check the views provided by a GenericMap.
+
+        Parameters
+        ----------
+        genericMap : `lsst.afw.typehandling.GenericMap`
+            The map to test.
+        contents : `Mapping`
+            The key-value pairs that should be present in ``genericMap``
+        msg : `str`
+            Error message suffix describing test parameters
+        """
+        self.assertEqual(set(genericMap.keys()), set(contents.keys()), msg=msg)
+        self.assertEqual(Counter(genericMap.values()), Counter(contents.values()), msg=msg)
+        self.assertEqual(Counter(genericMap.items()), Counter(contents.items()), msg=msg)
+
+
+class MutableGenericMapTestBaseClass(GenericMapTestBaseClass):
+    """Base class for unit tests of GenericMap that allow insertion/deletion.
+
+    Subclasses must call `MutableGenericMapTestBaseClass.setUp(self)`
+    if they provide their own version.
+    """
+
+    @classmethod
+    def _fillMap(cls, mapFactory, contents):
+        """Create a new GenericMap with particular contents.
+
+        Parameters
+        ----------
+        mapFactory : callable
+            A zero-argument callable that creates an empty
+            `lsst.afw.typehandling.GenericMap` object
+        contents : `Mapping`
+            The key-value pairs that should be present in the new map.
+
+        Returns
+        -------
+        map : `lsst.afw.typehandling.GenericMap`
+            a GenericMap equivalent to ``contents``
+        """
+        return cls._fillPartialMap(mapFactory, contents, len(contents))
+
+    @classmethod
+    def _fillPartialMap(cls, mapFactory, contents, numElements):
+        """Create a new GenericMap with particular contents.
+
+        Parameters
+        ----------
+        mapFactory : callable
+            A zero-argument callable that creates an empty
+            `lsst.afw.typehandling.GenericMap` object
+        contents : `Mapping`
+            The key-value pairs that should be present in the new map.
+        numElements : `int`
+            The number of elements from ``contents`` to be inserted.
+
+        Returns
+        -------
+        map : `lsst.afw.typehandling.GenericMap`
+            a GenericMap containing ``numElements`` of ``contents`` or all of
+            ``contents``, whichever is smaller
+        """
+        newMap = mapFactory()
+        for i, (key, value) in enumerate(contents.items()):
+            if i < numElements:
+                newMap[key] = value
+            else:
+                break
+        return newMap
+
+    # MutableMapping must have:
+    #   __setitem__
+    #   setdefault
+    #   __delitem__
+    #   pop
+    #   popitem
+    #   clear
+    #   update
+
+    def checkInsertItem(self, keyType, mapFactory, contents, msg=""):
+        """Check element insertion in a GenericMap.
+
+        Parameters
+        ----------
+        keyType : `type`
+            The type of key allowed by ``mapClass``.
+        mapFactory : callable
+            A zero-argument callable that creates an empty
+            `lsst.afw.typehandling.GenericMap` object of the type to be tested
+        contents : `Mapping`
+            The key-value pairs to insert into the map
+        msg : `str`
+            Error message suffix describing test parameters
+        """
+        genericMap = mapFactory()
+
+        for length, (key, value) in enumerate(contents.items()):
+            loopMsg = msg + " Inserting %r=%r" % (key, value)
+            genericMap[key] = value
+            self.assertEqual(len(genericMap), length+1, msg=loopMsg)
+            self.assertEqual(genericMap[key], value, msg=loopMsg)
+
+        self.assertEqual(dict(genericMap), dict(contents), msg=msg)
+
+        with self.assertRaises(TypeError, msg=msg):
+            genericMap[keyType(0)] = GenericMapTestBaseClass.NotAStorable()
+
+        wrongType = float if keyType is not float else int
+        with self.assertRaises(TypeError):
+            genericMap[wrongType(0)] = 0
+
+    def checkSetdefault(self, keyType, mapFactory, contents, msg=""):
+        """Check that GenericMap.setdefault works correctly.
+
+        Parameters
+        ----------
+        keyType : `type`
+            The type of key allowed by ``mapClass``.
+        mapFactory : callable
+            A zero-argument callable that creates an empty
+            `lsst.afw.typehandling.GenericMap` object of the type to be tested
+        contents : `Mapping`
+            The key-value pairs to insert into the map
+        msg : `str`
+            Error message suffix describing test parameters
+        """
+        genericMap = mapFactory()
+
+        result = genericMap.setdefault(keyType(0))
+        self.assertEqual(len(genericMap), 1, msg=msg)
+        self.assertIsNone(result, msg=msg)
+        self.assertIsNone(genericMap[keyType(0)], msg=msg)
+        del genericMap[keyType(0)]
+
+        default = "This is a default"
+        for length, (key, _) in enumerate(contents.items()):
+            loopMsg = msg + " Defaulting %r" % (key)
+            result = genericMap.setdefault(key, default)
+            self.assertEqual(len(genericMap), length+1, msg=loopMsg)
+            self.assertEqual(result, default, msg=loopMsg)
+            self.assertEqual(genericMap[key], default, msg=loopMsg)
+
+        self.assertEqual(genericMap.keys(), contents.keys(), msg=msg)
+
+        with self.assertRaises(TypeError, msg=msg):
+            genericMap.setdefault(keyType(100), GenericMapTestBaseClass.NotAStorable())
+
+        wrongType = float if keyType is not float else int
+        with self.assertRaises(TypeError):
+            genericMap.setdefault(wrongType(0), default)
+
+        genericMap = self._fillMap(mapFactory, contents)
+        for length, (key, value) in enumerate(contents.items()):
+            loopMsg = msg + " Defaulting existing %r=%r" % (key, value)
+            result = genericMap.setdefault(key, default)
+            self.assertEqual(len(genericMap), len(contents), msg=loopMsg)
+            self.assertEqual(result, contents[key], msg=loopMsg)
+            self.assertEqual(genericMap[key], contents[key], msg=loopMsg)
+
+    def checkUpdateMapping(self, keyType, mapFactory, contents, msg=""):
+        """Check bulk insertion from a mapping into a GenericMap.
+
+        Parameters
+        ----------
+        keyType : `type`
+            The type of key allowed by ``mapClass``.
+        mapFactory : callable
+            A zero-argument callable that creates an empty
+            `lsst.afw.typehandling.GenericMap` object of the type to be tested
+        contents : `Mapping`
+            The key-value pairs to insert into the map
+        msg : `str`
+            Error message suffix describing test parameters
+        """
+        genericMap = self._fillPartialMap(mapFactory, dict.fromkeys(contents, 0), len(contents)/2)
+        self.assertLess(len(genericMap), len(contents), msg=msg)
+
+        genericMap.update(contents)
+        self.assertEqual(dict(genericMap), dict(contents), msg=msg)
+
+        with self.assertRaises(TypeError, msg=msg):
+            genericMap.update({keyType(0): GenericMapTestBaseClass.NotAStorable()})
+
+        wrongType = float if keyType is not float else int
+        with self.assertRaises(TypeError, msg=msg):
+            genericMap.update({wrongType(0): 0})
+
+    def checkUpdatePairs(self, keyType, mapFactory, contents, msg=""):
+        """Check bulk insertion from an iterable of pairs into a GenericMap.
+
+        Parameters
+        ----------
+        keyType : `type`
+            The type of key allowed by ``mapClass``.
+        mapFactory : callable
+            A zero-argument callable that creates an empty
+            `lsst.afw.typehandling.GenericMap` object of the type to be tested
+        contents : `Mapping`
+            The key-value pairs to insert into the map
+        msg : `str`
+            Error message suffix describing test parameters
+        """
+        genericMap = self._fillPartialMap(mapFactory, dict.fromkeys(contents, 0), len(contents)/2)
+        self.assertLess(len(genericMap), len(contents), msg=msg)
+
+        genericMap.update(contents.items())
+        self.assertEqual(dict(genericMap), dict(contents), msg=msg)
+
+        with self.assertRaises(TypeError, msg=msg):
+            genericMap.update([(keyType(0), GenericMapTestBaseClass.NotAStorable())])
+
+        wrongType = float if keyType is not float else int
+        with self.assertRaises(TypeError, msg=msg):
+            genericMap.update([(wrongType(0), 0)])
+
+    def checkUpdateKwargs(self, mapFactory, contents, msg=""):
+        """Check bulk insertion from keywords into a GenericMap.
+
+        Parameters
+        ----------
+        keyType : `type`
+            The type of key allowed by ``mapClass``.
+        mapFactory : callable
+            A zero-argument callable that creates an empty
+            `lsst.afw.typehandling.GenericMap` object of the type to be tested
+            Must allow string keys.
+        contents : `Mapping`
+            The key-value pairs to insert into the map
+        msg : `str`
+            Error message suffix describing test parameters
+        """
+        genericMap = self._fillPartialMap(mapFactory, dict.fromkeys(contents, 0), len(contents)/2)
+        self.assertLess(len(genericMap), len(contents), msg=msg)
+
+        genericMap.update(**contents)
+        self.assertEqual(dict(genericMap), dict(contents), msg=msg)
+
+        with self.assertRaises(TypeError, msg=msg):
+            genericMap.update(notAKey=GenericMapTestBaseClass.NotAStorable())
+
+    def checkReplaceItem(self, keyType, genericMap, msg=""):
+        """Check element replacement in a GenericMap.
+
+        Parameters
+        ----------
+        keyType : `type`
+            The type of key allowed by ``mapClass``.
+        genericMap : `lsst.afw.typehandling.GenericMap`
+            The map to test. Must be empty.
+        msg : `str`
+            Error message suffix describing test parameters
+        """
+        self.assertFalse(genericMap, msg=msg)
+        key = keyType(42)
+
+        for value in self.getTestData(keyType).values():
+            loopMsg = msg + " Inserting %r=%r" % (key, value)
+            genericMap[key] = value  # value may be of a different type
+            self.assertEqual(len(genericMap), 1, msg=loopMsg)
+            self.assertEqual(genericMap[key], value, msg=loopMsg)
+
+        self.assertEqual(dict(genericMap), {key: value}, msg=msg)
+
+        with self.assertRaises(TypeError, msg=msg):
+            genericMap[key] = GenericMapTestBaseClass.NotAStorable()
+
+    def checkRemoveItem(self, keyType, mapFactory, contents, msg=""):
+        """Check element removal from a GenericMap.
+
+        Parameters
+        ----------
+        keyType : `type`
+            The type of key allowed by ``mapClass``.
+        mapFactory : callable
+            A zero-argument callable that creates an empty
+            `lsst.afw.typehandling.GenericMap` object of the type to be tested
+        contents : `Mapping`
+            The key-value pairs initially occupying the map
+        msg : `str`
+            Error message suffix describing test parameters
+        """
+        genericMap = self._fillMap(mapFactory, contents)
+
+        with self.assertRaises(KeyError, msg=msg):
+            del genericMap[keyType(2019)]
+
+        keysToRemove = list(contents.keys())
+        np.random.shuffle(keysToRemove)
+        for numPrevious, rawKey in enumerate(keysToRemove):
+            key = keyType(rawKey)
+            loopMsg = msg + " Deleting %r" % (key)
+            del genericMap[key]
+            self.assertEqual(len(genericMap), len(contents)-numPrevious-1, msg=loopMsg)
+            self.assertNotIn(key, genericMap, msg=loopMsg)
+
+        wrongType = float if keyType is not float else int
+        with self.assertRaises(TypeError):
+            del genericMap[wrongType(0)]
+
+    def checkPop(self, keyType, mapFactory, contents, msg=""):
+        """Check that GenericMap.pop works correctly.
+
+        Parameters
+        ----------
+        keyType : `type`
+            The type of key allowed by ``mapClass``.
+        mapFactory : callable
+            A zero-argument callable that creates an empty
+            `lsst.afw.typehandling.GenericMap` object of the type to be tested
+        contents : `Mapping`
+            The key-value pairs initially occupying the map
+        msg : `str`
+            Error message suffix describing test parameters
+        """
+        genericMap = self._fillMap(mapFactory, contents)
+
+        with self.assertRaises(KeyError, msg=msg):
+            genericMap.pop(keyType(2019))
+
+        default = "This is a default"
+        result = genericMap.pop(keyType(2019), default)
+        self.assertEqual(dict(genericMap), dict(contents), msg=msg)
+        self.assertEqual(result, default)
+
+        wrongType = float if keyType is not float else int
+        with self.assertRaises(TypeError):
+            genericMap.pop(wrongType(0))
+
+        itemsToRemove = list(contents.items())
+        np.random.shuffle(itemsToRemove)
+        for numPrevious, (rawKey, value) in enumerate(itemsToRemove):
+            key = keyType(rawKey)
+            loopMsg = msg + " Popping %r=%r" % (key, value)
+            result = genericMap.pop(key)
+            self.assertEqual(len(genericMap), len(contents)-numPrevious-1, msg=loopMsg)
+            self.assertNotIn(key, genericMap, msg=loopMsg)
+            self.assertEqual(result, value, msg=loopMsg)
+
+    def checkPopitem(self, mapFactory, contents, msg=""):
+        """Check that GenericMap.popitem works correctly.
+
+        Parameters
+        ----------
+        mapFactory : callable
+            A zero-argument callable that creates an empty
+            `lsst.afw.typehandling.GenericMap` object of the type to be tested
+        contents : `Mapping`
+            The key-value pairs initially occupying the map
+        msg : `str`
+            Error message suffix describing test parameters
+        """
+        genericMap = self._fillMap(mapFactory, contents)
+
+        for numPrevious in range(len(genericMap)):
+            key, value = genericMap.popitem()
+            loopMsg = msg + " Popping %r=%r" % (key, value)
+            self.assertIn((key, value), contents.items(), msg=loopMsg)
+            self.assertEqual(len(genericMap), len(contents)-numPrevious-1, msg=loopMsg)
+            self.assertNotIn(key, genericMap, msg=loopMsg)
+
+        with self.assertRaises(KeyError, msg=msg):
+            genericMap.popitem()
+
+    def checkClear(self, mapFactory, contents, msg=""):
+        """Check erasing a GenericMap.
+
+        Parameters
+        ----------
+        mapFactory : callable
+            A zero-argument callable that creates an empty
+            `lsst.afw.typehandling.GenericMap` object of the type to be tested
+        contents : `Mapping`
+            The key-value pairs initially occupying the map
+        msg : `str`
+            Error message suffix describing test parameters
+        """
+        genericMap = self._fillMap(mapFactory, contents)
+        self.assertTrue(genericMap, msg=msg)
+
+        genericMap.clear()
+        self.assertFalse(genericMap, msg=msg)
+        self.assertEqual(len(genericMap), 0, msg=msg)
+        for key in genericMap:
+            self.fail("Unexpected key: %s" % key, msg=msg)
+
+    def checkMutableViews(self, mapFactory, contents, msg=""):
+        """Check that the views of a GenericMap update automatically.
+
+        This test supersedes `GenericMapTestBaseClass.checkViews`.
+
+        Parameters
+        ----------
+        genericMap : `lsst.afw.typehandling.GenericMap`
+            The map to test.
+        contents : `Mapping`
+            The key-value pairs that should be present in ``genericMap``
+        msg : `str`
+            Error message suffix describing test parameters
+        """
+        genericMap = mapFactory()
+        keyView = genericMap.keys()
+        valueView = genericMap.values()
+        itemView = genericMap.items()
+
+        for view in (keyView, valueView, itemView):
+            self.assertEqual(len(view), len(genericMap), msg=msg)
+        # is initial state correct?
+        self.checkViews(genericMap, {}, msg)
+
+        for key, value in contents.items():
+            genericMap[key] = value
+
+        for view in (keyView, valueView, itemView):
+            self.assertEqual(len(view), len(genericMap), msg=msg)
+        # is final state correct?
+        self.checkViews(genericMap, contents, msg)

--- a/src/typehandling/PolymorphicValue.cc
+++ b/src/typehandling/PolymorphicValue.cc
@@ -1,0 +1,86 @@
+// -*- LSST-C++ -*-
+/*
+ * This file is part of afw.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "lsst/pex/exceptions.h"
+
+#include "lsst/afw/typehandling/PolymorphicValue.h"
+
+namespace lsst {
+namespace afw {
+namespace typehandling {
+
+PolymorphicValue::PolymorphicValue(Storable const& value) : _value(value.clone()) {}
+// No move-constructor, because putting a pointer to Storable&& into a
+// unique_ptr is safe only if the object was dynamically allocated
+
+PolymorphicValue::~PolymorphicValue() noexcept = default;
+
+PolymorphicValue::PolymorphicValue(PolymorphicValue const& other)
+        : _value(other._value ? other._value->clone() : std::unique_ptr<Storable>()) {}
+PolymorphicValue::PolymorphicValue(PolymorphicValue&&) = default;  // other._value emptied
+
+PolymorphicValue& PolymorphicValue::operator=(PolymorphicValue const& other) {
+    if (other._value) {
+        _value = other._value->clone();
+    } else {
+        _value.reset();
+    }
+    return *this;
+}
+PolymorphicValue& PolymorphicValue::operator=(PolymorphicValue&& other) {
+    using std::swap;
+    swap(_value, other._value);
+    return *this;
+}
+
+bool PolymorphicValue::empty() const noexcept { return !_value; }
+
+PolymorphicValue::operator Storable&() { return get(); }
+PolymorphicValue::operator Storable const&() const { return get(); }
+Storable& PolymorphicValue::get() {
+    // Both casts are safe; see Effective C++, Item 3
+    return const_cast<Storable&>(static_cast<PolymorphicValue const&>(*this).get());
+}
+Storable const& PolymorphicValue::get() const {
+    if (_value) {
+        return *_value;
+    } else {
+        throw LSST_EXCEPT(pex::exceptions::LogicError, "Dereferenced empty PolymorphicValue.");
+    }
+}
+
+bool PolymorphicValue::operator==(PolymorphicValue const& other) const noexcept {
+    if (!empty() && !other.empty()) {
+        return get().equals(other.get());
+    } else {
+        // At least one pointer is null; pointer comparison has desired behavior
+        return _value == other._value;
+    }
+}
+
+std::size_t PolymorphicValue::hash_value() const { return std::hash<Storable>()(get()); }
+
+}  // namespace typehandling
+}  // namespace afw
+}  // namespace lsst

--- a/src/typehandling/python.cc
+++ b/src/typehandling/python.cc
@@ -21,29 +21,32 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "pybind11/pybind11.h"
+#include <string>
 
-#include "lsst/utils/python.h"
-
-namespace py = pybind11;
-using namespace pybind11::literals;
+#include "lsst/afw/typehandling/python.h"
 
 namespace lsst {
 namespace afw {
 namespace typehandling {
 
-using utils::python::WrapperCollection;
+std::string declareGenericMapRestrictions(std::string const& className, std::string const& keyName) {
+    // Give the class a custom docstring to avoid confusing Python users
+    std::string docstring = R"docstring(
+For compatibility with C++, ``)docstring" +
+                            className + R"docstring(`` has the following restrictions:
+    - all keys must be )docstring" + keyName +
+                            R"docstring(
+    - values must be built-in types or subclasses of `lsst.afw.typehandling.Storable`.
+      Almost any user-defined class in C++ or Python can have
+      `~lsst.afw.typehandling.Storable` as a mixin.
 
-void wrapGenericMap(utils::python::WrapperCollection& wrappers);
-void wrapStorable(utils::python::WrapperCollection& wrappers);
-void wrapSimpleGenericMap(utils::python::WrapperCollection& wrappers);
-
-PYBIND11_MODULE(_typehandling, mod) {
-    WrapperCollection w(mod, "lsst.afw.typehandling");
-    wrapStorable(w);
-    wrapGenericMap(w);
-    wrapSimpleGenericMap(w);
-    w.finish();
+As a safety precaution, `~lsst.afw.typehandling.Storable` objects that are
+added from C++ may be copied when you retrieve them from Python, making it
+impossible to modify them in-place. This issue does not affect objects that
+are added from Python, or objects that are always passed by
+:cpp:class:`shared_ptr` in C++.
+)docstring";
+    return docstring;
 }
 
 }  // namespace typehandling

--- a/tests/test_Storable.py
+++ b/tests/test_Storable.py
@@ -1,0 +1,133 @@
+# This file is part of afw.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import copy
+import unittest
+
+import lsst.utils.tests
+
+from lsst.afw.typehandling import Storable, UnsupportedOperationException
+
+
+class PointlessStorable(Storable):
+    """Test of default behavior of Storable.
+    """
+    pass
+
+
+class PointyStorable(Storable):
+    """Test that we can inherit from Storable in Python.
+    """
+    def __init__(self, state):
+        super().__init__()
+        self._state = state
+
+    def __str__(self):
+        return "value = %s" % self._state
+
+    def __repr__(self):
+        return "PointyStorable(%r)" % self._state
+
+    def __hash__(self):
+        return hash(self._state)
+
+    def __copy__(self):
+        return PointyStorable(self._state)
+
+    def __deepcopy__(self, memo=None):
+        return PointyStorable(copy.deepcopy(self._state, memo))
+
+    def __eq__(self, other):
+        return self._state == other._state
+
+
+class StorableTestSuite(lsst.utils.tests.TestCase):
+
+    def setUp(self):
+        self.testbed = PointlessStorable()
+
+    def testCopy(self):
+        with self.assertRaises(UnsupportedOperationException):
+            copy.copy(self.testbed)
+        with self.assertRaises(UnsupportedOperationException):
+            copy.deepcopy(self.testbed)
+
+    def testStr(self):
+        with self.assertRaises(UnsupportedOperationException):
+            str(self.testbed)
+
+    def testRepr(self):
+        with self.assertRaises(UnsupportedOperationException):
+            repr(self.testbed)
+
+    def testHash(self):
+        with self.assertRaises(UnsupportedOperationException):
+            hash(self.testbed)
+
+    def testEq(self):
+        self.assertNotEqual(self.testbed, PointlessStorable())
+
+
+class PointyStorableTestSuite(lsst.utils.tests.TestCase):
+
+    def setUp(self):
+        self.aList = [42]
+        self.testbed = PointyStorable(self.aList)
+
+    def testCopy(self):
+        shallow = copy.copy(self.testbed)
+        self.assertIsNot(shallow, self.testbed)
+        self.assertEqual(shallow, self.testbed)
+
+        deep = copy.deepcopy(self.testbed)
+        self.assertIsNot(deep, self.testbed)
+        self.assertEqual(deep, self.testbed)
+
+        self.aList.append(43)
+        self.assertEqual(shallow, PointyStorable([42, 43]))
+        self.assertEqual(deep, PointyStorable([42]))
+
+    def testStr(self):
+        self.assertEqual(str(self.testbed), "value = [42]")
+
+    def testRepr(self):
+        self.assertEqual(repr(self.testbed), "PointyStorable([42])")
+
+    def testHash(self):
+        with self.assertRaises(TypeError):
+            hash(self.testbed)
+
+    def testEq(self):
+        self.assertEqual(self.testbed, PointyStorable([42]))
+        self.assertNotEqual(self.testbed, PointyStorable(0))
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_genericmap.cc
+++ b/tests/test_genericmap.cc
@@ -1,0 +1,151 @@
+// -*- LSST-C++ -*-
+/*
+ * This file is part of afw.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE GenericMapCpp
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
+#include "boost/test/unit_test.hpp"
+#pragma clang diagnostic pop
+
+#include <string>
+#include <sstream>
+
+#include "lsst/utils/tests.h"
+
+#include "lsst/afw/math/ChebyshevBoundedField.h"
+#include "lsst/afw/typehandling/GenericMap.h"
+
+using namespace std::string_literals;
+
+namespace lsst {
+namespace afw {
+namespace typehandling {
+
+// TODO: use templated test cases to streamline and generalize some of these tests
+
+BOOST_AUTO_TEST_CASE(KeyCopies) {
+    auto key1a = makeKey<double>("fancyKey"s);
+    auto key1b(key1a);
+    BOOST_TEST(key1a == key1b);
+
+    auto key2a = makeKey<std::string>(101);
+    auto key2b = key2a;
+    BOOST_TEST(key2a == key2b);
+}
+
+BOOST_AUTO_TEST_CASE(KeyMoves) {
+    auto key1a = makeKey<double>("fancyKey"s);
+    auto key1b(key1a);
+    BOOST_TEST(key1a == key1b);
+
+    auto key2a = makeKey<std::string>(101);
+    auto key2b = std::move(key2a);
+    BOOST_TEST(key2b == makeKey<std::string>(101));
+}
+
+BOOST_AUTO_TEST_CASE(KeyId) {
+    auto key1 = makeKey<int>("specialKey"s);
+    std::string id1 = key1.getId();
+    BOOST_TEST(id1 == "specialKey"s);
+
+    auto key2 = makeKey<int>(26);
+    int id2 = key2.getId();
+    BOOST_TEST(id2 == 26);
+}
+
+BOOST_AUTO_TEST_CASE(KeyFactory) {
+    Key<std::string, int> foo1 = makeKey<int>("foo"s);
+    Key<std::string, int> foo2 = Key<std::string, int>("foo"s);
+    BOOST_TEST(foo1 == foo2);
+}
+
+BOOST_AUTO_TEST_CASE(KeyOutputString) {
+    std::stringstream buffer;
+    buffer << makeKey<int>("fancyKey"s);
+    // Don't test value in brackets; it's compiler-dependent
+    BOOST_TEST(buffer.str().find("fancyKey<"s) == 0);
+    BOOST_TEST(buffer.str().rfind(">"s) == buffer.str().size() - 1);
+}
+
+BOOST_AUTO_TEST_CASE(KeyOutputInt) {
+    std::stringstream buffer;
+    buffer << makeKey<std::string>(42);
+    // Don't test value in brackets; it's compiler-dependent
+    BOOST_TEST(buffer.str().find("42<"s) == 0);
+    BOOST_TEST(buffer.str().rfind(">"s) == buffer.str().size() - 1);
+}
+
+BOOST_AUTO_TEST_CASE(KeyEquality) {
+    auto key1 = makeKey<double>("fancyKey"s);
+    auto key2 = makeKey<double>("fancyKey"s);
+    auto key3 = makeKey<int>("fancyKey"s);
+    auto key4 = makeKey<int const>("fancyKey"s);
+
+    BOOST_TEST(key1 == key1);
+    BOOST_TEST(!(key1 != key1));
+    BOOST_TEST(key2 == key2);
+    BOOST_TEST(!(key2 != key2));
+    BOOST_TEST(key3 == key3);
+    BOOST_TEST(!(key3 != key3));
+    BOOST_TEST(key4 == key4);
+    BOOST_TEST(!(key4 != key4));
+
+    BOOST_TEST(key1 == key2);
+    BOOST_TEST(!(key1 != key2));
+    BOOST_TEST(key2 != key3);
+    BOOST_TEST(!(key2 == key3));
+    BOOST_TEST(key3 != key1);
+    BOOST_TEST(!(key3 == key1));
+
+    BOOST_TEST(key3 != key4);
+    BOOST_TEST(!(key3 == key4));
+}
+
+BOOST_AUTO_TEST_CASE(KeySorting) {
+    auto key1 = makeKey<double>("a"s);
+    auto key2 = makeKey<int>("b"s);
+    auto key3 = makeKey<double>("c"s);
+
+    BOOST_TEST(key1 < key2);
+    BOOST_TEST(key2 < key3);
+    BOOST_TEST(key1 < key3);
+
+    BOOST_TEST(std::less<>()(key1, key2));
+    BOOST_TEST(std::less<>()(key2, key3));
+    BOOST_TEST(std::less<>()(key1, key3));
+}
+
+BOOST_AUTO_TEST_CASE(KeyHash) {
+    utils::assertValidHash<Key<std::string, int>>();
+    utils::assertValidHash<Key<int, lsst::afw::math::ChebyshevBoundedField>>();
+
+    using TestKey = Key<std::string, int>;
+    utils::assertHashesEqual(TestKey("foo"s), TestKey("foo"s));
+    utils::assertHashesEqual(TestKey("bar"s), makeKey<int>("bar"s));
+}
+
+}  // namespace typehandling
+}  // namespace afw
+}  // namespace lsst

--- a/tests/test_polymorphicValue.cc
+++ b/tests/test_polymorphicValue.cc
@@ -1,0 +1,177 @@
+// -*- LSST-C++ -*-
+/*
+ * This file is part of afw.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE PolymorphicValueCpp
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
+#include "boost/test/unit_test.hpp"
+#pragma clang diagnostic pop
+
+#include "lsst/utils/tests.h"
+#include "lsst/afw/typehandling/PolymorphicValue.h"
+#include "lsst/afw/typehandling/test.h"
+
+namespace lsst {
+namespace afw {
+namespace typehandling {
+
+using test::ComplexStorable;
+using test::SimpleStorable;
+
+/**
+ * Attempt to create an empty PolymorphicValue.
+ *
+ * There is no operation on PolymorphicValue that guarantees an empty state,
+ * so test code should check the returned object.
+ */
+PolymorphicValue makeEmpty() {
+    SimpleStorable foo;
+    PolymorphicValue empty(foo);
+    PolymorphicValue nonEmpty(std::move(empty));
+    return empty;
+}
+
+BOOST_AUTO_TEST_CASE(Empty) {
+    SimpleStorable foo;
+    PolymorphicValue fooHolder(foo);
+    BOOST_TEST(!fooHolder.empty());
+
+    ComplexStorable bar(1.0);
+    PolymorphicValue barHolder(bar);
+    BOOST_TEST(!barHolder.empty());
+
+    BOOST_WARN(!makeEmpty().empty());
+}
+
+BOOST_AUTO_TEST_CASE(Equals) {
+    SimpleStorable foo1, foo2;
+    ComplexStorable bar1(1.0), bar2(1.5);
+
+    PolymorphicValue fooHolder1(foo1), fooHolder2(foo2);
+    PolymorphicValue barHolder1(bar1), barHolder2(bar2);
+
+    // Warning: operator== for SimpleStorable/ComplexStorable is ill-behaved; don't assume symmetry
+    BOOST_CHECK_EQUAL(fooHolder1 == fooHolder2, foo1 == foo2);
+    BOOST_CHECK_EQUAL(fooHolder2 == fooHolder1, foo2 == foo1);
+    BOOST_CHECK_EQUAL(barHolder1 == barHolder2, bar1 == bar2);
+    BOOST_CHECK_EQUAL(barHolder2 == barHolder1, bar2 == bar1);
+
+    BOOST_CHECK_EQUAL(barHolder1 == fooHolder2, bar1 == foo2);
+    BOOST_CHECK_EQUAL(barHolder2 == fooHolder1, bar2 == foo1);
+    BOOST_CHECK_EQUAL(fooHolder1 == barHolder2, foo1 == bar2);
+    BOOST_CHECK_EQUAL(fooHolder2 == barHolder1, foo2 == bar1);
+
+    PolymorphicValue empty1 = makeEmpty(), empty2 = makeEmpty();
+    // makeEmpty() can't guarantee the result is actually empty
+    if (empty1.empty() && empty2.empty()) {
+        BOOST_TEST(empty1 == empty2);
+        BOOST_TEST(empty2 == empty1);
+        BOOST_TEST(empty1 != fooHolder1);
+        BOOST_TEST(fooHolder1 != empty1);
+    } else {
+        BOOST_WARN(!empty1.empty());
+        BOOST_WARN(!empty2.empty());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Hash) {
+    utils::assertValidHash<PolymorphicValue>();
+
+    utils::assertHashesEqual(PolymorphicValue(ComplexStorable(1.0)), PolymorphicValue(ComplexStorable(1.0)));
+    utils::assertHashesEqual(PolymorphicValue(ComplexStorable(3.8)), PolymorphicValue(ComplexStorable(3.8)));
+
+    auto unhashable = PolymorphicValue(SimpleStorable());
+    BOOST_CHECK_THROW(std::hash<PolymorphicValue>()(unhashable), UnsupportedOperationException);
+}
+
+BOOST_AUTO_TEST_CASE(Copy) {
+    auto original = PolymorphicValue(ComplexStorable(3.5));
+    auto copy = PolymorphicValue(original);
+    BOOST_CHECK(copy == original);
+
+    // Independent copy?
+    static_cast<ComplexStorable&>(copy.get()) = 4.2;
+    BOOST_CHECK(copy != original);
+}
+
+BOOST_AUTO_TEST_CASE(Move) {
+    auto original = PolymorphicValue(ComplexStorable(3.5));
+    auto backup = PolymorphicValue(original);
+    auto copy = PolymorphicValue(std::move(original));
+
+    BOOST_CHECK(copy == backup);
+
+    // changes to copy shouldn't affect original
+    auto postMove = PolymorphicValue(original);
+    BOOST_REQUIRE(original == postMove);
+    static_cast<ComplexStorable&>(copy.get()) = 4.2;
+    BOOST_CHECK(original == postMove);
+}
+
+BOOST_AUTO_TEST_CASE(CopyAssign) {
+    auto original = PolymorphicValue(ComplexStorable(3.5));
+    auto copy = PolymorphicValue(SimpleStorable());
+    copy = original;
+    BOOST_CHECK(copy == original);
+
+    // Independent copy?
+    static_cast<ComplexStorable&>(copy.get()) = 4.2;
+    BOOST_CHECK(copy != original);
+}
+
+BOOST_AUTO_TEST_CASE(MoveAssign) {
+    auto original = PolymorphicValue(ComplexStorable(3.5));
+    auto backup = PolymorphicValue(original);
+    auto copy = PolymorphicValue(SimpleStorable());
+    copy = std::move(original);
+
+    BOOST_CHECK(copy == backup);
+
+    // changes to copy shouldn't affect original
+    auto postMove = PolymorphicValue(original);
+    BOOST_REQUIRE(original == postMove);
+    static_cast<ComplexStorable&>(copy.get()) = 4.2;
+    BOOST_CHECK(original == postMove);
+}
+
+BOOST_AUTO_TEST_CASE(ImplicitConversion) {
+    auto original = ComplexStorable(3.5);
+    PolymorphicValue holder = original;
+
+    // Does PolymorphicValue make a copy?
+    BOOST_REQUIRE(original.equals(holder.get()));
+    static_cast<ComplexStorable&>(original) = 0.0;
+    BOOST_CHECK(!original.equals(holder.get()));
+
+    // Does modifying contents change holder?
+    Storable& contents = holder;
+    BOOST_REQUIRE(holder == PolymorphicValue(ComplexStorable(3.5)));
+    static_cast<ComplexStorable&>(contents) = 1.6;
+    BOOST_CHECK(holder != PolymorphicValue(ComplexStorable(3.5)));
+}
+
+}  // namespace typehandling
+}  // namespace afw
+}  // namespace lsst

--- a/tests/test_simpleGenericMap.cc
+++ b/tests/test_simpleGenericMap.cc
@@ -1,0 +1,163 @@
+// -*- LSST-C++ -*-
+/*
+ * This file is part of afw.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE SimpleGenericMapCpp
+#define BOOST_TEST_NO_MAIN
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
+#include "boost/test/unit_test.hpp"
+#pragma clang diagnostic pop
+
+#include <memory>
+#include <string>
+
+#include "lsst/afw/typehandling/SimpleGenericMap.h"
+#include "lsst/afw/typehandling/test.h"
+
+using namespace std::string_literals;
+
+namespace lsst {
+namespace afw {
+namespace typehandling {
+
+class SimpleGenericMapFactory final : public test::GenericFactory {
+public:
+    /**
+     * Create a map containing the following state:
+     *
+     * * `KEY0: VALUE0`
+     * * `KEY1: VALUE1`
+     * * `KEY2: VALUE2`
+     * * `KEY3: VALUE3`
+     * * `KEY4: std::shared_ptr<>(VALUE4)`
+     * * `KEY5: VALUE5`
+     */
+    virtual std::unique_ptr<GenericMap<int>> makeGenericMap() const {
+        auto map = std::make_unique<SimpleGenericMap<int>>();
+        map->insert(test::KEY0, test::VALUE0);
+        map->insert(test::KEY1, test::VALUE1);
+        map->insert<double>(test::KEY2, test::VALUE2);
+        map->insert(test::KEY3, test::VALUE3);
+        map->insert(test::KEY4, std::make_shared<test::SimpleStorable>(test::VALUE4));
+        map->insert(test::KEY5, test::VALUE5);
+        return map;
+    }
+
+    /// Create an empty map.
+    virtual std::unique_ptr<MutableGenericMap<std::string>> makeMutableGenericMap() const {
+        return std::make_unique<SimpleGenericMap<std::string>>();
+    }
+};
+
+std::unique_ptr<SimpleGenericMap<int>> makeDerivedMap() {
+    static SimpleGenericMapFactory factory;
+    using Map = SimpleGenericMap<int>;
+    // Exception-safe because only makeGenericMap() can throw
+    return std::unique_ptr<Map>(dynamic_cast<Map*>(factory.makeGenericMap().release()));
+}
+
+void checkIndependentCopy(SimpleGenericMap<int>& copy, SimpleGenericMap<int>& original) {
+    // Use BOOST_CHECK to avoid BOOST_TEST bug from GenericMap being unprintable
+    BOOST_CHECK(original == copy);
+
+    // copy and original should change independently
+    copy.erase(test::KEY1);
+    BOOST_CHECK(copy != original);
+    copy.insert(test::KEY1, test::VALUE1);
+    BOOST_CHECK(copy == original);
+    copy.at(test::KEY0) = !test::VALUE0;
+    BOOST_CHECK(copy != original);
+    original.at(test::KEY0) = !test::VALUE0;
+    BOOST_CHECK(copy == original);
+}
+
+BOOST_AUTO_TEST_CASE(Copy) {
+    auto original = makeDerivedMap();
+
+    SimpleGenericMap<int> copy(*original);
+    checkIndependentCopy(copy, *original);
+}
+
+BOOST_AUTO_TEST_CASE(CopyAssign) {
+    auto original = makeDerivedMap();
+
+    SimpleGenericMap<int> copy;
+    copy = *original;
+    checkIndependentCopy(copy, *original);
+}
+
+void checkIndependentMove(SimpleGenericMap<int>& copy, SimpleGenericMap<int> const& original) {
+    // state of original is undefined, but changes to copy should not affect it
+    SimpleGenericMap<int> const movedValue(original);
+    BOOST_REQUIRE(movedValue == original);
+
+    copy.insert(makeKey<bool>(-127), true);
+    BOOST_CHECK(movedValue == original);
+    copy.clear();
+    BOOST_CHECK(movedValue == original);
+    copy.insert(makeKey<bool>(-127), true);
+    BOOST_CHECK(movedValue == original);
+}
+
+BOOST_AUTO_TEST_CASE(Move) {
+    auto original = makeDerivedMap();
+    SimpleGenericMap<int> const backup(*original);
+
+    SimpleGenericMap<int> copy(std::move(*original));
+    BOOST_CHECK(backup == copy);
+
+    checkIndependentMove(copy, *original);
+}
+
+BOOST_AUTO_TEST_CASE(MoveAssign) {
+    auto original = makeDerivedMap();
+    SimpleGenericMap<int> const backup(*original);
+
+    SimpleGenericMap<int> copy;
+    copy = std::move(*original);
+    BOOST_CHECK(backup == copy);
+
+    checkIndependentMove(copy, *original);
+}
+
+/// Boost::test initialization function
+// Yes, we have to do it this way if we want the GenericMap tests to be defined
+// before we have a concrete GenericMap class
+// https://www.boost.org/doc/libs/1_68_0/libs/test/doc/html/boost_test/tests_organization/test_cases/test_organization_templates.html#ref_BOOST_TEST_CASE_TEMPLATE
+bool init_unit_test() {
+    test::addMutableGenericMapTestCases<SimpleGenericMapFactory>();
+    return true;
+}
+
+}  // namespace typehandling
+}  // namespace afw
+}  // namespace lsst
+
+/// Boost::test entry point
+// Must be customized to call our init_unit_test
+// https://www.boost.org/doc/libs/1_68_0/libs/test/doc/html/boost_test/adv_scenarios/shared_lib_customizations/init_func.html
+int main(int argc, char* argv[]) {
+    return boost::unit_test::unit_test_main(&lsst::afw::typehandling::init_unit_test, argc, argv);
+}

--- a/tests/test_simpleGenericMap.py
+++ b/tests/test_simpleGenericMap.py
@@ -1,0 +1,195 @@
+# This file is part of afw.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from collections.abc import MutableMapping
+import unittest
+
+import lsst.utils.tests
+
+from lsst.afw.typehandling import SimpleGenericMapS
+from lsst.afw.typehandling.testUtils import MutableGenericMapTestBaseClass
+
+
+class SimpleGenericMapTestSuite(MutableGenericMapTestBaseClass):
+
+    @staticmethod
+    def makeMap(mapType, values):
+        """Initialize a map type using __setattr__ instead of a bulk constructor.
+        """
+        result = mapType()
+        for key, value in values.items():
+            result[key] = value
+        return result
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.targets = {(str, SimpleGenericMapS)}
+        cls.examples = {
+            "SimpleGenericMapS(testData)": (str, SimpleGenericMapS, cls.getTestData(str)),
+            "SimpleGenericMapS(testKeys : 0)":
+                (str, SimpleGenericMapS, {key: 0 for key in cls.getTestData(str).keys()}),
+            "SimpleGenericMapS()": (str, SimpleGenericMapS, {}),
+        }
+
+    def tearDown(self):
+        pass
+
+    def testClass(self):
+        self.assertTrue(issubclass(SimpleGenericMapS, MutableMapping))
+        for (_, target) in self.targets:
+            self.assertIsInstance(target(), MutableMapping)
+
+    def testInitKeywords(self):
+        for (keyType, target) in self.targets:
+            self.checkInitKwargs(target, self.getTestData(keyType), msg=str(target))
+
+    def testInitPairs(self):
+        for (keyType, target) in self.targets:
+            self.checkInitPairs(keyType, target, self.getTestData(keyType), msg=str(target))
+
+    def testInitMapping(self):
+        for (keyType, target) in self.targets:
+            # Init from dict
+            self.checkInitMapping(keyType, target, self.getTestData(keyType), msg=str(target))
+            # Init from GenericMap
+            self.checkInitMapping(keyType, target, self.makeMap(target, self.getTestData(keyType)),
+                                  msg=str(target))
+
+    def testFromKeys(self):
+        for (keyType, target) in self.targets:
+            keys = self.getTestData(keyType).keys()
+            for value in self.getTestData(keyType).values():
+                self.checkFromKeys(keyType, target, keys, value,
+                                   msg=" class=%s, value=%r" % (target, value))
+            self.checkFromKeysDefault(keyType, target, keys, msg=" class=%s, no value" % (target))
+
+    def testCopy(self):
+        for label, (keyType, mappingType, contents) in self.examples.items():
+            mapping1 = self.makeMap(mappingType, contents)
+            mapping2 = mapping1.copy()
+            self.assertEqual(mapping1, mapping2, msg="%s" % label)
+            mapping1[keyType(42)] = "A random value!"
+            self.assertNotEqual(mapping1, mapping2, msg="%s" % label)
+
+    def testEquality(self):
+        for label1, (_, mappingType1, contents1) in self.examples.items():
+            mapping1 = self.makeMap(mappingType1, contents1)
+            for label2, (_, mappingType2, contents2) in self.examples.items():
+                mapping2 = self.makeMap(mappingType2, contents2)
+                if contents1 == contents2:
+                    self.assertIsNot(mapping1, mapping2, msg="%s vs %s" % (label1, label2))
+                    self.assertEqual(mapping1, mapping2, msg="%s vs %s" % (label1, label2))
+                    self.assertEqual(mapping1, contents2, msg="%s vs dict(%s)" % (label1, label2))
+                    self.assertEqual(contents1, mapping2, msg="dict(%s) vs %s" % (label1, label2))
+                else:
+                    self.assertNotEqual(mapping1, mapping2, msg="%s vs %s" % (label1, label2))
+                    self.assertNotEqual(mapping1, contents2, msg="%s vs dict(%s)" % (label1, label2))
+                    self.assertNotEqual(contents1, mapping2, msg="dict(%s) vs %s" % (label1, label2))
+
+    def testBool(self):
+        for label, (_, mappingType, contents) in self.examples.items():
+            mapping = self.makeMap(mappingType, contents)
+            if contents:
+                self.assertTrue(mapping, msg=label)
+            else:
+                self.assertFalse(mapping, msg=label)
+
+    def testContains(self):
+        for label, (keyType, mappingType, contents) in self.examples.items():
+            mapping = self.makeMap(mappingType, contents)
+            self.checkContains(keyType, mapping, contents, msg=label)
+
+    def testContents(self):
+        for label, (keyType, mappingType, contents) in self.examples.items():
+            mapping = self.makeMap(mappingType, contents)
+            self.checkContents(keyType, mapping, contents, msg=label)
+
+    def testGet(self):
+        for label, (keyType, mappingType, contents) in self.examples.items():
+            mapping = self.makeMap(mappingType, contents)
+            self.checkGet(keyType, mapping, contents, msg=label)
+
+    def testIteration(self):
+        for label, (_, mappingType, contents) in self.examples.items():
+            mapping = self.makeMap(mappingType, contents)
+            self.checkIteration(mapping, contents, msg=label)
+
+    def testViews(self):
+        for label, (_, mappingType, contents) in self.examples.items():
+            self.checkMutableViews(mappingType, contents, msg=label)
+
+    def testInsertItem(self):
+        for (keyType, target) in self.targets:
+            self.checkInsertItem(keyType, target, self.getTestData(keyType), msg=str(target))
+
+    def testSetdefault(self):
+        for (keyType, target) in self.targets:
+            self.checkSetdefault(keyType, target, self.getTestData(keyType), msg=str(target))
+
+    def testUpdateMapping(self):
+        for (keyType, target) in self.targets:
+            # Update from dict
+            self.checkUpdateMapping(keyType, target, self.getTestData(keyType), msg=str(target))
+            # Update from GenericMap
+            self.checkUpdateMapping(keyType, target, self.makeMap(target, self.getTestData(keyType)),
+                                    msg=str(target))
+
+    def testUpdatePairs(self):
+        for (keyType, target) in self.targets:
+            self.checkUpdatePairs(keyType, target, self.getTestData(keyType), msg=str(target))
+
+    def testUpdateKwargs(self):
+        for (keyType, target) in self.targets:
+            self.checkUpdateKwargs(target, self.getTestData(keyType), msg=str(target))
+
+    def testReplaceItem(self):
+        for (keyType, target) in self.targets:
+            self.checkReplaceItem(keyType, target(), msg=str(target))
+
+    def testRemoveItem(self):
+        for (keyType, target) in self.targets:
+            self.checkRemoveItem(keyType, target, self.getTestData(keyType), msg=str(target))
+
+    def testPop(self):
+        for (keyType, target) in self.targets:
+            self.checkPop(keyType, target, self.getTestData(keyType), msg=str(target))
+
+    def testPopitem(self):
+        for (keyType, target) in self.targets:
+            self.checkPopitem(target, self.getTestData(keyType), msg=str(target))
+
+    def testClear(self):
+        for (keyType, target) in self.targets:
+            self.checkClear(target, self.getTestData(keyType), msg=str(target))
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_storable.cc
+++ b/tests/test_storable.cc
@@ -1,0 +1,59 @@
+// -*- LSST-C++ -*-
+/*
+ * This file is part of afw.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE StorableCpp
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
+#include "boost/test/unit_test.hpp"
+#pragma clang diagnostic pop
+
+#include <sstream>
+
+#include "lsst/afw/typehandling/Storable.h"
+
+namespace lsst {
+namespace afw {
+namespace typehandling {
+
+namespace {
+
+class Dummy : public Storable {};
+
+}  // namespace
+
+BOOST_AUTO_TEST_CASE(Defaults) {
+    Dummy dummy;
+    BOOST_CHECK_THROW(dummy.clone(), UnsupportedOperationException);
+
+    BOOST_TEST(!dummy.isPersistable());
+    BOOST_TEST(!dummy.equals(Dummy()));
+
+    std::stringstream buffer;
+    BOOST_CHECK_THROW(buffer << dummy, UnsupportedOperationException);
+}
+
+}  // namespace typehandling
+}  // namespace afw
+}  // namespace lsst


### PR DESCRIPTION
This pull request creates a new subpackage, `lsst.afw.typehandling`, containing the `Storable` and `HeteroMap` interfaces. A single reference implementation of `HeteroMap`, `SimpleHeteroMap`, is provided as well. `HeteroMap` is expected to be used to simplify the persistence of complex compound types such as `ExposureInfo`.

`(Mutable)HeteroMap` has all the capabilities of a Python `(Mutable)Mapping`, aside from some restrictions on key and value types. The C++ class is more limited; in particular, until [DM-19467](https://jira.lsstcorp.org/browse/DM-19467) there is no way to iterate over or persist a `HeteroMap` in C++.