### PR TITLE
DM-19902: Observatory longitude should be W and latitude N.

### DIFF
--- a/src/coord/Observatory.cc
+++ b/src/coord/Observatory.cc
@@ -56,7 +56,7 @@ void Observatory::setLongitude(lsst::geom::Angle const longitude) { _longitude =
 void Observatory::setElevation(double const elevation) { _elevation = elevation; }
 
 std::string Observatory::toString() const {
-    return (boost::format("%gW, %gN  %g") % getLatitude().asDegrees() % getLongitude().asDegrees() %
+    return (boost::format("%gW, %gN  %g") % getLongitude().asDegrees() % getLatitude().asDegrees() %
             getElevation())
             .str();
 }


### PR DESCRIPTION
The Observatory latitude and longitude appear to have been switched in the string representation.