### PR TITLE
DM-19575: Add Storable mixin to ExposureInfo components

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,5 +1,5 @@
 Copyright 2014-2018 The Trustees of Princeton University
-Copyright 2014-2018 University of Washington
+Copyright 2014-2019 University of Washington
 Copyright 2014-2018 Association of Universities for Research in Astronomy
 Copyright 2014-2015, 2017-2018 The Board of Trustees of the Leland Stanford Junior University, through SLAC National Accelerator Laboratory
 Copyright 2017 California Institute of Technology

--- a/include/lsst/afw/cameraGeom/Detector.h
+++ b/include/lsst/afw/cameraGeom/Detector.h
@@ -32,6 +32,7 @@
 #include "lsst/afw/cameraGeom/CameraSys.h"
 #include "lsst/afw/cameraGeom/Orientation.h"
 #include "lsst/afw/cameraGeom/TransformMap.h"
+#include "lsst/afw/typehandling/Storable.h"
 
 namespace lsst {
 namespace afw {
@@ -58,7 +59,7 @@ enum DetectorType {
  * for instance it is not possible to construct one from a non-const catalog,
  * so I don't know how to construct one.
  */
-class Detector final : public table::io::PersistableFacade<Detector>, public table::io::Persistable {
+class Detector final : public table::io::PersistableFacade<Detector>, public typehandling::Storable {
 public:
     typedef ndarray::Array<float const, 2> CrosstalkMatrix;
 

--- a/include/lsst/afw/detection/Psf.h
+++ b/include/lsst/afw/detection/Psf.h
@@ -34,6 +34,7 @@
 #include "lsst/afw/math/Kernel.h"
 #include "lsst/afw/image/Color.h"
 #include "lsst/afw/table/io/Persistable.h"
+#include "lsst/afw/typehandling/Storable.h"
 
 namespace lsst {
 namespace afw {
@@ -74,7 +75,7 @@ struct PsfCacheKey;
  */
 class Psf : public daf::base::Citizen,
             public afw::table::io::PersistableFacade<Psf>,
-            public afw::table::io::Persistable {
+            public afw::typehandling::Storable {
     static lsst::geom::Point2D makeNullPoint() {
         return lsst::geom::Point2D(std::numeric_limits<double>::quiet_NaN());
     }
@@ -107,6 +108,14 @@ public:
      *  returned images.
      */
     virtual std::shared_ptr<Psf> clone() const = 0;
+
+    /**
+     * @copybrief clone
+     *
+     * This method is an alias of @ref clone that can be called from a
+     * reference to @ref typehandling::Storable "Storable".
+     */
+    std::shared_ptr<typehandling::Storable> cloneStorable() const override final { return clone(); }
 
     /**
      *  Return clone with specified kernel dimensions

--- a/include/lsst/afw/geom/SkyWcs.h
+++ b/include/lsst/afw/geom/SkyWcs.h
@@ -39,6 +39,7 @@
 #include "lsst/afw/geom/Endpoint.h"
 #include "lsst/afw/geom/Transform.h"
 #include "lsst/afw/table/io/Persistable.h"
+#include "lsst/afw/typehandling/Storable.h"
 
 namespace lsst {
 namespace afw {
@@ -113,7 +114,7 @@ Eigen::Matrix2d makeCdMatrix(lsst::geom::Angle const &scale,
  *
  * The other frames are of type ast::Frame and have 2 axes.
  */
-class SkyWcs final : public table::io::PersistableFacade<SkyWcs>, public table::io::Persistable {
+class SkyWcs final : public table::io::PersistableFacade<SkyWcs>, public typehandling::Storable {
 public:
     SkyWcs(SkyWcs const &) = default;
     SkyWcs(SkyWcs &&) = default;
@@ -400,6 +401,21 @@ public:
 
     /// Serialize this SkyWcs to a string, using the same format as writeStream
     std::string writeString() const;
+
+    // Override methods required by afw::typehandling::Storable
+
+    /// Create a new SkyWcs that is a copy of this one.
+    std::shared_ptr<typehandling::Storable> cloneStorable() const override;
+
+    /// Create a string representation of this object.
+    std::string toString() const override;
+
+    /**
+     * Compare this object to another Storable.
+     *
+     * @returns `*this == other` if `other` is a SkyWcs; otherwise `false`.
+     */
+    bool equals(typehandling::Storable const &other) const noexcept override;
 
 protected:
     // Override methods required by afw::table::io::Persistable

--- a/include/lsst/afw/geom/polygon/Polygon.h
+++ b/include/lsst/afw/geom/polygon/Polygon.h
@@ -38,6 +38,7 @@
 #include "lsst/afw/geom/Transform.h"
 #include "lsst/afw/image/Image.h"
 #include "lsst/afw/image/MaskedImage.h"
+#include "lsst/afw/typehandling/Storable.h"
 
 namespace lsst {
 namespace afw {
@@ -55,7 +56,7 @@ LSST_EXCEPTION_TYPE(SinglePolygonException, lsst::pex::exceptions::RuntimeError,
 ///
 /// Polygons are defined by a set of vertices
 
-class Polygon : public afw::table::io::PersistableFacade<Polygon>, public afw::table::io::Persistable {
+class Polygon final : public afw::table::io::PersistableFacade<Polygon>, public afw::typehandling::Storable {
 public:
     typedef lsst::geom::Box2D Box;
     typedef lsst::geom::Point2D Point;
@@ -137,7 +138,7 @@ public:
     bool operator!=(Polygon const& other) const { return !(*this == other); }
 
     /// Return a hash of this object.
-    std::size_t hash_value() const noexcept;
+    std::size_t hash_value() const noexcept override;
 
     /// Returns whether the polygon contains the point
     bool contains(Point const& point) const;
@@ -249,9 +250,21 @@ public:
     }
     //@}
 
-    //@{
     /// Whether Polygon is persistable which is always true
     bool isPersistable() const noexcept override { return true; }
+
+    /// Create a new Polygon that is a copy of this one.
+    std::shared_ptr<typehandling::Storable> cloneStorable() const override;
+
+    /// Create a string representation of this object.
+    std::string toString() const override;
+
+    /**
+     * Compare this object to another Storable.
+     *
+     * @returns `*this == other` if `other` is a Polygon; otherwise `false`.
+     */
+    bool equals(typehandling::Storable const& other) const noexcept override;
 
 protected:
     std::string getPersistenceName() const override;

--- a/include/lsst/afw/image/ApCorrMap.h
+++ b/include/lsst/afw/image/ApCorrMap.h
@@ -28,6 +28,7 @@
 #include <map>
 
 #include "lsst/afw/table/io/Persistable.h"
+#include "lsst/afw/typehandling/Storable.h"
 #include "lsst/afw/math/BoundedField.h"
 
 namespace lsst {
@@ -41,7 +42,7 @@ namespace image {
  *  (given the simplified interface, for instance, we could switch to unordered_map or some other
  *  underyling container in the future).
  */
-class ApCorrMap : public table::io::PersistableFacade<ApCorrMap>, public table::io::Persistable {
+class ApCorrMap final : public table::io::PersistableFacade<ApCorrMap>, public typehandling::Storable {
     typedef std::map<std::string, std::shared_ptr<math::BoundedField>> Internal;
 
 public:
@@ -79,6 +80,9 @@ public:
     /// Scale all fields by a constant
     ApCorrMap& operator*=(double const scale);
     ApCorrMap& operator/=(double const scale) { return *this *= 1.0 / scale; }
+
+    /// Create a new ApCorrMap that is a copy of this one.
+    std::shared_ptr<typehandling::Storable> cloneStorable() const override;
 
 private:
     std::string getPersistenceName() const override;

--- a/include/lsst/afw/image/CoaddInputs.h
+++ b/include/lsst/afw/image/CoaddInputs.h
@@ -27,6 +27,7 @@
 #include "lsst/base.h"
 #include "lsst/afw/table/Exposure.h"
 #include "lsst/afw/table/io/Persistable.h"
+#include "lsst/afw/typehandling/Storable.h"
 
 namespace lsst {
 namespace afw {
@@ -45,7 +46,7 @@ namespace image {
  *  single-depth ones, so they simply pick out the single non-coadd-Psf that is valid for each
  *  point).
  */
-class CoaddInputs : public table::io::PersistableFacade<CoaddInputs>, public table::io::Persistable {
+class CoaddInputs final : public table::io::PersistableFacade<CoaddInputs>, public typehandling::Storable {
 public:
     table::ExposureCatalog visits;
     table::ExposureCatalog ccds;
@@ -77,6 +78,9 @@ public:
      *  Psf is not persistable, it will silently not be saved, instead of throwing an exception.
      */
     bool isPersistable() const noexcept override;
+
+    /// Create a new CoaddInputs that is a copy of this one.
+    std::shared_ptr<typehandling::Storable> cloneStorable() const override;
 
 protected:
     std::string getPersistenceName() const override;

--- a/include/lsst/afw/image/Filter.h
+++ b/include/lsst/afw/image/Filter.h
@@ -39,7 +39,7 @@
 #include <memory>
 #include "lsst/base.h"
 #include "lsst/daf/base/PropertySet.h"
-
+#include "lsst/afw/typehandling/Storable.h"
 
 namespace lsst {
 namespace afw {
@@ -138,7 +138,7 @@ private:
 /**
  * Holds an integer identifier for an LSST filter.
  */
-class Filter final {
+class Filter final : public typehandling::Storable {
 public:
     static int const AUTO;
     static int const UNKNOWN;
@@ -177,7 +177,7 @@ public:
     bool operator!=(Filter const& rhs) const noexcept { return !(*this == rhs); }
 
     /// Return a hash of this object.
-    std::size_t hash_value() const noexcept;
+    std::size_t hash_value() const noexcept override;
 
     /**
      * Return a Filter's integral id
@@ -229,6 +229,23 @@ public:
      * Return a list of known filters
      */
     static std::vector<std::string> getNames();
+
+    /// Create a new Filter that is a copy of this one.
+    std::shared_ptr<typehandling::Storable> cloneStorable() const override;
+
+    /**
+     * Compare this object to another Storable.
+     *
+     * @returns `*this == other` if `other` is a Filter; otherwise `false`.
+     */
+    bool equals(typehandling::Storable const& other) const noexcept override;
+
+    bool isPersistable() const noexcept override;
+
+protected:
+    std::string getPersistenceName() const override;
+    std::string getPythonModule() const override;
+    void write(OutputArchiveHandle& handle) const override;
 
 private:
     typedef std::unordered_map<std::string, std::string const> AliasMap;

--- a/include/lsst/afw/image/PhotoCalib.h
+++ b/include/lsst/afw/image/PhotoCalib.h
@@ -39,6 +39,7 @@
 #include "lsst/geom/Box.h"
 #include "lsst/afw/table/Source.h"
 #include "lsst/afw/table/io/Persistable.h"
+#include "lsst/afw/typehandling/Storable.h"
 #include "lsst/afw/image/MaskedImage.h"
 #include "lsst/daf/base/PropertyList.h"
 #include "lsst/pex/exceptions/Exception.h"
@@ -112,7 +113,7 @@ inline void assertNonNegative(double value, std::string const &name) {
  * @f]
  * Note that this is independent of referenceFlux.
  */
-class PhotoCalib : public table::io::PersistableFacade<PhotoCalib>, public table::io::Persistable {
+class PhotoCalib final : public table::io::PersistableFacade<PhotoCalib>, public typehandling::Storable {
 public:
     // Allow move, but no copy
     PhotoCalib(PhotoCalib const &) = default;
@@ -478,8 +479,6 @@ public:
 
     bool isPersistable() const noexcept override { return true; }
 
-    friend std::ostream &operator<<(std::ostream &os, PhotoCalib const &photoCalib);
-
     /* Backwards compatibility with old Calib object */
 
     /// No-op: for backwards compatibility with Calib.
@@ -554,6 +553,20 @@ public:
                 "`makePhotoCalibFromCalibZeroPoint`.";
         throw LSST_EXCEPT(pex::exceptions::RuntimeError, msg);
     }
+
+    /// Create a new PhotoCalib that is a copy of this one.
+    std::shared_ptr<typehandling::Storable> cloneStorable() const override;
+
+    /// Create a string representation of this object.
+    std::string toString() const override;
+
+    /**
+     * Compare this object to another Storable.
+     *
+     * @returns `*this == other` if `other` is a PhotoCalib; otherwise `false`.
+     */
+    bool equals(typehandling::Storable const &other) const noexcept override;
+    // PhotoCalib equality comparable but intentionally not hashable
 
 protected:
     std::string getPersistenceName() const override;

--- a/include/lsst/afw/image/TransmissionCurve.h
+++ b/include/lsst/afw/image/TransmissionCurve.h
@@ -28,6 +28,7 @@
 #include "lsst/afw/geom/Transform.h"
 #include "lsst/geom/Box.h"
 #include "lsst/afw/table/io/Persistable.h"
+#include "lsst/afw/typehandling/Storable.h"
 
 namespace lsst {
 namespace afw {
@@ -56,7 +57,7 @@ namespace image {
  *  normalization expected/provided.
  */
 class TransmissionCurve : public table::io::PersistableFacade<TransmissionCurve>,
-                          public table::io::Persistable,
+                          public typehandling::Storable,
                           public std::enable_shared_from_this<TransmissionCurve> {
 public:
     /**

--- a/include/lsst/afw/image/VisitInfo.h
+++ b/include/lsst/afw/image/VisitInfo.h
@@ -35,6 +35,7 @@
 #include "lsst/geom/SpherePoint.h"
 #include "lsst/afw/table/misc.h"  // for RecordId
 #include "lsst/afw/table/io/Persistable.h"
+#include "lsst/afw/typehandling/Storable.h"
 
 namespace lsst {
 namespace afw {
@@ -64,7 +65,7 @@ enum class RotType {
  *
  * VisitInfo is immutable.
  */
-class VisitInfo : public table::io::PersistableFacade<VisitInfo>, public table::io::Persistable {
+class VisitInfo : public table::io::PersistableFacade<VisitInfo>, public typehandling::Storable {
 public:
     /**
      * Construct a VisitInfo
@@ -118,7 +119,7 @@ public:
     bool operator!=(VisitInfo const &other) const { return !(*this == other); };
 
     /// Return a hash of this object.
-    std::size_t hash_value() const noexcept;
+    std::size_t hash_value() const noexcept override;
 
     /// get exposure ID
     table::RecordId getExposureId() const { return _exposureId; }
@@ -185,6 +186,19 @@ public:
      * zenith The angle is positive for objects East of the meridian, and negative for objects to the West.
      */
     lsst::geom::Angle getBoresightParAngle() const;
+
+    /// Create a new VisitInfo that is a copy of this one.
+    std::shared_ptr<typehandling::Storable> cloneStorable() const override;
+
+    /// Create a string representation of this object.
+    std::string toString() const override;
+
+    /**
+     * Compare this object to another Storable.
+     *
+     * @returns `*this == other` if `other` is a VisitInfo; otherwise `false`.
+     */
+    bool equals(typehandling::Storable const &other) const noexcept override;
 
 protected:
     std::string getPersistenceName() const override;

--- a/include/lsst/afw/typehandling/PolymorphicValue.h
+++ b/include/lsst/afw/typehandling/PolymorphicValue.h
@@ -59,11 +59,39 @@ public:
     PolymorphicValue(Storable const& value);
     ~PolymorphicValue() noexcept;
 
+    /**
+     * Try to copy a PolymorphicValue.
+     *
+     * @param other the PolymorphicValue to copy.
+     *
+     * @throws UnsupportedOperationException Thrown if a copy is required and
+     *      the object in `other` does not implement Storable::clone.
+     *
+     * @{
+     */
     PolymorphicValue(PolymorphicValue const& other);
     PolymorphicValue(PolymorphicValue&& other);
 
+    /** @} */
+
+    /**
+     * Try to assign a PolymorphicValue.
+     *
+     * To preserve the run-time type of the object in `other`, this method
+     * swaps (and possibly copies) the Storables instead of relying on the
+     * `Storable`'s `operator=`.
+     *
+     * @param other the PolymorphicValue to overwrite this value with.
+     *
+     * @throws UnsupportedOperationException Thrown if a copy is required and
+     *      the object in `other` does not implement Storable::clone.
+     *
+     * @{
+     */
     PolymorphicValue& operator=(PolymorphicValue const& other);
     PolymorphicValue& operator=(PolymorphicValue&& other);
+
+    /** @} */
 
     /**
      * Check whether this object contains a Storable.

--- a/include/lsst/afw/typehandling/PolymorphicValue.h
+++ b/include/lsst/afw/typehandling/PolymorphicValue.h
@@ -65,7 +65,7 @@ public:
      * @param other the PolymorphicValue to copy.
      *
      * @throws UnsupportedOperationException Thrown if a copy is required and
-     *      the object in `other` does not implement Storable::clone.
+     *      the object in `other` does not implement Storable::cloneStorable.
      *
      * @{
      */
@@ -84,7 +84,7 @@ public:
      * @param other the PolymorphicValue to overwrite this value with.
      *
      * @throws UnsupportedOperationException Thrown if a copy is required and
-     *      the object in `other` does not implement Storable::clone.
+     *      the object in `other` does not implement Storable::cloneStorable.
      *
      * @{
      */

--- a/include/lsst/afw/typehandling/PolymorphicValue.h
+++ b/include/lsst/afw/typehandling/PolymorphicValue.h
@@ -137,7 +137,8 @@ public:
     std::size_t hash_value() const;
 
 private:
-    std::unique_ptr<Storable> _value;
+    // unique_ptr would be more appropriate, but Storable::cloneStorable must return shared_ptr
+    std::shared_ptr<Storable> _value;
 };
 
 }  // namespace typehandling

--- a/include/lsst/afw/typehandling/Storable.h
+++ b/include/lsst/afw/typehandling/Storable.h
@@ -65,6 +65,9 @@ public:
     /**
      * Create a new object that is a copy of this one (optional operation).
      *
+     * This operation is required for Storables that are stored in GenericMap
+     * by value, but not for those stored by shared pointer.
+     *
      * @throws UnsupportedOperationException Thrown if this object is not cloneable.
      */
     virtual std::unique_ptr<Storable> clone() const;

--- a/include/lsst/afw/typehandling/Storable.h
+++ b/include/lsst/afw/typehandling/Storable.h
@@ -69,8 +69,11 @@ public:
      * by value, but not for those stored by shared pointer.
      *
      * @throws UnsupportedOperationException Thrown if this object is not cloneable.
+     *
+     * @note If this class supports a `clone` operation, the two should behave
+     *       identically except for the formal return type.
      */
-    virtual std::unique_ptr<Storable> clone() const;
+    virtual std::unique_ptr<Storable> cloneStorable() const;
 
     /**
      * Create a string representation of this object (optional operation).

--- a/include/lsst/afw/typehandling/Storable.h
+++ b/include/lsst/afw/typehandling/Storable.h
@@ -67,18 +67,14 @@ public:
      *
      * @throws UnsupportedOperationException Thrown if this object is not cloneable.
      */
-    virtual std::unique_ptr<Storable> clone() const {
-        throw LSST_EXCEPT(UnsupportedOperationException, "Cloning is not supported.");
-    }
+    virtual std::unique_ptr<Storable> clone() const;
 
     /**
      * Create a string representation of this object (optional operation).
      *
      * @throws UnsupportedOperationException Thrown if this object does not have a string representation.
      */
-    virtual std::string toString() const {
-        throw LSST_EXCEPT(UnsupportedOperationException, "No string representation available.");
-    }
+    virtual std::string toString() const;
 
     /**
      * Return a hash of this object (optional operation).
@@ -87,9 +83,7 @@ public:
      *
      * @note Subclass authors are responsible for any associated specializations of std::hash.
      */
-    virtual std::size_t hash_value() const {
-        throw LSST_EXCEPT(UnsupportedOperationException, "Hashes are not supported.");
-    }
+    virtual std::size_t hash_value() const;
 
     /**
      * Compare this object to another Storable.
@@ -106,12 +100,8 @@ public:
      * they are symmetric and will give the same result no matter what the
      * compile-time types of the left- and right-hand sides are.
      */
-    virtual bool equals(Storable const& other) const noexcept { return false; }
+    virtual bool equals(Storable const& other) const noexcept;
 };
-
-inline Storable::~Storable() {}
-
-/** @} */
 
 /**
  * Output operator for Storable.

--- a/include/lsst/afw/typehandling/Storable.h
+++ b/include/lsst/afw/typehandling/Storable.h
@@ -101,8 +101,46 @@ public:
      * cross-class comparisons are valid, implementers should take care that
      * they are symmetric and will give the same result no matter what the
      * compile-time types of the left- and right-hand sides are.
+     *
+     * @see singleClassEquals
      */
     virtual bool equals(Storable const& other) const noexcept;
+
+protected:
+    /**
+     * Test if a Storable is of a particular class and equal to another object.
+     *
+     * This method template simplifies implementations of @ref equals that
+     * delegate to `operator==` without supporting cross-class comparisons.
+     *
+     * @tparam T The class expected of the two objects to be compared.
+     * @param lhs, rhs The objects to compare. Note that `rhs` need not be
+     *                 a `T`, while `lhs` must be.
+     * @returns `true` if `rhs` is a `T` and `lhs == rhs`; `false` otherwise.
+     *
+     * @exceptsafe Provides the same level of exception safety as `operator==`.
+     *             Most implementations of `operator==` do not throw.
+     *
+     * @note This method template calls `operator==` with both arguments of
+     *       compile-time type `T const&`. Its use is *not* recommended if
+     *       there would be any ambiguity as to which `operator==` gets picked
+     *       by overload resolution.
+     *
+     * This method template is typically called from @ref equals as:
+     *
+     *     bool MyType::equals(Storable const& other) const noexcept {
+     *         return singleClassEquals(*this, other);
+     *     }
+     */
+    template <class T>
+    static bool singleClassEquals(T const& lhs, Storable const& rhs) {
+        auto typedRhs = dynamic_cast<T const*>(&rhs);
+        if (typedRhs != nullptr) {
+            return lhs == *typedRhs;
+        } else {
+            return false;
+        }
+    }
 };
 
 /**

--- a/include/lsst/afw/typehandling/Storable.h
+++ b/include/lsst/afw/typehandling/Storable.h
@@ -52,11 +52,6 @@ LSST_EXCEPTION_TYPE(UnsupportedOperationException, pex::exceptions::RuntimeError
  * optional, and may throw UnsupportedOperationException if they are not defined.
  *
  * @see StorableHelper
- *
- * @note All Storables are equality-comparable through operator==(Storable const&, Storable const&). This may
- * cause inconsistent behavior when Storable is used as a mixin in a class hierarchy with an existing equality
- * operator. Developers should take care to ensure the result is the same no matter which operator is called;
- * disambiguating calls may require adding an explicit overload for the derived class.
  */
 class Storable : public table::io::Persistable {
 public:

--- a/include/lsst/afw/typehandling/Storable.h
+++ b/include/lsst/afw/typehandling/Storable.h
@@ -73,7 +73,8 @@ public:
      * @note If this class supports a `clone` operation, the two should behave
      *       identically except for the formal return type.
      */
-    virtual std::unique_ptr<Storable> cloneStorable() const;
+    // Return shared_ptr to work around https://github.com/pybind/pybind11/issues/1138
+    virtual std::shared_ptr<Storable> cloneStorable() const;
 
     /**
      * Create a string representation of this object (optional operation).

--- a/include/lsst/afw/typehandling/Storable.h
+++ b/include/lsst/afw/typehandling/Storable.h
@@ -99,7 +99,7 @@ public:
      * method to give results consistent with `operator==` for all inputs that
      * are accepted by both.
      *
-     * @return This implementation always returns `false`.
+     * @returns This implementation returns whether the two objects are the same.
      *
      * @warning This method compares an object to any type of Storable,
      * although cross-class comparisons should usually return `false`. If

--- a/include/lsst/afw/typehandling/test.h
+++ b/include/lsst/afw/typehandling/test.h
@@ -63,10 +63,7 @@ public:
 
     std::string toString() const override { return "Simplest possible representation"; }
 
-    bool equals(Storable const& other) const noexcept override {
-        auto simpleOther = dynamic_cast<SimpleStorable const*>(&other);
-        return simpleOther != nullptr;
-    }
+    bool equals(Storable const& other) const noexcept override { return singleClassEquals(*this, other); }
     virtual bool operator==(SimpleStorable const& other) const { return true; }
     bool operator!=(SimpleStorable const& other) const { return !(*this == other); }
 };

--- a/include/lsst/afw/typehandling/test.h
+++ b/include/lsst/afw/typehandling/test.h
@@ -59,7 +59,7 @@ class SimpleStorable : public Storable {
 public:
     virtual ~SimpleStorable() = default;
 
-    std::unique_ptr<Storable> clone() const override { return std::make_unique<SimpleStorable>(); }
+    std::unique_ptr<Storable> cloneStorable() const override { return std::make_unique<SimpleStorable>(); }
 
     std::string toString() const override { return "Simplest possible representation"; }
 
@@ -80,7 +80,9 @@ public:
         return *this;
     }
 
-    std::unique_ptr<Storable> clone() const override { return std::make_unique<ComplexStorable>(storage); }
+    std::unique_ptr<Storable> cloneStorable() const override {
+        return std::make_unique<ComplexStorable>(storage);
+    }
 
     std::string toString() const override { return "ComplexStorable(" + std::to_string(storage) + ")"; }
 

--- a/include/lsst/afw/typehandling/test.h
+++ b/include/lsst/afw/typehandling/test.h
@@ -59,7 +59,7 @@ class SimpleStorable : public Storable {
 public:
     virtual ~SimpleStorable() = default;
 
-    std::unique_ptr<Storable> cloneStorable() const override { return std::make_unique<SimpleStorable>(); }
+    std::shared_ptr<Storable> cloneStorable() const override { return std::make_unique<SimpleStorable>(); }
 
     std::string toString() const override { return "Simplest possible representation"; }
 
@@ -80,7 +80,7 @@ public:
         return *this;
     }
 
-    std::unique_ptr<Storable> cloneStorable() const override {
+    std::shared_ptr<Storable> cloneStorable() const override {
         return std::make_unique<ComplexStorable>(storage);
     }
 

--- a/python/lsst/afw/typehandling/_Storable.cc
+++ b/python/lsst/afw/typehandling/_Storable.cc
@@ -38,19 +38,12 @@ namespace typehandling {
 using PyStorable = py::class_<Storable, std::shared_ptr<Storable>, table::io::Persistable, StorableHelper<>>;
 
 void wrapStorable(utils::python::WrapperCollection& wrappers) {
-    wrappers.addSignatureDependency("lsst.pex.exceptions");
     wrappers.addInheritanceDependency("lsst.afw.table.io");
 
-    wrappers.wrapException<UnsupportedOperationException, pex::exceptions::RuntimeError>(
-            "UnsupportedOperationException", "RuntimeError");
     wrappers.wrapType(PyStorable(wrappers.module, "Storable"), [](auto& mod, auto& cls) {
         // Do not wrap methods inherited from Persistable
         cls.def(py::init<>());  // Dummy constructor for pure-Python subclasses
-        cls.def("__copy__", &Storable::clone);
-        cls.def("__deepcopy__", [](Storable const& self, py::dict const& memo) { return self.clone(); },
-                "memo"_a = py::none());
-        cls.def("__repr__", &Storable::toString);
-        cls.def("__hash__", &Storable::hash_value);
+        // Do not wrap optional Storable methods; let subclasses do it as appropriate
         cls.def("__eq__", [](Storable const& self, Storable const& other) { return self.equals(other); },
                 "other"_a);
     });

--- a/src/geom/SkyWcs.cc
+++ b/src/geom/SkyWcs.cc
@@ -329,6 +329,16 @@ std::string SkyWcs::writeString() const {
     return os.str();
 }
 
+std::shared_ptr<typehandling::Storable> SkyWcs::cloneStorable() const {
+    return std::make_unique<SkyWcs>(*this);
+}
+
+std::string SkyWcs::toString() const { return "SkyWcs"; }
+
+bool SkyWcs::equals(typehandling::Storable const& other) const noexcept {
+    return singleClassEquals(*this, other);
+}
+
 std::string SkyWcs::getPersistenceName() const { return getSkyWcsPersistenceName(); }
 
 std::string SkyWcs::getPythonModule() const { return "lsst.afw.geom"; }
@@ -517,7 +527,7 @@ std::shared_ptr<TransformPoint2ToPoint2> getPixelToIntermediateWorldCoords(SkyWc
 }
 
 std::ostream& operator<<(std::ostream& os, SkyWcs const& wcs) {
-    os << "SkyWcs";
+    os << wcs.toString();
     return os;
 };
 

--- a/src/geom/polygon/Polygon.cc
+++ b/src/geom/polygon/Polygon.cc
@@ -170,7 +170,7 @@ std::ostream& operator<<(std::ostream& os, BoostPolygon const& poly) {
 }
 
 std::ostream& operator<<(std::ostream& os, Polygon const& poly) {
-    os << "Polygon(" << poly.getVertices() << ")";
+    os << poly.toString();
     return os;
 }
 
@@ -589,6 +589,21 @@ void Polygon::write(OutputArchiveHandle& handle) const {
 
     handle.saveCatalog(catalog);
 }
+
+std::shared_ptr<typehandling::Storable> Polygon::cloneStorable() const {
+    return std::make_unique<Polygon>(*this);
+}
+
+std::string Polygon::toString() const {
+    std::stringstream buffer;
+    buffer << "Polygon(" << this->getVertices() << ")";
+    return buffer.str();
+}
+
+bool Polygon::equals(typehandling::Storable const& other) const noexcept {
+    return singleClassEquals(*this, other);
+}
+
 }  // namespace polygon
 }  // namespace geom
 }  // namespace afw

--- a/src/image/ApCorrMap.cc
+++ b/src/image/ApCorrMap.cc
@@ -145,6 +145,11 @@ ApCorrMap& ApCorrMap::operator*=(double const scale) {
     _internal = replacement;
     return *this;
 }
+
+std::shared_ptr<typehandling::Storable> ApCorrMap::cloneStorable() const {
+    return std::make_unique<ApCorrMap>(*this);
+}
+
 }  // namespace image
 }  // namespace afw
 }  // namespace lsst

--- a/src/image/CoaddInputs.cc
+++ b/src/image/CoaddInputs.cc
@@ -70,6 +70,10 @@ CoaddInputs::~CoaddInputs() = default;
 
 bool CoaddInputs::isPersistable() const noexcept { return true; }
 
+std::shared_ptr<typehandling::Storable> CoaddInputs::cloneStorable() const {
+    return std::make_unique<CoaddInputs>(*this);
+}
+
 std::string CoaddInputs::getPersistenceName() const { return "CoaddInputs"; }
 
 std::string CoaddInputs::getPythonModule() const { return "lsst.afw.image"; }

--- a/src/image/PhotoCalib.cc
+++ b/src/image/PhotoCalib.cc
@@ -21,6 +21,7 @@
  */
 
 #include <cmath>
+#include <iostream>
 
 #include "lsst/geom/Point.h"
 #include "lsst/afw/image/PhotoCalib.h"
@@ -263,12 +264,26 @@ double PhotoCalib::computeCalibrationMean(std::shared_ptr<afw::math::BoundedFiel
     return calibration->mean();
 }
 
-std::ostream &operator<<(std::ostream &os, PhotoCalib const &photoCalib) {
-    if (photoCalib._isConstant)
-        os << "spatially constant with ";
+std::shared_ptr<typehandling::Storable> PhotoCalib::cloneStorable() const {
+    return std::make_unique<PhotoCalib>(*this);
+}
+
+std::string PhotoCalib::toString() const {
+    std::stringstream buffer;
+    if (_isConstant)
+        buffer << "spatially constant with ";
     else
-        os << *(photoCalib._calibration) << " with ";
-    return os << "mean: " << photoCalib._calibrationMean << " error: " << photoCalib._calibrationErr;
+        buffer << *_calibration << " with ";
+    buffer << "mean: " << _calibrationMean << " error: " << _calibrationErr;
+    return buffer.str();
+}
+
+bool PhotoCalib::equals(typehandling::Storable const &other) const noexcept {
+    return singleClassEquals(*this, other);
+}
+
+std::ostream &operator<<(std::ostream &os, PhotoCalib const &photoCalib) {
+    return os << photoCalib.toString();
 }
 
 MaskedImage<float> PhotoCalib::calibrateImage(MaskedImage<float> const &maskedImage,

--- a/src/image/VisitInfo.cc
+++ b/src/image/VisitInfo.cc
@@ -445,22 +445,36 @@ lsst::geom::Angle VisitInfo::getBoresightParAngle() const {
     return result * lsst::geom::radians;
 }
 
+std::shared_ptr<typehandling::Storable> VisitInfo::cloneStorable() const {
+    return std::make_unique<VisitInfo>(*this);
+}
+
+bool VisitInfo::equals(typehandling::Storable const& other) const noexcept {
+    return singleClassEquals(*this, other);
+}
+
+std::string VisitInfo::toString() const {
+    std::stringstream buffer;
+    buffer << "VisitInfo(";
+    buffer << "exposureId=" << getExposureId() << ", ";
+    buffer << "exposureTime=" << getExposureTime() << ", ";
+    buffer << "darkTime=" << getDarkTime() << ", ";
+    buffer << "date=" << getDate().toString(daf::base::DateTime::TAI) << ", ";
+    buffer << "UT1=" << getUt1() << ", ";
+    buffer << "ERA=" << getEra() << ", ";
+    buffer << "boresightRaDec=" << getBoresightRaDec() << ", ";
+    buffer << "boresightAzAlt=" << getBoresightAzAlt() << ", ";
+    buffer << "boresightAirmass=" << getBoresightAirmass() << ", ";
+    buffer << "boresightRotAngle=" << getBoresightRotAngle() << ", ";
+    buffer << "rotType=" << static_cast<int>(getRotType()) << ", ";
+    buffer << "observatory=" << getObservatory() << ", ";
+    buffer << "weather=" << getWeather();
+    buffer << ")";
+    return buffer.str();
+}
+
 std::ostream& operator<<(std::ostream& os, VisitInfo const& visitInfo) {
-    os << "VisitInfo(";
-    os << "exposureId=" << visitInfo.getExposureId() << ", ";
-    os << "exposureTime=" << visitInfo.getExposureTime() << ", ";
-    os << "darkTime=" << visitInfo.getDarkTime() << ", ";
-    os << "date=" << visitInfo.getDate().toString(daf::base::DateTime::TAI) << ", ";
-    os << "UT1=" << visitInfo.getUt1() << ", ";
-    os << "ERA=" << visitInfo.getEra() << ", ";
-    os << "boresightRaDec=" << visitInfo.getBoresightRaDec() << ", ";
-    os << "boresightAzAlt=" << visitInfo.getBoresightAzAlt() << ", ";
-    os << "boresightAirmass=" << visitInfo.getBoresightAirmass() << ", ";
-    os << "boresightRotAngle=" << visitInfo.getBoresightRotAngle() << ", ";
-    os << "rotType=" << static_cast<int>(visitInfo.getRotType()) << ", ";
-    os << "observatory=" << visitInfo.getObservatory() << ", ";
-    os << "weather=" << visitInfo.getWeather();
-    os << ")";
+    os << visitInfo.toString();
     return os;
 }
 

--- a/src/typehandling/PolymorphicValue.cc
+++ b/src/typehandling/PolymorphicValue.cc
@@ -32,12 +32,12 @@ namespace typehandling {
 
 PolymorphicValue::PolymorphicValue(Storable const& value) : _value(value.cloneStorable()) {}
 // No move-constructor, because putting a pointer to Storable&& into a
-// unique_ptr is safe only if the object was dynamically allocated
+// shared_ptr is safe only if the object was dynamically allocated
 
 PolymorphicValue::~PolymorphicValue() noexcept = default;
 
 PolymorphicValue::PolymorphicValue(PolymorphicValue const& other)
-        : _value(other._value ? other._value->cloneStorable() : std::unique_ptr<Storable>()) {}
+        : _value(other._value ? other._value->cloneStorable() : nullptr) {}
 PolymorphicValue::PolymorphicValue(PolymorphicValue&&) = default;  // other._value emptied
 
 PolymorphicValue& PolymorphicValue::operator=(PolymorphicValue const& other) {

--- a/src/typehandling/PolymorphicValue.cc
+++ b/src/typehandling/PolymorphicValue.cc
@@ -30,19 +30,19 @@ namespace lsst {
 namespace afw {
 namespace typehandling {
 
-PolymorphicValue::PolymorphicValue(Storable const& value) : _value(value.clone()) {}
+PolymorphicValue::PolymorphicValue(Storable const& value) : _value(value.cloneStorable()) {}
 // No move-constructor, because putting a pointer to Storable&& into a
 // unique_ptr is safe only if the object was dynamically allocated
 
 PolymorphicValue::~PolymorphicValue() noexcept = default;
 
 PolymorphicValue::PolymorphicValue(PolymorphicValue const& other)
-        : _value(other._value ? other._value->clone() : std::unique_ptr<Storable>()) {}
+        : _value(other._value ? other._value->cloneStorable() : std::unique_ptr<Storable>()) {}
 PolymorphicValue::PolymorphicValue(PolymorphicValue&&) = default;  // other._value emptied
 
 PolymorphicValue& PolymorphicValue::operator=(PolymorphicValue const& other) {
     if (other._value) {
-        _value = other._value->clone();
+        _value = other._value->cloneStorable();
     } else {
         _value.reset();
     }

--- a/src/typehandling/Storable.cc
+++ b/src/typehandling/Storable.cc
@@ -45,7 +45,7 @@ std::size_t Storable::hash_value() const {
     throw LSST_EXCEPT(UnsupportedOperationException, "Hashes are not supported.");
 }
 
-bool Storable::equals(Storable const& other) const noexcept { return false; }
+bool Storable::equals(Storable const& other) const noexcept { return this == &other; }
 
 }  // namespace typehandling
 }  // namespace afw

--- a/src/typehandling/Storable.cc
+++ b/src/typehandling/Storable.cc
@@ -1,0 +1,52 @@
+// -*- LSST-C++ -*-
+/*
+ * This file is part of afw.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <memory>
+#include <string>
+
+#include "lsst/afw/typehandling/Storable.h"
+
+namespace lsst {
+namespace afw {
+namespace typehandling {
+
+Storable::~Storable() noexcept {}
+
+std::unique_ptr<Storable> Storable::clone() const {
+    throw LSST_EXCEPT(UnsupportedOperationException, "Cloning is not supported.");
+}
+
+std::string Storable::toString() const {
+    throw LSST_EXCEPT(UnsupportedOperationException, "No string representation available.");
+}
+
+std::size_t Storable::hash_value() const {
+    throw LSST_EXCEPT(UnsupportedOperationException, "Hashes are not supported.");
+}
+
+bool Storable::equals(Storable const& other) const noexcept { return false; }
+
+}  // namespace typehandling
+}  // namespace afw
+}  // namespace lsst

--- a/src/typehandling/Storable.cc
+++ b/src/typehandling/Storable.cc
@@ -33,7 +33,7 @@ namespace typehandling {
 
 Storable::~Storable() noexcept {}
 
-std::unique_ptr<Storable> Storable::cloneStorable() const {
+std::shared_ptr<Storable> Storable::cloneStorable() const {
     throw LSST_EXCEPT(UnsupportedOperationException, "Cloning is not supported.");
 }
 

--- a/src/typehandling/Storable.cc
+++ b/src/typehandling/Storable.cc
@@ -33,7 +33,7 @@ namespace typehandling {
 
 Storable::~Storable() noexcept {}
 
-std::unique_ptr<Storable> Storable::clone() const {
+std::unique_ptr<Storable> Storable::cloneStorable() const {
     throw LSST_EXCEPT(UnsupportedOperationException, "Cloning is not supported.");
 }
 

--- a/tests/test_Storable.py
+++ b/tests/test_Storable.py
@@ -24,16 +24,10 @@ import unittest
 
 import lsst.utils.tests
 
-from lsst.afw.typehandling import Storable, UnsupportedOperationException
+from lsst.afw.typehandling import Storable
 
 
-class PointlessStorable(Storable):
-    """Test of default behavior of Storable.
-    """
-    pass
-
-
-class PointyStorable(Storable):
+class DemoStorable(Storable):
     """Test that we can inherit from Storable in Python.
     """
     def __init__(self, state):
@@ -44,53 +38,26 @@ class PointyStorable(Storable):
         return "value = %s" % self._state
 
     def __repr__(self):
-        return "PointyStorable(%r)" % self._state
+        return "DemoStorable(%r)" % self._state
 
     def __hash__(self):
         return hash(self._state)
 
     def __copy__(self):
-        return PointyStorable(self._state)
+        return DemoStorable(self._state)
 
     def __deepcopy__(self, memo=None):
-        return PointyStorable(copy.deepcopy(self._state, memo))
+        return DemoStorable(copy.deepcopy(self._state, memo))
 
     def __eq__(self, other):
         return self._state == other._state
-
-
-class StorableTestSuite(lsst.utils.tests.TestCase):
-
-    def setUp(self):
-        self.testbed = PointlessStorable()
-
-    def testCopy(self):
-        with self.assertRaises(UnsupportedOperationException):
-            copy.copy(self.testbed)
-        with self.assertRaises(UnsupportedOperationException):
-            copy.deepcopy(self.testbed)
-
-    def testStr(self):
-        with self.assertRaises(UnsupportedOperationException):
-            str(self.testbed)
-
-    def testRepr(self):
-        with self.assertRaises(UnsupportedOperationException):
-            repr(self.testbed)
-
-    def testHash(self):
-        with self.assertRaises(UnsupportedOperationException):
-            hash(self.testbed)
-
-    def testEq(self):
-        self.assertNotEqual(self.testbed, PointlessStorable())
 
 
 class PointyStorableTestSuite(lsst.utils.tests.TestCase):
 
     def setUp(self):
         self.aList = [42]
-        self.testbed = PointyStorable(self.aList)
+        self.testbed = DemoStorable(self.aList)
 
     def testCopy(self):
         shallow = copy.copy(self.testbed)
@@ -102,22 +69,22 @@ class PointyStorableTestSuite(lsst.utils.tests.TestCase):
         self.assertEqual(deep, self.testbed)
 
         self.aList.append(43)
-        self.assertEqual(shallow, PointyStorable([42, 43]))
-        self.assertEqual(deep, PointyStorable([42]))
+        self.assertEqual(shallow, DemoStorable([42, 43]))
+        self.assertEqual(deep, DemoStorable([42]))
 
     def testStr(self):
         self.assertEqual(str(self.testbed), "value = [42]")
 
     def testRepr(self):
-        self.assertEqual(repr(self.testbed), "PointyStorable([42])")
+        self.assertEqual(repr(self.testbed), "DemoStorable([42])")
 
     def testHash(self):
         with self.assertRaises(TypeError):
             hash(self.testbed)
 
     def testEq(self):
-        self.assertEqual(self.testbed, PointyStorable([42]))
-        self.assertNotEqual(self.testbed, PointyStorable(0))
+        self.assertEqual(self.testbed, DemoStorable([42]))
+        self.assertNotEqual(self.testbed, DemoStorable(0))
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -223,7 +223,7 @@ class FitsReaderTestCase(lsst.utils.tests.TestCase):
         detector = DetectorWrapper().detector
         record = coaddInputs.ccds.addNew()
         record.setWcs(wcs)
-        record.setCalib(calib)
+        record.setPhotoCalib(calib)
         record.setPsf(psf)
         record.setValidPolygon(polygon)
         record.setApCorrMap(apCorrMap)
@@ -240,7 +240,7 @@ class FitsReaderTestCase(lsst.utils.tests.TestCase):
                 exposureIn.setMetadata(metadata)
                 exposureIn.setWcs(wcs)
                 exposureIn.setFilter(Filter("test_readers_filter"))
-                exposureIn.setCalib(calib)
+                exposureIn.setPhotoCalib(calib)
                 exposureIn.setPsf(psf)
                 exposureIn.getInfo().setValidPolygon(polygon)
                 exposureIn.getInfo().setApCorrMap(apCorrMap)

--- a/tests/test_storable.cc
+++ b/tests/test_storable.cc
@@ -48,6 +48,7 @@ BOOST_AUTO_TEST_CASE(Defaults) {
     BOOST_CHECK_THROW(dummy.cloneStorable(), UnsupportedOperationException);
 
     BOOST_TEST(!dummy.isPersistable());
+    BOOST_TEST(dummy.equals(dummy));
     BOOST_TEST(!dummy.equals(Dummy()));
 
     std::stringstream buffer;

--- a/tests/test_storable.cc
+++ b/tests/test_storable.cc
@@ -41,6 +41,19 @@ namespace {
 
 class Dummy : public Storable {};
 
+class Comparable : public Storable {
+public:
+    explicit Comparable(int id) : id(id) {}
+
+    bool operator==(Comparable const& other) const noexcept { return id == other.id; }
+    bool operator!=(Comparable const& other) const noexcept { return !(*this == other); }
+
+    bool equals(Storable const& other) const noexcept override { return singleClassEquals(*this, other); }
+
+private:
+    int id;
+};
+
 }  // namespace
 
 BOOST_AUTO_TEST_CASE(Defaults) {
@@ -53,6 +66,26 @@ BOOST_AUTO_TEST_CASE(Defaults) {
 
     std::stringstream buffer;
     BOOST_CHECK_THROW(buffer << dummy, UnsupportedOperationException);
+}
+
+BOOST_AUTO_TEST_CASE(SingleClassEquals) {
+    Comparable value1(42), value2(44);
+
+    BOOST_REQUIRE(value1 == value1);
+    BOOST_REQUIRE(value2 == value2);
+    BOOST_REQUIRE(value1 != value2);
+    BOOST_REQUIRE(value2 != value1);
+
+    BOOST_TEST(value1.equals(value1));
+    BOOST_TEST(value2.equals(value2));
+    BOOST_TEST(!value1.equals(value2));
+    BOOST_TEST(!value2.equals(value1));
+
+    Dummy dummy;
+    BOOST_TEST(!value1.equals(dummy));
+    BOOST_TEST(!value2.equals(dummy));
+    BOOST_TEST(!dummy.equals(value1));
+    BOOST_TEST(!dummy.equals(value1));
 }
 
 }  // namespace typehandling

--- a/tests/test_storable.cc
+++ b/tests/test_storable.cc
@@ -45,7 +45,7 @@ class Dummy : public Storable {};
 
 BOOST_AUTO_TEST_CASE(Defaults) {
     Dummy dummy;
-    BOOST_CHECK_THROW(dummy.clone(), UnsupportedOperationException);
+    BOOST_CHECK_THROW(dummy.cloneStorable(), UnsupportedOperationException);
 
     BOOST_TEST(!dummy.isPersistable());
     BOOST_TEST(!dummy.equals(Dummy()));

--- a/tests/test_warpExposure.py
+++ b/tests/test_warpExposure.py
@@ -110,7 +110,7 @@ class WarpExposureTestCase(lsst.utils.tests.TestCase):
         originalFilter = afwImage.Filter("i")
         originalPhotoCalib = afwImage.PhotoCalib(1.0e5, 1.0e3)
         originalExposure.setFilter(originalFilter)
-        originalExposure.setCalib(originalPhotoCalib)
+        originalExposure.setPhotoCalib(originalPhotoCalib)
         afwWarpedExposure = afwImage.ExposureF(
             originalExposure.getBBox(),
             originalExposure.getWcs())

--- a/tests/test_warper.py
+++ b/tests/test_warper.py
@@ -85,7 +85,7 @@ class WarpExposureTestCase(lsst.utils.tests.TestCase):
         originalFilter = afwImage.Filter("i")
         originalPhotoCalib = afwImage.PhotoCalib(1.0e5, 1.0e3)
         originalExposure.setFilter(originalFilter)
-        originalExposure.setCalib(originalPhotoCalib)
+        originalExposure.setPhotoCalib(originalPhotoCalib)
 
         warpedExposure1 = warper.warpExposure(
             destWcs=swarpedWcs, srcExposure=originalExposure)


### PR DESCRIPTION
This PR adds the `Storable` mixin to all `afw` classes in `ExposureInfo` (note that it does not modify `daf::base::PropertySet`, which as noted on [Jira](https://jira.lsstcorp.org/browse/DM-19575) will need special treatment for now). This amounts to adding the following four methods, though some keep their default implementation of throwing an `UnsupportedOperationException`:
* `cloneStorable`: creates a `shared_ptr<Storable>`; implemented in terms of a more specific `clone` if applicable. Using a virtual `cloneStorable` instead of shadowing (as was done with e.g. `BaseTable`) is less prone to developer error, because only one implementation is required (e.g., in `Psf`) rather than one for every subclass.
* `equals`: compares the object to any `Storable`, usually returning `false` for mixed-class comparisons. Implemented in terms of `operator==` if applicable and appropriate.
* `toString`: returns a string representation of an object. I found it easier to reimplement `operator<<` in terms of `toString` rather than vice versa (the latter would have involved a method template in `Storable.h` that would introduce extra dependencies).
* `hash_value`: conforms to the convention I introduced in #410, so no delegation required.

A couple of design issues for which I would like feedback:
* I'm really unhappy about making `cloneStorable` return `shared_ptr` rather than `unique_ptr` (which is more flexible for the client; see Effective Modern C++), especially since doing so imposes awkward implementation constraints on `PolymorphicValue`. However, it's not possible to implement a `unique_ptr` clone in terms of a `shared_ptr` clone if you don't already have a `unique_ptr` clone, and trying instead to change `Psf::clone` to use `unique_ptr` triggers a [pybind11 bug](https://github.com/pybind/pybind11/issues/1138) that, judging from the discussion in related PRs, will never be fixed. A third option would be appreciated.
* the `singleClassEquals` helper is a static method template so that subclasses of `Storable` can cast to the correct type, and to duck-type around the fact that `Storable` itself does not implement `operator==`. The code works and is clean, but I feel like there should be a more natural solution.
* `Storable` imposes a lot of API clutter on its subclasses, especially since the "unsupported" versions of methods still appear in the documentation. Currently `cloneStorable` is absolutely essential, and `equals` is needed for C++ equality comparisons of `GenericMap`. We do not use `toString` (no `GenericMap` printing yet) or `hash_value`. Can we afford to remove these methods? If we do, they will be hard to add later, scaling to the number of subclasses `Storable` has.
* Adding `Storable` to `Filter` required implementing `Persistable` in `Filter`. I cargo-culted the code from `ApCorrMap`, so a careful review would be appreciated.