### PR TITLE
DM-17982: Reiplement ExposureInfo using GenericMap

### DIFF
--- a/doc/lsst.afw.image/exposure-fits-metadata.rst
+++ b/doc/lsst.afw.image/exposure-fits-metadata.rst
@@ -4,8 +4,8 @@
 FITS metadata for lsst.afw.image Exposures
 ##########################################
 
-`ExposureInfo` and contents such as `Calib` and `VisitInfo` can be stored as FITS header keywords.
-The catalog schemas are described in ``ExposureInfo.cc``, ``Calib.cc``, and ``VisitInfo.cc``.
+`ExposureInfo` and contents such as `Filter` and `VisitInfo` can be stored as FITS header keywords.
+The catalog schemas are described in ``ExposureInfo.cc``, ``Filter.cc``, and ``VisitInfo.cc``.
 This page describes the equivalent FITS header keywords.
 
 HDU 0
@@ -177,20 +177,6 @@ HDU 0
      - `VisitInfo.getWeather`
 
        Relative humidity.
-
-   * - ``FLUXMAG0``
-     - float
-     - ADU
-     - `Calib.getFluxMag0`
-
-       Flux of a zero-magnitude object.
-
-   * - ``FLUXMAG0ERR``
-     - float
-     - ADU
-     - `Calib.getFluxMag0Err`
-
-       Error in the flux of a zero-magnitude object.
 
    * - ``FILTER``
      - str

--- a/doc/lsst.afw.image/exposure-fits-metadata.rst
+++ b/doc/lsst.afw.image/exposure-fits-metadata.rst
@@ -215,6 +215,13 @@ HDU 0
      -
      - Archive ID for the Exposure's valid polygon
 
+   * - ``ARCHIVE_ID_[name]``
+     - int
+     -
+     - `getComponent("[name]")`
+
+       Archive ID for an arbitrary Exposure component
+
 HDUs 1 to 3
 ===========
 

--- a/include/lsst/afw/image/Exposure.h
+++ b/include/lsst/afw/image/Exposure.h
@@ -315,8 +315,6 @@ public:
     void setPsf(std::shared_ptr<lsst::afw::detection::Psf const> psf) { _info->setPsf(psf); }
 
     /// Return the Exposure's Psf object
-    std::shared_ptr<lsst::afw::detection::Psf> getPsf() { return _info->getPsf(); }
-    /// Return the Exposure's Psf object
     std::shared_ptr<lsst::afw::detection::Psf const> getPsf() const { return _info->getPsf(); }
 
     /// Does this Exposure have a Psf?

--- a/include/lsst/afw/image/ExposureFitsReader.h
+++ b/include/lsst/afw/image/ExposureFitsReader.h
@@ -140,6 +140,9 @@ public:
     /// Read the Exposure's detector.
     std::shared_ptr<cameraGeom::Detector> readDetector();
 
+    /// Read the Exposure's non-standard components
+    std::map<std::string, std::shared_ptr<table::io::Persistable>> readExtraComponents();
+
     /// Read the ExposureInfo containing all non-image components.
     std::shared_ptr<ExposureInfo> readExposureInfo();
 

--- a/include/lsst/afw/image/ExposureInfo.h
+++ b/include/lsst/afw/image/ExposureInfo.h
@@ -68,8 +68,6 @@ class TransmissionCurve;
  *  The constness semantics of the things held by ExposureInfo are admittedly a bit of a mess,
  *  but they're that way to preserve backwards compatibility for now.  Eventually I'd like to make
  *  a lot of these things immutable, but in the meantime, here's the summary:
- *   - Psf is held by non-const pointer, and you can get a non-const pointer via a
- *     non-const member function accessor and a const pointer via a const member function accessor.
  *   - PhotoCalib is held by const pointer and only returned by const pointer (it's immutable).
  *   - Detector is held by const pointer and only returned by const pointer (but if you're
  *     in Python, SWIG will have casted all that constness away).
@@ -91,6 +89,8 @@ class ExposureInfo final {
 public:
     /// Standard key for looking up the Wcs.
     static typehandling::Key<std::string, std::shared_ptr<geom::SkyWcs const>> const KEY_WCS;
+    /// Standard key for looking up the point-spread function.
+    static typehandling::Key<std::string, std::shared_ptr<detection::Psf const>> const KEY_PSF;
 
     /// Does this exposure have a Wcs?
     bool hasWcs() const;
@@ -149,17 +149,13 @@ public:
     void setMetadata(std::shared_ptr<daf::base::PropertySet> metadata) { _metadata = metadata; }
 
     /// Does this exposure have a Psf?
-    bool hasPsf() const { return static_cast<bool>(_psf); }
+    bool hasPsf() const;
 
     /// Return the exposure's point-spread function
-    std::shared_ptr<detection::Psf> getPsf() const { return _psf; }
+    std::shared_ptr<detection::Psf const> getPsf() const;
 
     /// Set the exposure's point-spread function
-    void setPsf(std::shared_ptr<detection::Psf const> psf) {
-        // Psfs are immutable, so this is always safe; it'd be better to always just pass around
-        // const or non-const pointers, instead of both, but this is more backwards-compatible.
-        _psf = std::const_pointer_cast<detection::Psf>(psf);
-    }
+    void setPsf(std::shared_ptr<detection::Psf const> psf);
 
     /// Does this exposure have a valid Polygon
     bool hasValidPolygon() const { return static_cast<bool>(_validPolygon); }
@@ -452,7 +448,6 @@ private:
         }
     }
 
-    std::shared_ptr<detection::Psf> _psf;
     std::shared_ptr<PhotoCalib const> _photoCalib;
     std::shared_ptr<cameraGeom::Detector const> _detector;
     std::shared_ptr<geom::polygon::Polygon const> _validPolygon;

--- a/include/lsst/afw/image/ExposureInfo.h
+++ b/include/lsst/afw/image/ExposureInfo.h
@@ -243,14 +243,14 @@ public:
             std::shared_ptr<TransmissionCurve const> const& transmissionCurve =
                     std::shared_ptr<TransmissionCurve>());
 
-    /// Copy constructor; deep-copies all components except the metadata.
+    /// Copy constructor; shares all components except the filter.
     ExposureInfo(ExposureInfo const& other);
     ExposureInfo(ExposureInfo&& other);
 
-    /// Copy constructor; deep-copies everything, possibly including the metadata.
+    /// Copy constructor; shares everything but the filter and possibly the metadata.
     ExposureInfo(ExposureInfo const& other, bool copyMetadata);
 
-    /// Assignment; deep-copies all components except the metadata.
+    /// Assignment; shares all components except the filter.
     ExposureInfo& operator=(ExposureInfo const& other);
     ExposureInfo& operator=(ExposureInfo&& other);
 

--- a/include/lsst/afw/image/ExposureInfo.h
+++ b/include/lsst/afw/image/ExposureInfo.h
@@ -97,6 +97,8 @@ public:
             KEY_VALID_POLYGON;
     /// Standard key for looking up coadd provenance catalogs.
     static typehandling::Key<std::string, std::shared_ptr<CoaddInputs const>> const KEY_COADD_INPUTS;
+    /// Standard key for looking up the aperture correction map.
+    static typehandling::Key<std::string, std::shared_ptr<ApCorrMap const>> const KEY_AP_CORR_MAP;
 
     /// Does this exposure have a Wcs?
     bool hasWcs() const;
@@ -173,16 +175,13 @@ public:
     void setValidPolygon(std::shared_ptr<geom::polygon::Polygon const> polygon);
 
     /// Return true if the exposure has an aperture correction map
-    bool hasApCorrMap() const { return static_cast<bool>(_apCorrMap); }
+    bool hasApCorrMap() const;
 
     /// Return the exposure's aperture correction map (null pointer if !hasApCorrMap())
-    std::shared_ptr<ApCorrMap> getApCorrMap() { return _apCorrMap; }
-
-    /// Return the exposure's aperture correction map (null pointer if !hasApCorrMap())
-    std::shared_ptr<ApCorrMap const> getApCorrMap() const { return _apCorrMap; }
+    std::shared_ptr<ApCorrMap const> getApCorrMap() const;
 
     /// Set the exposure's aperture correction map (null pointer if !hasApCorrMap())
-    void setApCorrMap(std::shared_ptr<ApCorrMap> apCorrMap) { _apCorrMap = apCorrMap; }
+    void setApCorrMap(std::shared_ptr<ApCorrMap const> apCorrMap);
 
     /**
      *  Set the exposure's aperture correction map to a new, empty map
@@ -456,7 +455,6 @@ private:
 
     Filter _filter;
     std::shared_ptr<daf::base::PropertySet> _metadata;
-    std::shared_ptr<ApCorrMap> _apCorrMap;
     std::shared_ptr<image::VisitInfo const> _visitInfo;
     std::shared_ptr<TransmissionCurve const> _transmissionCurve;
 

--- a/include/lsst/afw/image/ExposureInfo.h
+++ b/include/lsst/afw/image/ExposureInfo.h
@@ -99,6 +99,9 @@ public:
     static typehandling::Key<std::string, std::shared_ptr<CoaddInputs const>> const KEY_COADD_INPUTS;
     /// Standard key for looking up the aperture correction map.
     static typehandling::Key<std::string, std::shared_ptr<ApCorrMap const>> const KEY_AP_CORR_MAP;
+    /// Standard key for looking up the transmission curve.
+    static typehandling::Key<std::string, std::shared_ptr<TransmissionCurve const>> const
+            KEY_TRANSMISSION_CURVE;
 
     /// Does this exposure have a Wcs?
     bool hasWcs() const;
@@ -210,13 +213,13 @@ public:
     void setVisitInfo(std::shared_ptr<image::VisitInfo const> const visitInfo) { _visitInfo = visitInfo; }
 
     /// Does this exposure have a transmission curve?
-    bool hasTransmissionCurve() const { return static_cast<bool>(_transmissionCurve); }
+    bool hasTransmissionCurve() const;
 
     /// Return the exposure's transmission curve.
-    std::shared_ptr<TransmissionCurve const> getTransmissionCurve() const { return _transmissionCurve; }
+    std::shared_ptr<TransmissionCurve const> getTransmissionCurve() const;
 
     /// Set the exposure's transmission curve.
-    void setTransmissionCurve(std::shared_ptr<TransmissionCurve const> tc) { _transmissionCurve = tc; }
+    void setTransmissionCurve(std::shared_ptr<TransmissionCurve const> tc);
 
     /**
      * Add a generic component to the ExposureInfo.
@@ -456,7 +459,6 @@ private:
     Filter _filter;
     std::shared_ptr<daf::base::PropertySet> _metadata;
     std::shared_ptr<image::VisitInfo const> _visitInfo;
-    std::shared_ptr<TransmissionCurve const> _transmissionCurve;
 
     // Class invariant: all values in _components are shared_ptr<Storable>
     // This is required for table::io persistence to work correctly;

--- a/include/lsst/afw/image/ExposureInfo.h
+++ b/include/lsst/afw/image/ExposureInfo.h
@@ -68,8 +68,6 @@ class TransmissionCurve;
  *  The constness semantics of the things held by ExposureInfo are admittedly a bit of a mess,
  *  but they're that way to preserve backwards compatibility for now.  Eventually I'd like to make
  *  a lot of these things immutable, but in the meantime, here's the summary:
- *   - Detector is held by const pointer and only returned by const pointer (but if you're
- *     in Python, SWIG will have casted all that constness away).
  *   - Filter is held and returned by value.
  *   - VisitInfo is immutable and is held by a const ptr and has a setter and getter.
  *   - Metadata is held by non-const pointer, and you can get a non-const pointer via a const
@@ -92,6 +90,8 @@ public:
     static typehandling::Key<std::string, std::shared_ptr<detection::Psf const>> const KEY_PSF;
     /// Standard key for looking up the photometric calibration.
     static typehandling::Key<std::string, std::shared_ptr<PhotoCalib const>> const KEY_PHOTO_CALIB;
+    /// Standard key for looking up the detector information.
+    static typehandling::Key<std::string, std::shared_ptr<cameraGeom::Detector const>> const KEY_DETECTOR;
 
     /// Does this exposure have a Wcs?
     bool hasWcs() const;
@@ -103,13 +103,13 @@ public:
     void setWcs(std::shared_ptr<geom::SkyWcs const> wcs);
 
     /// Does this exposure have Detector information?
-    bool hasDetector() const { return static_cast<bool>(_detector); }
+    bool hasDetector() const;
 
     /// Return the exposure's Detector information
-    std::shared_ptr<cameraGeom::Detector const> getDetector() const { return _detector; }
+    std::shared_ptr<cameraGeom::Detector const> getDetector() const;
 
     /// Set the exposure's Detector information
-    void setDetector(std::shared_ptr<cameraGeom::Detector const> detector) { _detector = detector; }
+    void setDetector(std::shared_ptr<cameraGeom::Detector const> detector);
 
     /// Return the exposure's filter
     Filter getFilter() const { return _filter; }
@@ -449,7 +449,6 @@ private:
         }
     }
 
-    std::shared_ptr<cameraGeom::Detector const> _detector;
     std::shared_ptr<geom::polygon::Polygon const> _validPolygon;
     Filter _filter;
     std::shared_ptr<daf::base::PropertySet> _metadata;

--- a/include/lsst/afw/image/ExposureInfo.h
+++ b/include/lsst/afw/image/ExposureInfo.h
@@ -31,6 +31,7 @@
 #include "lsst/afw/table/io/OutputArchive.h"
 #include "lsst/afw/image/CoaddInputs.h"
 #include "lsst/afw/image/VisitInfo.h"
+#include "lsst/afw/typehandling/GenericMap.h"
 
 namespace lsst {
 namespace afw {
@@ -344,6 +345,10 @@ private:
     std::shared_ptr<ApCorrMap> _apCorrMap;
     std::shared_ptr<image::VisitInfo const> _visitInfo;
     std::shared_ptr<TransmissionCurve const> _transmissionCurve;
+
+    // Class invariant: all values in _components are Storable or shared_ptr<Storable>
+    // Class invariant: all pointers in _components are not null
+    std::unique_ptr<typehandling::MutableGenericMap<std::string>> _components;
 };
 }  // namespace image
 }  // namespace afw

--- a/include/lsst/afw/image/ExposureInfo.h
+++ b/include/lsst/afw/image/ExposureInfo.h
@@ -415,6 +415,14 @@ private:
      */
     void _finishWriteFits(fits::Fits& fitsfile, FitsWriteData const& data) const;
 
+    /**
+     * GenericMap visitor for saving Storable objects
+     *
+     * Consistent with ExposureInfo's original behavior, any Storables that are
+     * not persistable are silently ignored.
+     */
+    class StorablePersister;
+
     static std::shared_ptr<ApCorrMap> _cloneApCorrMap(std::shared_ptr<ApCorrMap const> apCorrMap);
 
     // Implementation of setComponent, assumes T extends Storable or T = shared_ptr<? extends Storable>

--- a/include/lsst/afw/image/ExposureInfo.h
+++ b/include/lsst/afw/image/ExposureInfo.h
@@ -283,6 +283,30 @@ private:
     };
 
     /**
+     * Add a Persistable object to FITS data.
+     *
+     * @param[out] data the FITS output data to update
+     * @param[in] object the object to store
+     * @param[in] key the FITS header keyword to contain a unique ID for the object
+     * @param[in] comment the comment for ``key`` in the FITS header
+     *
+     * @return the unique ID for the object, as stored with ``key``
+     *
+     * @throws lsst::pex::exceptions::InvalidParameterError Thrown if ``key`` contains the "." character.
+     * @exceptsafe Does not provide exception safety; ``data`` may be corrupted in
+     *             the event of an exception. No other side effects.
+     *
+     * @{
+     */
+    static int _addToArchive(FitsWriteData& data, table::io::Persistable const& object, std::string key,
+                             std::string comment);
+
+    static int _addToArchive(FitsWriteData& data, std::shared_ptr<table::io::Persistable const> const& object,
+                             std::string key, std::string comment);
+
+    /** @} */
+
+    /**
      *  Start the process of writing an exposure to FITS.
      *
      *  @param[in]  xy0   The origin of the exposure associated with this object, used to

--- a/include/lsst/afw/image/ExposureInfo.h
+++ b/include/lsst/afw/image/ExposureInfo.h
@@ -68,7 +68,6 @@ class TransmissionCurve;
  *  The constness semantics of the things held by ExposureInfo are admittedly a bit of a mess,
  *  but they're that way to preserve backwards compatibility for now.  Eventually I'd like to make
  *  a lot of these things immutable, but in the meantime, here's the summary:
- *   - PhotoCalib is held by const pointer and only returned by const pointer (it's immutable).
  *   - Detector is held by const pointer and only returned by const pointer (but if you're
  *     in Python, SWIG will have casted all that constness away).
  *   - Filter is held and returned by value.
@@ -91,6 +90,8 @@ public:
     static typehandling::Key<std::string, std::shared_ptr<geom::SkyWcs const>> const KEY_WCS;
     /// Standard key for looking up the point-spread function.
     static typehandling::Key<std::string, std::shared_ptr<detection::Psf const>> const KEY_PSF;
+    /// Standard key for looking up the photometric calibration.
+    static typehandling::Key<std::string, std::shared_ptr<PhotoCalib const>> const KEY_PHOTO_CALIB;
 
     /// Does this exposure have a Wcs?
     bool hasWcs() const;
@@ -117,29 +118,29 @@ public:
     void setFilter(Filter const& filter) { _filter = filter; }
 
     /// Does this exposure have a photometric calibration?
-    bool hasPhotoCalib() const { return static_cast<bool>(_photoCalib); }
+    bool hasPhotoCalib() const;
 
     /// Return the exposure's photometric calibration
-    std::shared_ptr<PhotoCalib const> getPhotoCalib() const { return _photoCalib; }
+    std::shared_ptr<PhotoCalib const> getPhotoCalib() const;
 
     /// Set the Exposure's PhotoCalib object
-    void setPhotoCalib(std::shared_ptr<PhotoCalib const> photoCalib) { _photoCalib = photoCalib; }
+    void setPhotoCalib(std::shared_ptr<PhotoCalib const> photoCalib);
 
     /// Does this exposure have a photometric calibration?
     [[deprecated("Replaced with hasPhotoCalib (will be removed in 18.0)")]] bool hasCalib() const {
-        return static_cast<bool>(_photoCalib);
+        return hasPhotoCalib();
     }
 
     /// Return the exposure's photometric calibration
     [[deprecated("Replaced with getPhotoCalib (will be removed in 18.0)")]] std::shared_ptr<PhotoCalib const>
     getCalib() const {
-        return _photoCalib;
+        return getPhotoCalib();
     }
 
     /// Set the Exposure's PhotoCalib object
     [[deprecated("Replaced with setPhotoCalib (will be removed in 18.0)")]] void setCalib(
             std::shared_ptr<PhotoCalib const> photoCalib) {
-        _photoCalib = photoCalib;
+        setPhotoCalib(photoCalib);
     }
 
     /// Return flexible metadata
@@ -448,7 +449,6 @@ private:
         }
     }
 
-    std::shared_ptr<PhotoCalib const> _photoCalib;
     std::shared_ptr<cameraGeom::Detector const> _detector;
     std::shared_ptr<geom::polygon::Polygon const> _validPolygon;
     Filter _filter;

--- a/include/lsst/afw/image/ExposureInfo.h
+++ b/include/lsst/afw/image/ExposureInfo.h
@@ -95,6 +95,8 @@ public:
     /// Standard key for looking up the valid polygon.
     static typehandling::Key<std::string, std::shared_ptr<geom::polygon::Polygon const>> const
             KEY_VALID_POLYGON;
+    /// Standard key for looking up coadd provenance catalogs.
+    static typehandling::Key<std::string, std::shared_ptr<CoaddInputs const>> const KEY_COADD_INPUTS;
 
     /// Does this exposure have a Wcs?
     bool hasWcs() const;
@@ -191,13 +193,13 @@ public:
     void initApCorrMap();
 
     /// Does this exposure have coadd provenance catalogs?
-    bool hasCoaddInputs() const { return static_cast<bool>(_coaddInputs); }
+    bool hasCoaddInputs() const;
 
     /// Set the exposure's coadd provenance catalogs.
-    void setCoaddInputs(std::shared_ptr<CoaddInputs> coaddInputs) { _coaddInputs = coaddInputs; }
+    void setCoaddInputs(std::shared_ptr<CoaddInputs const> coaddInputs);
 
     /// Return a pair of catalogs that record the inputs, if this Exposure is a coadd (otherwise null).
-    std::shared_ptr<CoaddInputs> getCoaddInputs() const { return _coaddInputs; }
+    std::shared_ptr<CoaddInputs const> getCoaddInputs() const;
 
     /// Return the exposure's visit info
     std::shared_ptr<image::VisitInfo const> getVisitInfo() const { return _visitInfo; }
@@ -454,7 +456,6 @@ private:
 
     Filter _filter;
     std::shared_ptr<daf::base::PropertySet> _metadata;
-    std::shared_ptr<CoaddInputs> _coaddInputs;
     std::shared_ptr<ApCorrMap> _apCorrMap;
     std::shared_ptr<image::VisitInfo const> _visitInfo;
     std::shared_ptr<TransmissionCurve const> _transmissionCurve;

--- a/include/lsst/afw/image/ExposureInfo.h
+++ b/include/lsst/afw/image/ExposureInfo.h
@@ -68,7 +68,7 @@ class TransmissionCurve;
  *  The constness semantics of the things held by ExposureInfo are admittedly a bit of a mess,
  *  but they're that way to preserve backwards compatibility for now.  Eventually I'd like to make
  *  a lot of these things immutable, but in the meantime, here's the summary:
- *   - Wcs and Psf are held by non-const pointer, and you can get a non-const pointer via a
+ *   - Psf is held by non-const pointer, and you can get a non-const pointer via a
  *     non-const member function accessor and a const pointer via a const member function accessor.
  *   - PhotoCalib is held by const pointer and only returned by const pointer (it's immutable).
  *   - Detector is held by const pointer and only returned by const pointer (but if you're
@@ -77,6 +77,7 @@ class TransmissionCurve;
  *   - VisitInfo is immutable and is held by a const ptr and has a setter and getter.
  *   - Metadata is held by non-const pointer, and you can get a non-const pointer via a const
  *     member function accessor (i.e. constness is not propagated).
+ *   - all other types are only accessible through non-const pointers
  *
  *  The setter for Wcs clones its input arguments (this is a departure from the
  *  previous behavior for Wcs but it's safer w.r.t. aliasing and it matches the old
@@ -88,14 +89,17 @@ class TransmissionCurve;
  */
 class ExposureInfo final {
 public:
+    /// Standard key for looking up the Wcs.
+    static typehandling::Key<std::string, std::shared_ptr<geom::SkyWcs const>> const KEY_WCS;
+
     /// Does this exposure have a Wcs?
-    bool hasWcs() const { return static_cast<bool>(_wcs); }
+    bool hasWcs() const;
 
     /// Return the WCS of the exposure
-    std::shared_ptr<geom::SkyWcs const> getWcs() const { return _wcs; }
+    std::shared_ptr<geom::SkyWcs const> getWcs() const;
 
     /// Set the WCS of the exposure
-    void setWcs(std::shared_ptr<geom::SkyWcs const> wcs) { _wcs = wcs; }
+    void setWcs(std::shared_ptr<geom::SkyWcs const> wcs);
 
     /// Does this exposure have Detector information?
     bool hasDetector() const { return static_cast<bool>(_detector); }
@@ -448,7 +452,6 @@ private:
         }
     }
 
-    std::shared_ptr<geom::SkyWcs const> _wcs;
     std::shared_ptr<detection::Psf> _psf;
     std::shared_ptr<PhotoCalib const> _photoCalib;
     std::shared_ptr<cameraGeom::Detector const> _detector;

--- a/include/lsst/afw/image/ExposureInfo.h
+++ b/include/lsst/afw/image/ExposureInfo.h
@@ -92,6 +92,9 @@ public:
     static typehandling::Key<std::string, std::shared_ptr<PhotoCalib const>> const KEY_PHOTO_CALIB;
     /// Standard key for looking up the detector information.
     static typehandling::Key<std::string, std::shared_ptr<cameraGeom::Detector const>> const KEY_DETECTOR;
+    /// Standard key for looking up the valid polygon.
+    static typehandling::Key<std::string, std::shared_ptr<geom::polygon::Polygon const>> const
+            KEY_VALID_POLYGON;
 
     /// Does this exposure have a Wcs?
     bool hasWcs() const;
@@ -159,13 +162,13 @@ public:
     void setPsf(std::shared_ptr<detection::Psf const> psf);
 
     /// Does this exposure have a valid Polygon
-    bool hasValidPolygon() const { return static_cast<bool>(_validPolygon); }
+    bool hasValidPolygon() const;
 
     /// Return the valid Polygon
-    std::shared_ptr<geom::polygon::Polygon const> getValidPolygon() const { return _validPolygon; }
+    std::shared_ptr<geom::polygon::Polygon const> getValidPolygon() const;
 
     /// Set the exposure's valid Polygon
-    void setValidPolygon(std::shared_ptr<geom::polygon::Polygon const> polygon) { _validPolygon = polygon; }
+    void setValidPolygon(std::shared_ptr<geom::polygon::Polygon const> polygon);
 
     /// Return true if the exposure has an aperture correction map
     bool hasApCorrMap() const { return static_cast<bool>(_apCorrMap); }
@@ -449,7 +452,6 @@ private:
         }
     }
 
-    std::shared_ptr<geom::polygon::Polygon const> _validPolygon;
     Filter _filter;
     std::shared_ptr<daf::base::PropertySet> _metadata;
     std::shared_ptr<CoaddInputs> _coaddInputs;

--- a/include/lsst/afw/typehandling/GenericMap.h
+++ b/include/lsst/afw/typehandling/GenericMap.h
@@ -594,6 +594,10 @@ private:
         try {
             auto foo = unsafeLookup(key.getId());
             auto pointer = boost::get<std::shared_ptr<Storable> const&>(foo);
+            if (pointer == nullptr) {  // dynamic_cast not helpful
+                return nullptr;
+            }
+
             std::shared_ptr<T> typedPointer = std::dynamic_pointer_cast<T>(pointer);
             // shared_ptr can be empty without being null. dynamic_pointer_cast
             // only promises result of failed cast is empty, so test for that
@@ -661,6 +665,9 @@ private:
         auto foo = unsafeLookup(key.getId());
         try {
             auto pointer = boost::get<std::shared_ptr<Storable> const&>(foo);
+            if (pointer == nullptr) {  // Can't confirm type with dynamic_cast
+                return true;
+            }
             std::shared_ptr<T> typedPointer = std::dynamic_pointer_cast<T>(pointer);
             // shared_ptr can be empty without being null. dynamic_pointer_cast
             // only promises result of failed cast is empty, so test for that

--- a/include/lsst/afw/typehandling/test.h
+++ b/include/lsst/afw/typehandling/test.h
@@ -124,6 +124,8 @@ auto const KEY4 = makeKey<std::shared_ptr<SimpleStorable>>(4);
 auto const VALUE4 = SimpleStorable();
 auto const KEY5 = makeKey<ComplexStorable>(5);
 auto const VALUE5 = ComplexStorable(-100.0);
+auto const KEY6 = makeKey<std::shared_ptr<Storable>>(6);
+auto const VALUE6 = std::shared_ptr<Storable>();
 }  // namespace
 
 /**
@@ -142,6 +144,7 @@ public:
      * * `KEY3: VALUE3`
      * * `KEY4: std::shared_ptr<>(VALUE4)`
      * * `KEY5: VALUE5`
+     * * `KEY6: VALUE6`
      */
     virtual std::unique_ptr<GenericMap<int>> makeGenericMap() const = 0;
 
@@ -159,6 +162,7 @@ BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestConstAt, GenericMapFactory) {
     BOOST_TEST(demoMap->at(KEY3) == VALUE3);
     BOOST_TEST(*(demoMap->at(KEY4)) == VALUE4);
     BOOST_TEST(demoMap->at(KEY5) == VALUE5);
+    BOOST_TEST(demoMap->at(KEY6) == VALUE6);
 }
 
 BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestAt, GenericMapFactory) {
@@ -199,6 +203,8 @@ BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestAt, GenericMapFactory) {
     ComplexStorable newValue(5.0);
     demoMap->at(KEY5) = newValue;
     BOOST_TEST(demoMap->at(KEY5) == newValue);
+
+    BOOST_TEST(demoMap->at(KEY6) == VALUE6);
 }
 
 BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestEquals, GenericMapFactory) {
@@ -232,6 +238,8 @@ BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestConstVisitor, GenericMapFactory) {
                 return universalToString(map->at(KEY4));
             case 5:
                 return universalToString(map->at(KEY5));
+            case 6:
+                return universalToString(map->at(KEY6));
             default:
                 throw std::invalid_argument("Bad key found");
         };
@@ -259,14 +267,17 @@ BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestConstVisitor, GenericMapFactory) {
     map->apply(printer);
     BOOST_REQUIRE(printer.results.size() == expected.size());
     for (std::size_t i = 0; i < printer.results.size(); ++i) {
-        BOOST_TEST(printer.results[i] == expected[i], printer.results[i] << " != " << expected[i] << ", key = " << mapKeys[i]);
+        BOOST_TEST(printer.results[i] == expected[i],
+                   printer.results[i] << " != " << expected[i] << ", key = " << mapKeys[i]);
     }
 
     // Test lambda that returns string
-    std::vector<std::string> strings = map->apply([](int, auto const& value) { return universalToString(value); });
+    std::vector<std::string> strings =
+            map->apply([](int, auto const& value) { return universalToString(value); });
     BOOST_REQUIRE(strings.size() == expected.size());
     for (std::size_t i = 0; i < strings.size(); ++i) {
-        BOOST_TEST(strings[i] == expected[i], strings[i] << " != " << expected[i] << ", key = " << mapKeys[i]);
+        BOOST_TEST(strings[i] == expected[i],
+                   strings[i] << " != " << expected[i] << ", key = " << mapKeys[i]);
     }
 }
 
@@ -304,6 +315,7 @@ BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestModifyingVoidVisitor, GenericMapFactory) {
     BOOST_TEST(*(map->at(KEY4)) == VALUE4);
     BOOST_TEST(map->at(KEY5) != VALUE5);
     BOOST_TEST(map->at(KEY5) == ComplexStorable(42));
+    BOOST_TEST(map->at(KEY6) == nullptr);
 }
 
 BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestModifyingReturningVisitor, GenericMapFactory) {
@@ -360,6 +372,7 @@ BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestModifyingReturningVisitor, GenericMapFacto
     BOOST_TEST(*(map->at(KEY4)) == VALUE4);
     BOOST_TEST(map->at(KEY5) != VALUE5);
     BOOST_TEST(map->at(KEY5) == ComplexStorable(42));
+    BOOST_TEST(map->at(KEY6) == nullptr);
 }
 
 BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestMutableEquals, GenericMapFactory) {
@@ -393,13 +406,19 @@ BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestMutableEquals, GenericMapFactory) {
     BOOST_CHECK(*map1 != *map2);
     map2->insert(storableKey, VALUE5);
     BOOST_CHECK(*map1 == *map2);
+
+    auto nullKey = makeKey<std::shared_ptr<ComplexStorable>>("null"s);
+    map1->insert(nullKey, std::static_pointer_cast<ComplexStorable>(VALUE6));
+    BOOST_CHECK(*map1 != *map2);
+    map2->insert(nullKey, std::static_pointer_cast<ComplexStorable>(VALUE6));
+    BOOST_CHECK(*map1 == *map2);
 }
 
 BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestSize, GenericMapFactory) {
     static GenericMapFactory const factory;
     std::unique_ptr<GenericMap<int>> demoMap = factory.makeGenericMap();
 
-    BOOST_TEST(demoMap->size() == 6);
+    BOOST_TEST(demoMap->size() == 7);
     BOOST_TEST(!demoMap->empty());
 }
 
@@ -433,7 +452,7 @@ BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestWeakContains, GenericMapFactory) {
     BOOST_TEST(demoMap->contains(KEY3.getId()));
     BOOST_TEST(demoMap->contains(KEY4.getId()));
     BOOST_TEST(demoMap->contains(KEY5.getId()));
-    BOOST_TEST(!demoMap->contains(6));
+    BOOST_TEST(demoMap->contains(KEY6.getId()));
 }
 
 BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestContains, GenericMapFactory) {
@@ -459,6 +478,10 @@ BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestContains, GenericMapFactory) {
     BOOST_TEST(demoMap->contains(KEY5));
     BOOST_TEST(demoMap->contains(makeKey<SimpleStorable>(KEY5.getId())));
     BOOST_TEST(demoMap->contains(makeKey<Storable>(KEY5.getId())));
+
+    BOOST_TEST(demoMap->contains(KEY6));
+    BOOST_TEST(demoMap->contains(makeKey<std::shared_ptr<SimpleStorable>>(KEY6.getId())));
+    BOOST_TEST(demoMap->contains(makeKey<std::shared_ptr<ComplexStorable>>(KEY6.getId())));
 }
 
 BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestKeys, GenericMapFactory) {
@@ -469,7 +492,7 @@ BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestKeys, GenericMapFactory) {
     std::set<int> keys(orderedKeys.begin(), orderedKeys.end());
 
     BOOST_TEST(keys == std::set<int>({KEY0.getId(), KEY1.getId(), KEY2.getId(), KEY3.getId(), KEY4.getId(),
-                                      KEY5.getId()}));
+                                      KEY5.getId(), KEY6.getId()}));
 }
 
 BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestKeyOrder, GenericMapFactory) {
@@ -622,15 +645,17 @@ BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestInsertStorable, GenericMapFactory) {
     BOOST_TEST(demoMap->insert<Storable>(makeKey<Storable>("foo"s), SimpleStorable()) == false);
     BOOST_TEST(demoMap->insert(makeKey<std::shared_ptr<SimpleStorable>>("bar"s),
                                std::make_shared<SimpleStorable>()) == false);
+    BOOST_TEST(demoMap->insert(makeKey<std::shared_ptr<SimpleStorable>>("null"s),
+                               std::make_shared<SimpleStorable>()) == true);
 
     BOOST_TEST(!demoMap->empty());
-    BOOST_TEST(demoMap->size() == 2);
+    BOOST_TEST(demoMap->size() == 3);
     BOOST_TEST(demoMap->contains("foo"s));
     BOOST_TEST(demoMap->contains(makeKey<Storable>("foo"s)));
     BOOST_TEST(demoMap->contains(makeKey<std::shared_ptr<ComplexStorable>>("bar"s)));
+    BOOST_TEST(demoMap->contains(makeKey<std::shared_ptr<SimpleStorable>>("null"s)));
 
     // ComplexStorable::operator== is asymmetric
-    // Use BOOST_CHECK_EQUAL to avoid BOOST_TEST bug from Storable being abstract
     BOOST_TEST(object == demoMap->at(makeKey<SimpleStorable>("foo"s)));
     object = ComplexStorable(1.4);
     BOOST_TEST(object != demoMap->at(makeKey<SimpleStorable>("foo"s)));

--- a/include/lsst/afw/typehandling/test.h
+++ b/include/lsst/afw/typehandling/test.h
@@ -465,11 +465,21 @@ BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestKeys, GenericMapFactory) {
     static GenericMapFactory const factory;
     std::unique_ptr<GenericMap<int> const> demoMap = factory.makeGenericMap();
     auto orderedKeys = demoMap->keys();
-    // GenericMaps don't have an iteration order yet
+    // GenericMap allows keys in any order, so just check they're the same
     std::set<int> keys(orderedKeys.begin(), orderedKeys.end());
 
     BOOST_TEST(keys == std::set<int>({KEY0.getId(), KEY1.getId(), KEY2.getId(), KEY3.getId(), KEY4.getId(),
                                       KEY5.getId()}));
+}
+
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestKeyOrder, GenericMapFactory) {
+    static GenericMapFactory const factory;
+    std::unique_ptr<GenericMap<int> const> demoMap = factory.makeGenericMap();
+    auto keys = demoMap->keys();
+
+    std::vector<int> iterOrder;
+    demoMap->apply([&iterOrder](int key, auto value) { iterOrder.push_back(key); });
+    BOOST_TEST(keys == iterOrder);
 }
 
 BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestClearIdempotent, GenericMapFactory) {
@@ -709,6 +719,7 @@ void addGenericMapTestCases(boost::unit_test::test_suite* const suite) {
     suite->add(BOOST_TEST_CASE_TEMPLATE(TestWeakContains, factories));
     suite->add(BOOST_TEST_CASE_TEMPLATE(TestContains, factories));
     suite->add(BOOST_TEST_CASE_TEMPLATE(TestKeys, factories));
+    suite->add(BOOST_TEST_CASE_TEMPLATE(TestKeyOrder, factories));
     suite->add(BOOST_TEST_CASE_TEMPLATE(TestConstVisitor, factories));
     suite->add(BOOST_TEST_CASE_TEMPLATE(TestModifyingVoidVisitor, factories));
     suite->add(BOOST_TEST_CASE_TEMPLATE(TestModifyingReturningVisitor, factories));

--- a/python/lsst/afw/cameraGeom/detector/detector.cc
+++ b/python/lsst/afw/cameraGeom/detector/detector.cc
@@ -33,6 +33,7 @@
 #include "lsst/geom.h"
 #include "lsst/afw/table/AmpInfo.h"
 #include "lsst/afw/table/io/python.h"
+#include "lsst/afw/typehandling/Storable.h"
 #include "lsst/afw/cameraGeom/Detector.h"
 #include "lsst/afw/cameraGeom/TransformMap.h"
 
@@ -77,7 +78,8 @@ void declare2SysMethods(PyClass &cls) {
 
 PYBIND11_MODULE(detector, mod) {
     /* Module level */
-    py::class_<Detector, std::shared_ptr<Detector>> cls(mod, "Detector");
+    py::module::import("lsst.afw.typehandling");
+    py::class_<Detector, std::shared_ptr<Detector>, typehandling::Storable> cls(mod, "Detector");
 
     /* Member types and enums */
     py::enum_<DetectorType>(mod, "DetectorType")

--- a/python/lsst/afw/detection/_psf.cc
+++ b/python/lsst/afw/detection/_psf.cc
@@ -30,6 +30,7 @@
 #include "lsst/geom/Point.h"
 #include "lsst/afw/image/Color.h"
 #include "lsst/afw/table/io/python.h"  // for addPersistableMethods
+#include "lsst/afw/typehandling/Storable.h"
 #include "lsst/afw/detection/Psf.h"
 
 namespace py = pybind11;
@@ -44,12 +45,14 @@ auto const NullPoint = lsst::geom::Point2D(std::numeric_limits<double>::quiet_Na
 }
 
 void wrapPsf(utils::python::WrapperCollection& wrappers) {
+    wrappers.addInheritanceDependency("lsst.afw.typehandling");
     wrappers.addSignatureDependency("lsst.afw.geom.ellipses");
     wrappers.addSignatureDependency("lsst.afw.image");
     wrappers.addSignatureDependency("lsst.afw.fits");
 
     auto clsPsf = wrappers.wrapType(
-            py::class_<Psf, std::shared_ptr<Psf>>(wrappers.module, "Psf"), [](auto& mod, auto& cls) {
+            py::class_<Psf, std::shared_ptr<Psf>, typehandling::Storable>(wrappers.module, "Psf"),
+            [](auto& mod, auto& cls) {
                 table::io::python::addPersistableMethods<Psf>(cls);
 
                 cls.def("clone", &Psf::clone);

--- a/python/lsst/afw/geom/polygon/polygon.cc
+++ b/python/lsst/afw/geom/polygon/polygon.cc
@@ -31,6 +31,7 @@
 #include "lsst/geom/Point.h"
 #include "lsst/geom/AffineTransform.h"
 #include "lsst/afw/geom/Transform.h"
+#include "lsst/afw/typehandling/Storable.h"
 #include "lsst/afw/geom/polygon/Polygon.h"
 #include "lsst/afw/table/io/python.h"  // for addPersistableMethods
 
@@ -44,12 +45,13 @@ namespace polygon {
 
 PYBIND11_MODULE(polygon, mod) {
     py::module::import("lsst.pex.exceptions");
+    py::module::import("lsst.afw.typehandling");
 
     // TODO: Commented-out code is waiting until needed and is untested.
     // Add tests for it and enable it or remove it before the final pybind11 merge.
 
     /* Module level */
-    py::class_<Polygon, std::shared_ptr<Polygon>> clsPolygon(mod, "Polygon");
+    py::class_<Polygon, std::shared_ptr<Polygon>, typehandling::Storable> clsPolygon(mod, "Polygon");
 
     pex::exceptions::python::declareException<SinglePolygonException, pex::exceptions::RuntimeError>(
             mod, "SinglePolygonException", "RuntimeError");

--- a/python/lsst/afw/geom/skyWcs/skyWcs.cc
+++ b/python/lsst/afw/geom/skyWcs/skyWcs.cc
@@ -34,6 +34,7 @@
 #include "lsst/geom.h"
 #include "lsst/afw/geom/Endpoint.h"
 #include "lsst/afw/geom/Transform.h"
+#include "lsst/afw/typehandling/Storable.h"
 #include "lsst/afw/geom/SkyWcs.h"
 #include "lsst/afw/table/io/python.h"  // for addPersistableMethods
 #include "lsst/utils/python.h"
@@ -49,6 +50,7 @@ namespace {
 PYBIND11_MODULE(skyWcs, mod) {
     py::module::import("lsst.geom");
     py::module::import("lsst.afw.geom.transform");
+    py::module::import("lsst.afw.typehandling");
 
     mod.def("makeCdMatrix", makeCdMatrix, "scale"_a, "orientation"_a = 0 * lsst::geom::degrees,
             "flipX"_a = false);
@@ -80,7 +82,7 @@ PYBIND11_MODULE(skyWcs, mod) {
     mod.def("getPixelToIntermediateWorldCoords", getPixelToIntermediateWorldCoords, "wcs"_a,
             "simplify"_a = true);
 
-    py::class_<SkyWcs, std::shared_ptr<SkyWcs>> cls(mod, "SkyWcs");
+    py::class_<SkyWcs, std::shared_ptr<SkyWcs>, typehandling::Storable> cls(mod, "SkyWcs");
 
     cls.def(py::init<daf::base::PropertySet &, bool>(), "metadata"_a, "strip"_a = false);
     cls.def(py::init<ast::FrameDict const &>(), "frameDict"_a);

--- a/python/lsst/afw/image/apCorrMap/apCorrMap.cc
+++ b/python/lsst/afw/image/apCorrMap/apCorrMap.cc
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "lsst/afw/table/io/python.h"  // for addPersistableMethods
+#include "lsst/afw/typehandling/Storable.h"
 #include "lsst/afw/image/ApCorrMap.h"
 #include "lsst/afw/table/io/Persistable.h"
 
@@ -38,10 +39,11 @@ namespace afw {
 namespace image {
 namespace {
 
-using PyApCorrMap = py::class_<ApCorrMap, std::shared_ptr<ApCorrMap>>;
+using PyApCorrMap = py::class_<ApCorrMap, std::shared_ptr<ApCorrMap>, typehandling::Storable>;
 
 PYBIND11_MODULE(apCorrMap, mod) {
     py::module::import("lsst.afw.table.io");
+    py::module::import("lsst.afw.typehandling");
 
     /* Declare CRTP base class. */
     PyApCorrMap cls(mod, "ApCorrMap");

--- a/python/lsst/afw/image/coaddInputs.cc
+++ b/python/lsst/afw/image/coaddInputs.cc
@@ -25,6 +25,7 @@
 #include "lsst/afw/table/io/python.h"  // for addPersistableMethods
 #include "lsst/afw/table/Schema.h"
 #include "lsst/afw/table/Exposure.h"
+#include "lsst/afw/typehandling/Storable.h"
 #include "lsst/afw/image/CoaddInputs.h"
 
 namespace py = pybind11;
@@ -35,10 +36,11 @@ namespace afw {
 namespace image {
 namespace {
 
-using PyCoaddInputs = py::class_<CoaddInputs, std::shared_ptr<CoaddInputs>>;
+using PyCoaddInputs = py::class_<CoaddInputs, std::shared_ptr<CoaddInputs>, typehandling::Storable>;
 
 PYBIND11_MODULE(coaddInputs, mod) {
     /* Module level */
+    py::module::import("lsst.afw.typehandling");
 
     PyCoaddInputs cls(mod, "CoaddInputs");
 

--- a/python/lsst/afw/image/exposureInfo.cc
+++ b/python/lsst/afw/image/exposureInfo.cc
@@ -155,6 +155,7 @@ PYBIND11_MODULE(exposureInfo, mod) {
     cls.def("getMetadata", &ExposureInfo::getMetadata);
     cls.def("setMetadata", &ExposureInfo::setMetadata, "metadata"_a);
 
+    cls.attr("KEY_PSF") = ExposureInfo::KEY_PSF.getId();
     cls.def("hasPsf", &ExposureInfo::hasPsf);
     cls.def("getPsf", &ExposureInfo::getPsf);
     cls.def("setPsf",

--- a/python/lsst/afw/image/exposureInfo.cc
+++ b/python/lsst/afw/image/exposureInfo.cc
@@ -198,6 +198,7 @@ PYBIND11_MODULE(exposureInfo, mod) {
     cls.def("getVisitInfo", &ExposureInfo::getVisitInfo);
     cls.def("setVisitInfo", &ExposureInfo::setVisitInfo, "visitInfo"_a);
 
+    cls.attr("KEY_TRANSMISSION_CURVE") = ExposureInfo::KEY_TRANSMISSION_CURVE.getId();
     cls.def("hasTransmissionCurve", &ExposureInfo::hasTransmissionCurve);
     cls.def("getTransmissionCurve", &ExposureInfo::getTransmissionCurve);
     cls.def("setTransmissionCurve", &ExposureInfo::setTransmissionCurve, "transmissionCurve"_a);

--- a/python/lsst/afw/image/exposureInfo.cc
+++ b/python/lsst/afw/image/exposureInfo.cc
@@ -148,6 +148,7 @@ PYBIND11_MODULE(exposureInfo, mod) {
     cls.def("getCalib", &ExposureInfo::getCalib);
     cls.def("setCalib", &ExposureInfo::setCalib, "calib"_a);
 
+    cls.attr("KEY_PHOTO_CALIB") = ExposureInfo::KEY_PHOTO_CALIB.getId();
     cls.def("hasPhotoCalib", &ExposureInfo::hasPhotoCalib);
     cls.def("getPhotoCalib", &ExposureInfo::getPhotoCalib);
     cls.def("setPhotoCalib", &ExposureInfo::setPhotoCalib, "photoCalib"_a);

--- a/python/lsst/afw/image/exposureInfo.cc
+++ b/python/lsst/afw/image/exposureInfo.cc
@@ -170,6 +170,7 @@ PYBIND11_MODULE(exposureInfo, mod) {
             },
             "psf"_a);
 
+    cls.attr("KEY_VALID_POLYGON") = ExposureInfo::KEY_VALID_POLYGON.getId();
     cls.def("hasValidPolygon", &ExposureInfo::hasValidPolygon);
     cls.def("getValidPolygon", &ExposureInfo::getValidPolygon);
     cls.def("setValidPolygon",
@@ -187,6 +188,7 @@ PYBIND11_MODULE(exposureInfo, mod) {
     cls.def("setApCorrMap", &ExposureInfo::setApCorrMap, "apCorrMap"_a);
     cls.def("initApCorrMap", &ExposureInfo::initApCorrMap);
 
+    cls.attr("KEY_COADD_INPUTS") = ExposureInfo::KEY_COADD_INPUTS.getId();
     cls.def("hasCoaddInputs", &ExposureInfo::hasCoaddInputs);
     cls.def("getCoaddInputs", &ExposureInfo::getCoaddInputs);
     cls.def("setCoaddInputs", &ExposureInfo::setCoaddInputs, "coaddInputs"_a);

--- a/python/lsst/afw/image/exposureInfo.cc
+++ b/python/lsst/afw/image/exposureInfo.cc
@@ -120,6 +120,7 @@ PYBIND11_MODULE(exposureInfo, mod) {
     cls.def(py::init<ExposureInfo, bool>(), "other"_a, "copyMetadata"_a);
 
     /* Members */
+    cls.attr("KEY_WCS") = ExposureInfo::KEY_WCS.getId();
     cls.def("hasWcs", &ExposureInfo::hasWcs);
     cls.def("getWcs", (std::shared_ptr<geom::SkyWcs>(ExposureInfo::*)()) & ExposureInfo::getWcs);
     cls.def("setWcs", &ExposureInfo::setWcs, "wcs"_a);

--- a/python/lsst/afw/image/exposureInfo.cc
+++ b/python/lsst/afw/image/exposureInfo.cc
@@ -183,6 +183,7 @@ PYBIND11_MODULE(exposureInfo, mod) {
             },
             "polygon"_a);
 
+    cls.attr("KEY_AP_CORR_MAP") = ExposureInfo::KEY_AP_CORR_MAP.getId();
     cls.def("hasApCorrMap", &ExposureInfo::hasApCorrMap);
     cls.def("getApCorrMap", (std::shared_ptr<ApCorrMap>(ExposureInfo::*)()) & ExposureInfo::getApCorrMap);
     cls.def("setApCorrMap", &ExposureInfo::setApCorrMap, "apCorrMap"_a);

--- a/python/lsst/afw/image/exposureInfo.cc
+++ b/python/lsst/afw/image/exposureInfo.cc
@@ -125,6 +125,7 @@ PYBIND11_MODULE(exposureInfo, mod) {
     cls.def("getWcs", (std::shared_ptr<geom::SkyWcs>(ExposureInfo::*)()) & ExposureInfo::getWcs);
     cls.def("setWcs", &ExposureInfo::setWcs, "wcs"_a);
 
+    cls.attr("KEY_DETECTOR") = ExposureInfo::KEY_DETECTOR.getId();
     cls.def("hasDetector", &ExposureInfo::hasDetector);
     cls.def("getDetector", &ExposureInfo::getDetector);
     cls.def("setDetector",

--- a/python/lsst/afw/image/filter.cc
+++ b/python/lsst/afw/image/filter.cc
@@ -25,6 +25,7 @@
 
 #include <cmath>
 #include "lsst/daf/base/PropertySet.h"
+#include "lsst/afw/typehandling/Storable.h"
 #include "lsst/afw/image/Filter.h"
 
 namespace py = pybind11;
@@ -37,10 +38,11 @@ namespace {
 
 using PyFilterProperty = py::class_<FilterProperty, std::shared_ptr<FilterProperty>>;
 
-using PyFilter = py::class_<Filter, std::shared_ptr<Filter>>;
+using PyFilter = py::class_<Filter, std::shared_ptr<Filter>, typehandling::Storable>;
 
 PYBIND11_MODULE(filter, mod) {
     py::module::import("lsst.daf.base");
+    py::module::import("lsst.afw.typehandling");
 
     mod.def("stripFilterKeywords", &detail::stripFilterKeywords, "metadata"_a);
 

--- a/python/lsst/afw/image/photoCalib.cc
+++ b/python/lsst/afw/image/photoCalib.cc
@@ -33,6 +33,7 @@
 #include "lsst/afw/math/BoundedField.h"
 #include "lsst/afw/table/io/Persistable.h"
 #include "lsst/afw/table/io/python.h"  // for addPersistableMethods
+#include "lsst/afw/typehandling/Storable.h"
 #include "lsst/afw/image/PhotoCalib.h"
 
 namespace py = pybind11;
@@ -59,9 +60,11 @@ void declareMeasurement(py::module &mod) {
 }
 
 PYBIND11_MODULE(photoCalib, mod) {
+    py::module::import("lsst.afw.typehandling");
+
     declareMeasurement(mod);
 
-    py::class_<PhotoCalib, std::shared_ptr<PhotoCalib>> cls(mod, "PhotoCalib");
+    py::class_<PhotoCalib, std::shared_ptr<PhotoCalib>, typehandling::Storable> cls(mod, "PhotoCalib");
 
     /* Constructors */
     cls.def(py::init<>());

--- a/python/lsst/afw/image/transmissionCurve.cc
+++ b/python/lsst/afw/image/transmissionCurve.cc
@@ -27,6 +27,7 @@
 
 #include "ndarray/pybind11.h"
 
+#include "lsst/afw/typehandling/Storable.h"
 #include "lsst/afw/image/TransmissionCurve.h"
 #include "lsst/afw/table/io/python.h"
 
@@ -39,7 +40,7 @@ namespace image {
 namespace {
 
 using PyTransmissionCurve =
-    py::class_<TransmissionCurve, std::shared_ptr<TransmissionCurve>>;
+        py::class_<TransmissionCurve, std::shared_ptr<TransmissionCurve>, typehandling::Storable>;
 
 PyTransmissionCurve declare(py::module & mod) {
     return PyTransmissionCurve(mod, "TransmissionCurve");
@@ -80,6 +81,8 @@ void define(PyTransmissionCurve & cls) {
 }
 
 PYBIND11_MODULE(transmissionCurve, mod) {
+    // import inheritance dependencies
+    py::module::import("lsst.afw.typehandling");
     // then declare classes
     auto cls = declare(mod);
     // then import dependencies used in method signatures

--- a/python/lsst/afw/image/visitInfo.cc
+++ b/python/lsst/afw/image/visitInfo.cc
@@ -35,6 +35,7 @@
 #include "lsst/geom/SpherePoint.h"
 #include "lsst/afw/table/io/python.h"  // for addPersistableMethods
 #include "lsst/afw/table/misc.h"
+#include "lsst/afw/typehandling/Storable.h"
 #include "lsst/afw/image/VisitInfo.h"
 
 namespace py = pybind11;
@@ -56,9 +57,10 @@ PYBIND11_MODULE(visitInfo, mod) {
     py::module::import("lsst.geom");
     py::module::import("lsst.afw.coord.observatory");
     py::module::import("lsst.afw.coord.weather");
+    py::module::import("lsst.afw.typehandling");
 
     /* Module level */
-    py::class_<VisitInfo, std::shared_ptr<VisitInfo>> cls(mod, "VisitInfo");
+    py::class_<VisitInfo, std::shared_ptr<VisitInfo>, typehandling::Storable> cls(mod, "VisitInfo");
 
     /* Member types and enums */
     py::enum_<RotType>(mod, "RotType")

--- a/python/lsst/afw/table/_aggregates.cc
+++ b/python/lsst/afw/table/_aggregates.cc
@@ -199,7 +199,8 @@ static void declareCovarianceMatrixKey(WrapperCollection &wrappers, const ::std:
 }  // namespace
 
 void wrapAggregates(WrapperCollection &wrappers) {
-    wrappers.addSignatureDependency("lsst.afw.geom.ellipses");
+    // TODO: uncomment once afw.geom uses WrapperCollection
+    // wrappers.addSignatureDependency("lsst.afw.geom.ellipses");
 
     wrappers.wrapType(py::enum_<CoordinateType>(wrappers.module, "CoordinateType"), [](auto &mod, auto &enm) {
         enm.value("PIXEL", CoordinateType::PIXEL);

--- a/python/lsst/afw/table/_exposure.cc
+++ b/python/lsst/afw/table/_exposure.cc
@@ -177,9 +177,10 @@ PyExposureCatalog declareExposureCatalog(WrapperCollection &wrappers) {
 }  // anonymous namespace
 
 void wrapExposure(WrapperCollection &wrappers) {
-    wrappers.addSignatureDependency("lsst.afw.geom");
-    // TODO: afw.image and afw.detection cannot be imported due to circular dependencies
-    // until at least afw.image uses WrapperCollection in DM-20703
+    // wrappers.addSignatureDependency("lsst.afw.geom");
+    // TODO: afw.geom, afw.image, and afw.detection cannot be imported due to
+    // circular dependencies until at least afw.image uses WrapperCollection
+    // in DM-20703
 
     auto clsExposureRecord = declareExposureRecord(wrappers);
     auto clsExposureTable = declareExposureTable(wrappers);

--- a/python/lsst/afw/table/_slots.cc
+++ b/python/lsst/afw/table/_slots.cc
@@ -68,7 +68,8 @@ void declareSlotDefinitionSubclass(WrapperCollection &wrappers, std::string cons
 }  // namespace
 
 void wrapSlots(WrapperCollection &wrappers) {
-    wrappers.addSignatureDependency("lsst.afw.geom.ellipses");
+    // TODO: uncomment once afw.geom uses WrapperCollection
+    // wrappers.addSignatureDependency("lsst.afw.geom.ellipses");
 
     declareSlotDefinition(wrappers);
     declareSlotDefinitionSubclass<FluxSlotDefinition>(wrappers, "Flux");

--- a/python/lsst/afw/table/_source.cc
+++ b/python/lsst/afw/table/_source.cc
@@ -190,7 +190,8 @@ PySourceColumnView declareSourceColumnView(WrapperCollection &wrappers) {
 }  // namespace
 
 void wrapSource(WrapperCollection &wrappers) {
-    wrappers.addSignatureDependency("lsst.afw.geom.ellipses");
+    // TODO: uncomment once afw.geom uses WrapperCollection
+    // wrappers.addSignatureDependency("lsst.afw.geom.ellipses");
 
     // SourceFitsFlags enum values are used as integer masks, so wrap as attributes instead of an enum
     // static_cast is required to avoid an import error (py::cast and py::int_ do not work by themselves

--- a/python/lsst/afw/table/io/_persistable.cc
+++ b/python/lsst/afw/table/io/_persistable.cc
@@ -37,7 +37,8 @@ namespace io {
 using PyPersistable = py::class_<Persistable, std::shared_ptr<Persistable>>;
 
 void wrapPersistable(utils::python::WrapperCollection &wrappers) {
-    wrappers.addSignatureDependency("lsst.afw.fits");
+    // TODO: uncomment once afw.fits uses WrapperCollection
+    // wrappers.addSignatureDependency("lsst.afw.fits");
 
     wrappers.wrapType(PyPersistable(wrappers.module, "Persistable"), [](auto &mod, auto &cls) {
         cls.def("writeFits",

--- a/src/image/ExposureInfo.cc
+++ b/src/image/ExposureInfo.cc
@@ -96,6 +96,17 @@ void ExposureInfo::setValidPolygon(std::shared_ptr<geom::polygon::Polygon const>
     setComponent(KEY_VALID_POLYGON, polygon);
 }
 
+typehandling::Key<std::string, std::shared_ptr<CoaddInputs const>> const ExposureInfo::KEY_COADD_INPUTS =
+        typehandling::makeKey<std::shared_ptr<CoaddInputs const>>("COADD_INPUTS"s);
+
+bool ExposureInfo::hasCoaddInputs() const { return hasComponent(KEY_COADD_INPUTS); }
+void ExposureInfo::setCoaddInputs(std::shared_ptr<CoaddInputs const> coaddInputs) {
+    setComponent(KEY_COADD_INPUTS, coaddInputs);
+}
+std::shared_ptr<CoaddInputs const> ExposureInfo::getCoaddInputs() const {
+    return getComponent(KEY_COADD_INPUTS);
+}
+
 int ExposureInfo::getFitsSerializationVersion() {
     // Version history:
     // unversioned and 0: photometric calibration via Calib, WCS via SkyWcs using AST.
@@ -131,7 +142,6 @@ ExposureInfo::ExposureInfo(std::shared_ptr<geom::SkyWcs const> const& wcs,
         : _filter(filter),
           _metadata(metadata ? metadata
                              : std::shared_ptr<daf::base::PropertySet>(new daf::base::PropertyList())),
-          _coaddInputs(coaddInputs),
           _apCorrMap(_cloneApCorrMap(apCorrMap)),
           _visitInfo(visitInfo),
           _transmissionCurve(transmissionCurve),
@@ -141,6 +151,7 @@ ExposureInfo::ExposureInfo(std::shared_ptr<geom::SkyWcs const> const& wcs,
     setPhotoCalib(photoCalib);
     setDetector(detector);
     setValidPolygon(polygon);
+    setCoaddInputs(coaddInputs);
 }
 
 ExposureInfo::ExposureInfo(ExposureInfo const& other) : ExposureInfo(other, false) {}
@@ -151,7 +162,6 @@ ExposureInfo::ExposureInfo(ExposureInfo&& other) : ExposureInfo(other) {}
 ExposureInfo::ExposureInfo(ExposureInfo const& other, bool copyMetadata)
         : _filter(other._filter),
           _metadata(other._metadata),
-          _coaddInputs(other._coaddInputs),
           _apCorrMap(_cloneApCorrMap(other._apCorrMap)),
           _visitInfo(other._visitInfo),
           _transmissionCurve(other._transmissionCurve),
@@ -164,7 +174,6 @@ ExposureInfo& ExposureInfo::operator=(ExposureInfo const& other) {
     if (&other != this) {
         _filter = other._filter;
         _metadata = other._metadata;
-        _coaddInputs = other._coaddInputs;
         _apCorrMap = _cloneApCorrMap(other._apCorrMap);
         _visitInfo = other._visitInfo;
         _transmissionCurve = other._transmissionCurve;
@@ -250,9 +259,6 @@ ExposureInfo::FitsWriteData ExposureInfo::_startWriteFits(lsst::geom::Point2I co
     // this is still the case so we're setting AR_HDU to 5 == 4 + 1
     //
     data.metadata->set("AR_HDU", 5, "HDU (1-indexed) containing the archive used to store ancillary objects");
-    if (hasCoaddInputs()) {
-        _addToArchive(data, getCoaddInputs(), "COADD_INPUTS_ID", "archive ID for coadd inputs catalogs");
-    }
     if (hasApCorrMap()) {
         _addToArchive(data, getApCorrMap(), "AP_CORR_MAP_ID", "archive ID for aperture correction map");
     }

--- a/src/image/ExposureInfo.cc
+++ b/src/image/ExposureInfo.cc
@@ -86,18 +86,7 @@ ExposureInfo::ExposureInfo(std::shared_ptr<geom::SkyWcs const> const& wcs,
           _visitInfo(visitInfo),
           _transmissionCurve(transmissionCurve) {}
 
-ExposureInfo::ExposureInfo(ExposureInfo const& other)
-        : _wcs(other._wcs),
-          _psf(other._psf),
-          _photoCalib(other._photoCalib),
-          _detector(other._detector),
-          _validPolygon(other._validPolygon),
-          _filter(other._filter),
-          _metadata(other._metadata),
-          _coaddInputs(other._coaddInputs),
-          _apCorrMap(_cloneApCorrMap(other._apCorrMap)),
-          _visitInfo(other._visitInfo),
-          _transmissionCurve(other._transmissionCurve) {}
+ExposureInfo::ExposureInfo(ExposureInfo const& other) : ExposureInfo(other, false) {}
 
 // Delegate to copy-constructor for backwards compatibility
 ExposureInfo::ExposureInfo(ExposureInfo&& other) : ExposureInfo(other) {}

--- a/src/image/ExposureInfo.cc
+++ b/src/image/ExposureInfo.cc
@@ -73,6 +73,17 @@ void ExposureInfo::setPhotoCalib(std::shared_ptr<PhotoCalib const> photoCalib) {
     setComponent(KEY_PHOTO_CALIB, photoCalib);
 }
 
+typehandling::Key<std::string, std::shared_ptr<cameraGeom::Detector const>> const ExposureInfo::KEY_DETECTOR =
+        typehandling::makeKey<std::shared_ptr<cameraGeom::Detector const>>("DETECTOR"s);
+
+bool ExposureInfo::hasDetector() const { return hasComponent(KEY_DETECTOR); }
+std::shared_ptr<cameraGeom::Detector const> ExposureInfo::getDetector() const {
+    return getComponent(KEY_DETECTOR);
+}
+void ExposureInfo::setDetector(std::shared_ptr<cameraGeom::Detector const> detector) {
+    setComponent(KEY_DETECTOR, detector);
+}
+
 int ExposureInfo::getFitsSerializationVersion() {
     // Version history:
     // unversioned and 0: photometric calibration via Calib, WCS via SkyWcs using AST.
@@ -105,8 +116,7 @@ ExposureInfo::ExposureInfo(std::shared_ptr<geom::SkyWcs const> const& wcs,
                            std::shared_ptr<ApCorrMap> const& apCorrMap,
                            std::shared_ptr<image::VisitInfo const> const& visitInfo,
                            std::shared_ptr<TransmissionCurve const> const& transmissionCurve)
-        : _detector(detector),
-          _validPolygon(polygon),
+        : _validPolygon(polygon),
           _filter(filter),
           _metadata(metadata ? metadata
                              : std::shared_ptr<daf::base::PropertySet>(new daf::base::PropertyList())),
@@ -118,6 +128,7 @@ ExposureInfo::ExposureInfo(std::shared_ptr<geom::SkyWcs const> const& wcs,
     setWcs(wcs);
     setPsf(psf);
     setPhotoCalib(photoCalib);
+    setDetector(detector);
 }
 
 ExposureInfo::ExposureInfo(ExposureInfo const& other) : ExposureInfo(other, false) {}
@@ -126,8 +137,7 @@ ExposureInfo::ExposureInfo(ExposureInfo const& other) : ExposureInfo(other, fals
 ExposureInfo::ExposureInfo(ExposureInfo&& other) : ExposureInfo(other) {}
 
 ExposureInfo::ExposureInfo(ExposureInfo const& other, bool copyMetadata)
-        : _detector(other._detector),
-          _validPolygon(other._validPolygon),
+        : _validPolygon(other._validPolygon),
           _filter(other._filter),
           _metadata(other._metadata),
           _coaddInputs(other._coaddInputs),
@@ -141,7 +151,6 @@ ExposureInfo::ExposureInfo(ExposureInfo const& other, bool copyMetadata)
 
 ExposureInfo& ExposureInfo::operator=(ExposureInfo const& other) {
     if (&other != this) {
-        _detector = other._detector;
         _validPolygon = other._validPolygon;
         _filter = other._filter;
         _metadata = other._metadata;
@@ -244,9 +253,6 @@ ExposureInfo::FitsWriteData ExposureInfo::_startWriteFits(lsst::geom::Point2I co
     if (hasTransmissionCurve() && getTransmissionCurve()->isPersistable()) {
         _addToArchive(data, getTransmissionCurve(), "TRANSMISSION_CURVE_ID",
                       "archive ID for the Exposure's transmission curve");
-    }
-    if (hasDetector() && getDetector()->isPersistable()) {
-        _addToArchive(data, getDetector(), "DETECTOR_ID", "archive ID for the Exposure's Detector");
     }
     _components->apply(StorablePersister(data));
 

--- a/src/image/Filter.cc
+++ b/src/image/Filter.cc
@@ -209,15 +209,15 @@ public:
     FilterFactory(std::string const& name) : afw::table::io::PersistableFactory(name) {}
 };
 
-std::string getPersistenceName() { return "Filter"; }
+std::string _getPersistenceName() { return "Filter"; }
 
-FilterFactory registration(getPersistenceName());
+FilterFactory registration(_getPersistenceName());
 
 }  // namespace
 
 bool Filter::isPersistable() const noexcept { return true; }
 
-std::string Filter::getPersistenceName() const { return getPersistenceName(); }
+std::string Filter::getPersistenceName() const { return _getPersistenceName(); }
 
 std::string Filter::getPythonModule() const { return "lsst.afw.image"; };
 

--- a/tests/testTableArchivesLib.cc
+++ b/tests/testTableArchivesLib.cc
@@ -147,4 +147,7 @@ PYBIND11_MODULE(testTableArchivesLib, mod) {
     cls.def("resized", &DummyPsf::resized);
     cls.def("isPersistable", &DummyPsf::isPersistable);
     cls.def("getValue", &DummyPsf::getValue);
+    cls.def("__eq__",
+            [](DummyPsf const& self, DummyPsf const& other) { return self.getValue() == other.getValue(); },
+            py::is_operator());
 }

--- a/tests/test_exposure.py
+++ b/tests/test_exposure.py
@@ -832,6 +832,7 @@ class ExposureInfoTestCase(lsst.utils.tests.TestCase):
                                                        lsst.geom.Point2D(25.0, 20.0)))
         self.coaddInputs = afwImage.CoaddInputs()
         self.apCorrMap = afwImage.ApCorrMap()
+        self.transmissionCurve = afwImage.TransmissionCurve.makeIdentity()
 
         self.exposureInfo = afwImage.ExposureInfo()
         gFilter = afwImage.Filter("g")
@@ -873,6 +874,8 @@ class ExposureInfoTestCase(lsst.utils.tests.TestCase):
                          self.exposureInfo.hasCoaddInputs, self.exposureInfo.getCoaddInputs)
         self._checkAlias(self.exposureInfo, cls.KEY_AP_CORR_MAP, self.apCorrMap,
                          self.exposureInfo.hasApCorrMap, self.exposureInfo.getApCorrMap)
+        self._checkAlias(self.exposureInfo, cls.KEY_TRANSMISSION_CURVE, self.transmissionCurve,
+                         self.exposureInfo.hasTransmissionCurve, self.exposureInfo.getTransmissionCurve)
 
     def testCopy(self):
         # Test that ExposureInfos have independently settable state

--- a/tests/test_exposure.py
+++ b/tests/test_exposure.py
@@ -861,6 +861,8 @@ class ExposureInfoTestCase(lsst.utils.tests.TestCase):
                          self.exposureInfo.hasPsf, self.exposureInfo.getPsf)
         self._checkAlias(self.exposureInfo, cls.KEY_PHOTO_CALIB, self.photoCalib,
                          self.exposureInfo.hasPhotoCalib, self.exposureInfo.getPhotoCalib)
+        self._checkAlias(self.exposureInfo, cls.KEY_DETECTOR, self.detector,
+                         self.exposureInfo.hasDetector, self.exposureInfo.getDetector)
 
     def testCopy(self):
         # Test that ExposureInfos have independently settable state

--- a/tests/test_exposure.py
+++ b/tests/test_exposure.py
@@ -831,6 +831,7 @@ class ExposureInfoTestCase(lsst.utils.tests.TestCase):
         self.polygon = afwGeom.Polygon(lsst.geom.Box2D(lsst.geom.Point2D(0.0, 0.0),
                                                        lsst.geom.Point2D(25.0, 20.0)))
         self.coaddInputs = afwImage.CoaddInputs()
+        self.apCorrMap = afwImage.ApCorrMap()
 
         self.exposureInfo = afwImage.ExposureInfo()
         gFilter = afwImage.Filter("g")
@@ -870,6 +871,8 @@ class ExposureInfoTestCase(lsst.utils.tests.TestCase):
                          self.exposureInfo.hasValidPolygon, self.exposureInfo.getValidPolygon)
         self._checkAlias(self.exposureInfo, cls.KEY_COADD_INPUTS, self.coaddInputs,
                          self.exposureInfo.hasCoaddInputs, self.exposureInfo.getCoaddInputs)
+        self._checkAlias(self.exposureInfo, cls.KEY_AP_CORR_MAP, self.apCorrMap,
+                         self.exposureInfo.hasApCorrMap, self.exposureInfo.getApCorrMap)
 
     def testCopy(self):
         # Test that ExposureInfos have independently settable state

--- a/tests/test_exposure.py
+++ b/tests/test_exposure.py
@@ -856,6 +856,8 @@ class ExposureInfoTestCase(lsst.utils.tests.TestCase):
         cls = type(self.exposureInfo)
         self._checkAlias(self.exposureInfo, cls.KEY_WCS, self.wcs,
                          self.exposureInfo.hasWcs, self.exposureInfo.getWcs)
+        self._checkAlias(self.exposureInfo, cls.KEY_PSF, self.psf,
+                         self.exposureInfo.hasPsf, self.exposureInfo.getPsf)
 
     def testCopy(self):
         # Test that ExposureInfos have independently settable state

--- a/tests/test_exposure.py
+++ b/tests/test_exposure.py
@@ -458,6 +458,10 @@ class ExposureTestCase(lsst.utils.tests.TestCase):
         photoCalib = afwImage.PhotoCalib(1e-10, 1e-12)
         mainExposure.setPhotoCalib(photoCalib)
 
+        mainInfo = mainExposure.getInfo()
+        for key, value in self.extras.items():
+            mainInfo.setComponent(key, value)
+
         with lsst.utils.tests.getTempFilePath(".fits") as tmpFile:
             mainExposure.writeFits(tmpFile)
 
@@ -470,6 +474,10 @@ class ExposureTestCase(lsst.utils.tests.TestCase):
                              readExposure.getFilter().getName())
 
             self.assertEqual(photoCalib, readExposure.getPhotoCalib())
+
+            readInfo = readExposure.getInfo()
+            for key, value in self.extras.items():
+                self.assertEqual(value, readInfo.getComponent(key))
 
             psf = readExposure.getPsf()
             self.assertIsNotNone(psf)

--- a/tests/test_exposure.py
+++ b/tests/test_exposure.py
@@ -828,6 +828,9 @@ class ExposureInfoTestCase(lsst.utils.tests.TestCase):
         self.photoCalib = afwImage.PhotoCalib(1.5)
         self.psf = DummyPsf(2.0)
         self.detector = DetectorWrapper().detector
+        self.polygon = afwGeom.Polygon(lsst.geom.Box2D(lsst.geom.Point2D(0.0, 0.0),
+                                                       lsst.geom.Point2D(25.0, 20.0)))
+        self.coaddInputs = afwImage.CoaddInputs()
 
         self.exposureInfo = afwImage.ExposureInfo()
         gFilter = afwImage.Filter("g")
@@ -863,6 +866,10 @@ class ExposureInfoTestCase(lsst.utils.tests.TestCase):
                          self.exposureInfo.hasPhotoCalib, self.exposureInfo.getPhotoCalib)
         self._checkAlias(self.exposureInfo, cls.KEY_DETECTOR, self.detector,
                          self.exposureInfo.hasDetector, self.exposureInfo.getDetector)
+        self._checkAlias(self.exposureInfo, cls.KEY_VALID_POLYGON, self.polygon,
+                         self.exposureInfo.hasValidPolygon, self.exposureInfo.getValidPolygon)
+        self._checkAlias(self.exposureInfo, cls.KEY_COADD_INPUTS, self.coaddInputs,
+                         self.exposureInfo.hasCoaddInputs, self.exposureInfo.getCoaddInputs)
 
     def testCopy(self):
         # Test that ExposureInfos have independently settable state

--- a/tests/test_exposure.py
+++ b/tests/test_exposure.py
@@ -473,7 +473,7 @@ class ExposureTestCase(lsst.utils.tests.TestCase):
 
             psf = readExposure.getPsf()
             self.assertIsNotNone(psf)
-            self.assertEqual(psf.getValue(), self.psf.getValue())
+            self.assertEqual(psf, self.psf)
 
     def checkWcs(self, parentExposure, subExposure):
         """Compare WCS at corner points of a sub-exposure and its parent exposure
@@ -515,7 +515,7 @@ class ExposureTestCase(lsst.utils.tests.TestCase):
         if not e1.getPsf():
             self.assertFalse(e2.getPsf())
         else:
-            self.assertEqual(e1.getPsf().getValue(), e2.getPsf().getValue())
+            self.assertEqual(e1.getPsf(), e2.getPsf())
         # Check extra components
         i1 = e1.getInfo()
         i2 = e2.getInfo()

--- a/tests/test_exposure.py
+++ b/tests/test_exposure.py
@@ -825,6 +825,7 @@ class ExposureInfoTestCase(lsst.utils.tests.TestCase):
                                       lsst.geom.SpherePoint(2.0, 34.0, lsst.geom.degrees),
                                       np.identity(2),
                                       )
+        self.photoCalib = afwImage.PhotoCalib(1.5)
         self.psf = DummyPsf(2.0)
         self.detector = DetectorWrapper().detector
 
@@ -858,6 +859,8 @@ class ExposureInfoTestCase(lsst.utils.tests.TestCase):
                          self.exposureInfo.hasWcs, self.exposureInfo.getWcs)
         self._checkAlias(self.exposureInfo, cls.KEY_PSF, self.psf,
                          self.exposureInfo.hasPsf, self.exposureInfo.getPsf)
+        self._checkAlias(self.exposureInfo, cls.KEY_PHOTO_CALIB, self.photoCalib,
+                         self.exposureInfo.hasPhotoCalib, self.exposureInfo.getPhotoCalib)
 
     def testCopy(self):
         # Test that ExposureInfos have independently settable state

--- a/tests/test_exposureTable.py
+++ b/tests/test_exposureTable.py
@@ -96,7 +96,7 @@ class ExposureTableTestCase(lsst.utils.tests.TestCase):
     def comparePsfs(self, psf1, psf2):
         self.assertIsNotNone(psf1)
         self.assertIsNotNone(psf2)
-        self.assertEqual(psf1.getValue(), psf2.getValue())
+        self.assertEqual(psf1, psf2)
 
     def setUp(self):
         np.random.seed(1)

--- a/tests/test_multiband.py
+++ b/tests/test_multiband.py
@@ -614,7 +614,7 @@ class MultibandExposureTestCase(lsst.utils.tests.TestCase):
         filters = self.exposure.filters
         newExposure = MultibandExposure.fromExposures(filters, exposures)
         for exposure in newExposure.singles:
-            self.assertNotEqual(exposure.getPsf(), None)
+            self.assertIsNotNone(exposure.getPsf())
 
     def testFilterSlicing(self):
         _testMaskedImageFilters(self, self.exposure, ExposureF)

--- a/tests/test_simpleGenericMap.cc
+++ b/tests/test_simpleGenericMap.cc
@@ -53,6 +53,7 @@ public:
      * * `KEY3: VALUE3`
      * * `KEY4: std::shared_ptr<>(VALUE4)`
      * * `KEY5: VALUE5`
+     * * `KEY6: VALUE6`
      */
     virtual std::unique_ptr<GenericMap<int>> makeGenericMap() const {
         auto map = std::make_unique<SimpleGenericMap<int>>();
@@ -62,6 +63,7 @@ public:
         map->insert(test::KEY3, test::VALUE3);
         map->insert(test::KEY4, std::make_shared<test::SimpleStorable>(test::VALUE4));
         map->insert(test::KEY5, test::VALUE5);
+        map->insert(test::KEY6, test::VALUE6);
         return map;
     }
 

--- a/tests/test_simpleGenericMap.cc
+++ b/tests/test_simpleGenericMap.cc
@@ -61,7 +61,7 @@ public:
         map->insert(test::KEY1, test::VALUE1);
         map->insert<double>(test::KEY2, test::VALUE2);
         map->insert(test::KEY3, test::VALUE3);
-        map->insert(test::KEY4, std::make_shared<test::SimpleStorable>(test::VALUE4));
+        map->insert(test::KEY4, std::make_shared<test::SimpleStorable const>(test::VALUE4));
         map->insert(test::KEY5, test::VALUE5);
         map->insert(test::KEY6, test::VALUE6);
         return map;


### PR DESCRIPTION
This PR changes the implementation of `ExposureInfo` to store components in a `GenericMap` rather than in dedicated pointers, and provides a generic API to add and remove components. The `filter`, `metadata`, and `visitInfo` components have not been migrated, because `metadata` cannot be made compatible with `GenericMap` due to package dependencies, `filter` cannot be round-tripped through `table::io` persistence, and both `filter` and `visitInfo` have a custom persisted form that would be broken by migration.

I'm a bit concerned about the API introduced in 8dcab8b23ab28486d1938f6b570b50c825f981fb. Not only does it expose the `GenericMap` back-end (which may be inevitable, given the requirements for this epic), but it's also fairly complex:
- setComponent(Key, shared_ptr<? extends Storable>)
- ~setComponent(string, ?)~
- ~hasComponent(Key<shared_ptr<? extends Storable>>)~
- hasComponent(Key\<other>)
- getComponent(Key<shared_ptr<? extends Storable>>)
- removeComponent(Key)

Note that there will be at least two additional declarations needed once it's safe to store components by value.

I also haven't addressed the problem of how to coordinate names of components across packages. Are the methods used for table columns, measurement plugins, mask planes, etc. adequate?