### PR TITLE
DM-20659: Fixes for the lsst.afw.table doc build

### DIFF
--- a/doc/lsst.afw.table/index.rst
+++ b/doc/lsst.afw.table/index.rst
@@ -6,11 +6,11 @@
 lsst.afw.table
 ##############
 
-The `lsst.afw.table`` module provides handlers for tables of data,
+The ``lsst.afw.table`` module provides handlers for tables of data,
 catalogs, and data records that comprise both for the LSST Science
 Pipelines.
 
-This module is a part of the larger `lsst.afw` code that provides the
+This module is a part of the larger ``lsst.afw`` package that provides the
 foundation of the pipelines.
 
 .. Paragraph that describes what this Python module does and links to related modules and frameworks.
@@ -22,11 +22,6 @@ Contributing
 
 ``lsst.afw.table`` is developed at https://github.com/lsst/afw.
 You can find Jira issues for this module under the `afw <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.
-
-.. toctree::
-   :maxdepth: 2
-
-   design-notes
 
 .. _lsst.afw.table-pyapi:
 

--- a/doc/lsst.afw.table/index.rst
+++ b/doc/lsst.afw.table/index.rst
@@ -34,22 +34,10 @@ Python API reference
 ====================
 
 .. automodapi:: lsst.afw.table
+   :no-main-docstr:
 
-.. automodapi:: lsst.afw.table.base
-.. automodapi:: lsst.afw.table.ampInfo
-.. automodapi:: lsst.afw.table.exposure
 .. automodapi:: lsst.afw.table.io
-.. automodapi:: lsst.afw.table.match
-.. automodapi:: lsst.afw.table.aggregates
-.. automodapi:: lsst.afw.table.aliasMap
-.. automodapi:: lsst.afw.table.arrays
-.. automodapi:: lsst.afw.table.baseColumnView
-.. automodapi:: lsst.afw.table.schema
-.. automodapi:: lsst.afw.table.schemaMapper
-.. automodapi:: lsst.afw.table.simple
-.. automodapi:: lsst.afw.table.source
+   :no-main-docstr:
 
-.. automodapi:: lsst.afw.table.multiMatch
-.. automodapi:: lsst.afw.table.catalogMatches
 .. automodapi:: lsst.afw.table.testUtils
-
+   :no-main-docstr:


### PR DESCRIPTION
This PR solves a documentation [build error](https://ci.lsst.codes/blue/organizations/jenkins/sqre%2Finfra%2Fdocumenteer/detail/documenteer/554/pipeline) on Jenkins:

```
  File "/j/ws/sqre/infra/documenteer/doc_template/home/.local/lib/python3.7/site-packages/sphinx/environment/__init__.py", line 785, in get_doctree
    with open(doctree_filename, 'rb') as f:
FileNotFoundError: [Errno 2] No such file or directory: '/j/ws/sqre/infra/documenteer/doc_template/_build/doctree/py-api/lsst.afw.table.multiMatch.CoordKey.doctree'
The full traceback has been saved in /tmp/sphinx-err-zna3ruxo.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
2019-07-17 12:21:44,310 ERROR documenteer.stackdocs.build: Sphinx errored: code 1
script returned exit code 1
```

The basic issue was that there were automodapi statements for individual sub packages that were already being pulled in by the automodapi directive for `lsst.afw.table` itself. Deleting those redundant automodapi directives solved the build issue.