### PR TITLE
DM-20142: Write DMTN on Exposure and persistence work

### DIFF
--- a/doc/manifest.yaml
+++ b/doc/manifest.yaml
@@ -13,3 +13,4 @@ modules:
   - "lsst.afw.image"
   - "lsst.afw.math"
   - "lsst.afw.table"
+  - "lsst.afw.typehandling"


### PR DESCRIPTION
This PR adds `lsst.afw.typehandling` to the site-wide documentation build; this subpackage was accidentally omitted in #461.