### PR TITLE
DM-19467: Add C++ iteration to GenericMap

### DIFF
--- a/include/lsst/afw/typehandling/GenericMap.h
+++ b/include/lsst/afw/typehandling/GenericMap.h
@@ -516,7 +516,7 @@ protected:
     /**
      * The types that can be stored in a map.
      *
-     * These are the pass-by-value equivalents (using std::decay) of ValueReference.
+     * These are the pass-by-value equivalents (using std::decay) of @ref ValueReference.
      */
     // this mouthful is shorter than the equivalent expression with result_of
     using StorableType = decltype(_referenceToType(std::declval<ValueReference>()));

--- a/include/lsst/afw/typehandling/GenericMap.h
+++ b/include/lsst/afw/typehandling/GenericMap.h
@@ -25,6 +25,7 @@
 #ifndef LSST_AFW_TYPEHANDLING_GENERICMAP_H
 #define LSST_AFW_TYPEHANDLING_GENERICMAP_H
 
+#include <algorithm>
 #include <cstdint>
 #include <functional>
 #include <ostream>
@@ -477,9 +478,9 @@ public:
      * @{
      */
     virtual bool operator==(GenericMap const& other) const {
-        auto keys1 = this->keySet();
-        auto keys2 = other.keySet();
-        if (keys1 != keys2) {
+        auto keys1 = this->keys();
+        auto keys2 = other.keys();
+        if (!std::is_permutation(keys1.begin(), keys1.end(), keys2.begin(), keys2.end())) {
             return false;
         }
         for (K const& key : keys1) {
@@ -535,17 +536,6 @@ protected:
      * @exceptsafe Must provide strong exception safety.
      */
     virtual ValueReference unsafeLookup(K key) const = 0;
-
-private:
-    /**
-     * Return the set of all keys, without type information.
-     *
-     * This method only differs from @ref keys in that it returns a set, not a list.
-     */
-    std::unordered_set<K> keySet() const {
-        auto rawKeys = keys();
-        return std::unordered_set<K>(rawKeys.begin(), rawKeys.end());
-    }
 };
 
 /**

--- a/include/lsst/afw/typehandling/GenericMap.h
+++ b/include/lsst/afw/typehandling/GenericMap.h
@@ -346,15 +346,18 @@ public:
     /**
      * Return the set of all keys, without type information.
      *
-     * @return a copy of all keys currently in the map, in the same iteration order as this object. The set
-     * will *not* be updated as this object changes, or vice versa.
+     * @return a read-only view of all keys currently in the map, in the same
+     *         iteration order as this object. The view will be updated by
+     *         changes to the underlying map.
+     *
+     * @warning Do not modify this map while iterating over its keys.
+     * @warning Do not store the returned reference in variables that outlive
+     *          the map; destroying the map will invalidate the reference.
      *
      * @note The keys are returned as a list, rather than a set, so that subclasses can give them a
      * well-defined iteration order.
-     *
-     * @exceptsafe Provides strong exception safety.
      */
-    virtual std::vector<K> keys() const = 0;
+    virtual std::vector<K> const& keys() const noexcept = 0;
 
     /**
      * Test for map equality.
@@ -370,7 +373,7 @@ public:
      *
      * @{
      */
-    virtual bool operator==(GenericMap const& other) const {
+    virtual bool operator==(GenericMap const& other) const noexcept {
         auto keys1 = this->keys();
         auto keys2 = other.keys();
         if (!std::is_permutation(keys1.begin(), keys1.end(), keys2.begin(), keys2.end())) {

--- a/include/lsst/afw/typehandling/PolymorphicValue.h
+++ b/include/lsst/afw/typehandling/PolymorphicValue.h
@@ -70,7 +70,7 @@ public:
      * @{
      */
     PolymorphicValue(PolymorphicValue const& other);
-    PolymorphicValue(PolymorphicValue&& other);
+    PolymorphicValue(PolymorphicValue&& other) noexcept;
 
     /** @} */
 
@@ -89,7 +89,10 @@ public:
      * @{
      */
     PolymorphicValue& operator=(PolymorphicValue const& other);
-    PolymorphicValue& operator=(PolymorphicValue&& other);
+    PolymorphicValue& operator=(PolymorphicValue&& other) noexcept;
+
+    /// Exchange the contents of this container and another.
+    void swap(PolymorphicValue& other) noexcept;
 
     /** @} */
 
@@ -141,6 +144,13 @@ private:
     std::shared_ptr<Storable> _value;
 };
 
+/**
+ * Swap specialization for PolymorphicValue.
+ *
+ * @relatesalso PolymorphicValue
+ */
+inline void swap(PolymorphicValue& lhs, PolymorphicValue& rhs) noexcept { lhs.swap(rhs); }
+
 }  // namespace typehandling
 }  // namespace afw
 }  // namespace lsst
@@ -159,6 +169,14 @@ struct hash<lsst::afw::typehandling::PolymorphicValue> {
     using result_type = size_t;
     size_t operator()(argument_type const& obj) const { return obj.hash_value(); }
 };
+
+/// Swap specialization for PolymorphicValue.
+template <>
+inline void swap(lsst::afw::typehandling::PolymorphicValue& lhs,
+                 lsst::afw::typehandling::PolymorphicValue& rhs) noexcept {
+    lhs.swap(rhs);
+}
+
 }  // namespace std
 
 #endif

--- a/include/lsst/afw/typehandling/SimpleGenericMap.h
+++ b/include/lsst/afw/typehandling/SimpleGenericMap.h
@@ -41,12 +41,10 @@ namespace typehandling {
 /**
  * A GenericMap that allows insertion and deletion of arbitrary values.
  *
- * In Python, a SimpleGenericMap behaves like a `dict`.
+ * In Python, a SimpleGenericMap behaves like a `dict`. In particular, it will
+ * iterate over keys in the order they were added.
  *
  * @tparam K the key type of the map. Must be hashable.
- *
- * @note This class offers no guarantees, such as thread-safety, beyond those
- *       provided by MutableGenericMap.
  */
 template <typename K>
 class SimpleGenericMap final : public MutableGenericMap<K> {
@@ -57,16 +55,33 @@ protected:
 public:
     SimpleGenericMap() = default;
     SimpleGenericMap(SimpleGenericMap const& other) = default;
-    SimpleGenericMap(SimpleGenericMap&&) = default;
-    SimpleGenericMap(GenericMap<K> const& other) : _storage(_convertStorage(other)) {}
+    SimpleGenericMap(SimpleGenericMap&&) noexcept = default;
+    /**
+     * Convert another GenericMap into a SimpleGenericMap.
+     *
+     * This constructor will insert key-value pairs following `other`'s
+     * iteration order. This may not be the order in which they were inserted
+     * into the original map.
+     */
+    SimpleGenericMap(GenericMap<K> const& other) : _storage(_convertStorage(other)), _keyView(other.keys()) {}
     virtual ~SimpleGenericMap() noexcept = default;
 
-    SimpleGenericMap& operator=(SimpleGenericMap const& other) = default;
-    SimpleGenericMap& operator=(SimpleGenericMap&&) = default;
+    SimpleGenericMap& operator=(SimpleGenericMap const& other) {
+        std::vector<K> newKeys = other._keyView;
+        _storage = other._storage;
+        // strong exception safety because no exceptions can occur past this point
+        using std::swap;
+        swap(_keyView, newKeys);
+        return *this;
+    }
+    SimpleGenericMap& operator=(SimpleGenericMap&&) noexcept = default;
     SimpleGenericMap& operator=(GenericMap<K> const& other) {
-        // Atomic because unordered_map is nothrow move-assignable,
-        // so only _convertStorage can fail
+        std::vector<K> newKeys = other.keys();
+        // strong exception safety: unordered_map is nothrow move-assignable and
+        // vector is nothrow swappable, so no exceptions can occur after _convertStorage returns
         _storage = _convertStorage(other);
+        using std::swap;
+        swap(_keyView, newKeys);
         return *this;
     }
 
@@ -74,20 +89,18 @@ public:
 
     bool empty() const noexcept override { return _storage.empty(); }
 
-    typename GenericMap<K>::size_type max_size() const noexcept override { return _storage.max_size(); }
+    typename GenericMap<K>::size_type max_size() const noexcept override {
+        return std::min(_storage.max_size(), _keyView.max_size());
+    }
 
     bool contains(K const& key) const override { return _storage.count(key) > 0; }
 
-    std::vector<K> keys() const override {
-        std::vector<K> keySnapshot;
-        keySnapshot.reserve(_storage.size());
-        for (auto const& pair : _storage) {
-            keySnapshot.push_back(pair.first);
-        }
-        return keySnapshot;
-    }
+    std::vector<K> const& keys() const noexcept override { return _keyView; }
 
-    void clear() noexcept override { _storage.clear(); }
+    void clear() noexcept override {
+        _storage.clear();
+        _keyView.clear();
+    }
 
 protected:
     ConstValueReference unsafeLookup(K key) const override {
@@ -101,14 +114,43 @@ protected:
     }
 
     bool unsafeInsert(K key, StorableType&& value) override {
-        return _storage.emplace(key, std::move(value)).second;
+        std::vector<K> newKeys = _keyView;
+        newKeys.emplace_back(key);
+        bool inserted = _storage.emplace(key, std::move(value)).second;
+        // strong exception safety because no exceptions can occur past this point
+        if (inserted) {
+            // _storage did not previously include key, so the key appended to newKeys is unique
+            using std::swap;
+            swap(_keyView, newKeys);
+        }
+        return inserted;
     }
 
-    bool unsafeErase(K key) override { return _storage.erase(key); }
+    bool unsafeErase(K key) override {
+        std::vector<K> newKeys = _keyView;
+        for (auto it = newKeys.cbegin(); it != newKeys.cend();) {
+            if (*it == key) {
+                it = newKeys.erase(it);
+            } else {
+                ++it;
+            }
+        }
+        // strong exception safety because no exceptions can occur past this point
+        bool erased = _storage.erase(key) > 0;
+        if (erased) {
+            using std::swap;
+            swap(_keyView, newKeys);
+        }
+        return erased;
+    }
 
 private:
     // StorableType is a value, so we might as well use it in the implementation
     std::unordered_map<K, StorableType> _storage;
+    std::vector<K> _keyView;
+    // Class invariant: the elements of _keyView are unique
+    // Class invariant: the elements of _keyView and the keys of _storage are the same
+    // Class invariant: the elements of _keyView are arranged in insertion order, oldest to newest
 
     /**
      * Create a new back-end map that contains the same mappings as a GenericMap.

--- a/include/lsst/afw/typehandling/SimpleGenericMap.h
+++ b/include/lsst/afw/typehandling/SimpleGenericMap.h
@@ -52,7 +52,7 @@ template <typename K>
 class SimpleGenericMap final : public MutableGenericMap<K> {
 protected:
     using typename GenericMap<K>::StorableType;
-    using typename GenericMap<K>::ValueReference;
+    using typename GenericMap<K>::ConstValueReference;
 
 public:
     SimpleGenericMap() = default;
@@ -83,7 +83,7 @@ public:
     void clear() noexcept override { _storage.clear(); }
 
 protected:
-    ValueReference unsafeLookup(K key) const override {
+    ConstValueReference unsafeLookup(K key) const override {
         try {
             return _storage.at(key);
         } catch (std::out_of_range& e) {

--- a/python/lsst/afw/typehandling/_GenericMap.cc
+++ b/python/lsst/afw/typehandling/_GenericMap.cc
@@ -126,8 +126,8 @@ void declareGenericMap(utils::python::WrapperCollection& wrappers, std::string c
         // __iter__ easier to implement in Python
         cls.def("__len__", &Class::size);
         cls.def("__bool__", [](Class const& self) { return !self.empty(); });
-        cls.def("_keys", &Class::keys);  // Private to let a proper view be defined in Python
-        // keys easier to implement in Python
+        // Can't wrap keys directly because pybind11 always copies vectors, so it won't be a view
+        cls.def("_keys", &Class::keys, py::return_value_policy::reference_internal);
         // items easier to implement in Python
         // values easier to implement in Python
     });

--- a/python/lsst/afw/typehandling/_GenericMap.cc
+++ b/python/lsst/afw/typehandling/_GenericMap.cc
@@ -65,7 +65,7 @@ namespace {
 template <typename K>
 class Publicist : public MutableGenericMap<K> {
 public:
-    using GenericMap<K>::ConstValueReference;
+    using typename GenericMap<K>::ConstValueReference;
     using GenericMap<K>::unsafeLookup;
     using MutableGenericMap<K>::unsafeErase;
 };

--- a/python/lsst/afw/typehandling/_GenericMap.cc
+++ b/python/lsst/afw/typehandling/_GenericMap.cc
@@ -65,13 +65,15 @@ namespace {
 template <typename K>
 class Publicist : public MutableGenericMap<K> {
 public:
-    using MutableGenericMap<K>::unsafeLookup;
+    using GenericMap<K>::ConstValueReference;
+    using GenericMap<K>::unsafeLookup;
     using MutableGenericMap<K>::unsafeErase;
 };
 
 template <typename K>
 py::object get(GenericMap<K>& self, K const& key) {
-    auto callable = &Publicist<K>::unsafeLookup;
+    auto callable = static_cast<typename Publicist<K>::ConstValueReference (GenericMap<K>::*)(K) const>(
+            &Publicist<K>::unsafeLookup);
     return py::cast((self.*callable)(key));
 };
 

--- a/python/lsst/afw/typehandling/_GenericMap.cc
+++ b/python/lsst/afw/typehandling/_GenericMap.cc
@@ -123,11 +123,12 @@ void declareGenericMap(utils::python::WrapperCollection& wrappers, std::string c
                 // Prevent segfaults when assigning a key<Storable> to Python variable, then deleting from map
                 // No existing code depends on being able to modify an item stored by value
                 "key"_a, "default"_a = py::none(), py::return_value_policy::copy);
-        // __iter__ easier to implement in Python
+        cls.def("__iter__",
+                [](Class const& self) { return py::make_iterator(self.keys().begin(), self.keys().end()); },
+                py::keep_alive<0, 1>());
         cls.def("__len__", &Class::size);
         cls.def("__bool__", [](Class const& self) { return !self.empty(); });
         // Can't wrap keys directly because pybind11 always copies vectors, so it won't be a view
-        cls.def("_keys", &Class::keys, py::return_value_policy::reference_internal);
         // items easier to implement in Python
         // values easier to implement in Python
     });

--- a/python/lsst/afw/typehandling/_GenericMap.py
+++ b/python/lsst/afw/typehandling/_GenericMap.py
@@ -34,10 +34,6 @@ class GenericMapS:
         className = type(self).__name__
         return className + "({" + ", ".join("%r: %r" % (key, value) for key, value in self.items()) + "})"
 
-    def __iter__(self):
-        for key in self._keys():
-            yield key
-
     # Support equality with any Mapping, including dict
     # Not clear why Mapping.__eq__ doesn't work
     def __eq__(self, other):

--- a/src/typehandling/PolymorphicValue.cc
+++ b/src/typehandling/PolymorphicValue.cc
@@ -38,7 +38,7 @@ PolymorphicValue::~PolymorphicValue() noexcept = default;
 
 PolymorphicValue::PolymorphicValue(PolymorphicValue const& other)
         : _value(other._value ? other._value->cloneStorable() : nullptr) {}
-PolymorphicValue::PolymorphicValue(PolymorphicValue&&) = default;  // other._value emptied
+PolymorphicValue::PolymorphicValue(PolymorphicValue&&) noexcept = default;  // other._value emptied
 
 PolymorphicValue& PolymorphicValue::operator=(PolymorphicValue const& other) {
     if (other._value) {
@@ -48,10 +48,15 @@ PolymorphicValue& PolymorphicValue::operator=(PolymorphicValue const& other) {
     }
     return *this;
 }
-PolymorphicValue& PolymorphicValue::operator=(PolymorphicValue&& other) {
+PolymorphicValue& PolymorphicValue::operator=(PolymorphicValue&& other) noexcept {
     using std::swap;
     swap(_value, other._value);
     return *this;
+}
+
+void PolymorphicValue::swap(PolymorphicValue& other) noexcept {
+    using std::swap;
+    swap(_value, other._value);
 }
 
 bool PolymorphicValue::empty() const noexcept { return !_value; }

--- a/tests/test_simpleGenericMap.cc
+++ b/tests/test_simpleGenericMap.cc
@@ -78,7 +78,7 @@ std::unique_ptr<SimpleGenericMap<int>> makeDerivedMap() {
     return std::unique_ptr<Map>(dynamic_cast<Map*>(factory.makeGenericMap().release()));
 }
 
-void checkIndependentCopy(SimpleGenericMap<int>& copy, SimpleGenericMap<int>& original) {
+void checkIndependentCopy(MutableGenericMap<int>& copy, MutableGenericMap<int>& original) {
     // Use BOOST_CHECK to avoid BOOST_TEST bug from GenericMap being unprintable
     BOOST_CHECK(original == copy);
 
@@ -100,8 +100,23 @@ BOOST_AUTO_TEST_CASE(Copy) {
     checkIndependentCopy(copy, *original);
 }
 
+BOOST_AUTO_TEST_CASE(CopyConvert) {
+    std::unique_ptr<MutableGenericMap<int>> original = makeDerivedMap();
+
+    SimpleGenericMap<int> copy(*original);
+    checkIndependentCopy(copy, *original);
+}
+
 BOOST_AUTO_TEST_CASE(CopyAssign) {
     auto original = makeDerivedMap();
+
+    SimpleGenericMap<int> copy;
+    copy = *original;
+    checkIndependentCopy(copy, *original);
+}
+
+BOOST_AUTO_TEST_CASE(CopyAssignConvert) {
+    std::unique_ptr<MutableGenericMap<int>> original = makeDerivedMap();
 
     SimpleGenericMap<int> copy;
     copy = *original;

--- a/tests/test_simpleGenericMap.cc
+++ b/tests/test_simpleGenericMap.cc
@@ -72,7 +72,7 @@ public:
 };
 
 std::unique_ptr<SimpleGenericMap<int>> makeDerivedMap() {
-    static SimpleGenericMapFactory factory;
+    static SimpleGenericMapFactory const factory;
     using Map = SimpleGenericMap<int>;
     // Exception-safe because only makeGenericMap() can throw
     return std::unique_ptr<Map>(dynamic_cast<Map*>(factory.makeGenericMap().release()));
@@ -155,6 +155,30 @@ BOOST_AUTO_TEST_CASE(MoveAssign) {
     BOOST_CHECK(backup == copy);
 
     checkIndependentMove(copy, *original);
+}
+
+BOOST_AUTO_TEST_CASE(IterationOrder) {
+    using namespace std::string_literals;
+    static SimpleGenericMapFactory const factory;
+    auto map = factory.makeMutableGenericMap();
+    auto const& keys = map->keys();
+
+    BOOST_REQUIRE(map->insert(makeKey<int>("firstKey"s), 42) == true);
+    BOOST_REQUIRE(map->insert(makeKey<std::string>("secondKey"s), "someValue"s) == true);
+    BOOST_REQUIRE(map->insert(makeKey<test::ComplexStorable>("thirdKey"s), test::ComplexStorable(-2.0)) ==
+                  true);
+    // Failed insert should not change iteration order
+    BOOST_REQUIRE(map->insert(makeKey<int>("firstKey"s), 0) == false);
+    BOOST_REQUIRE(map->insert(makeKey<std::string>("fourthKey"s), "anotherValue"s) == true);
+    // Failed insert should not change iteration order
+    BOOST_REQUIRE(map->insert(makeKey<double>("thirdKey"s), -2.0) == false);
+    BOOST_REQUIRE(map->insert(makeKey<bool>("fifthKey"s), false) == true);
+    BOOST_REQUIRE(map->erase(makeKey<std::string>("secondKey"s)) == true);
+    BOOST_REQUIRE(map->erase(makeKey<std::string>("fourthKey"s)) == true);
+    // A re-inserted key should not remember old position
+    BOOST_REQUIRE(map->insert(makeKey<std::string>("secondKey"s), "someValue"s) == true);
+
+    BOOST_TEST(keys == std::vector<std::string>({"firstKey"s, "thirdKey"s, "fifthKey"s, "secondKey"s}));
 }
 
 /// Boost::test initialization function


### PR DESCRIPTION
This PR introduces the visitor/"iteration" mechanism originally planned for `GenericMap`, adds some iteration-related features to `GenericMap` and `SimpleGenericMap`, and performs some refactoring of the code added in #461 that should make `GenericMap` easier to use and maintain. Because there are a lot of changes, I recommend reading the PR commit by commit (and possibly skipping the two "refactor" commits entirely, as they involve pushing a lot of TMP into private code).

One design decision that I'd like feedback on involves changing `GenericMap::keys` from a snapshot to a view. There needs to be _some_ API that lets `GenericMap` know how to iterate over its implementation class, and it's best if that API is non-throwing. I see three solutions that satisfy this requirement:
1. Make `keys` a view, as I've done. In C++, this forces the implementation class to maintain a `vector` of keys, and (if a `MutableGenericMap`) to keep it in sync with the "main" storage in an exception-safe way. The need for exception safety makes modifying methods more complicated than they would otherwise need to be, but this approach has the advantage of being conceptually simple.
1. Return a polymorphic iterator, whose subclass is specific to a particular `GenericMap` implementation. This avoids the exception-safety problems of a view and is straightforward to implement. However, to support polymorphism the iterator would need to be returned by smart pointer and passed around `GenericMap` code by pointer or reference, which is unC++ic (for example, the standard `for` loop expects iterators to be passed by value) and error-prone.
1. Create a non-polymorphic, non-template "iterator" class (though it behaves more like a Python generator) that will be created by the implementation class and used to implement `GenericMap` methods that need it. The "iterator" contains some storage (a `boost::any` or `std::any` memento) for the state of the iteration, as well as a callable that defines how to update the state and return the current key. The implementation class is responsible for defining the "iterator"'s initial state and the callable. This approach doesn't have the exception-safety issues of the key view and doesn't pretend to be compatible with the built-in iterator framework, but it's both unpythonic and unC++ic.

Which of these three approaches will make it easier to modify and create `GenericMap` subclasses in the long run?