### PR TITLE
DM-21181: Add getLocalCalibration function to photoCalib.

### DIFF
--- a/include/lsst/afw/image/PhotoCalib.h
+++ b/include/lsst/afw/image/PhotoCalib.h
@@ -434,6 +434,24 @@ public:
     double getInstFluxAtZeroMagnitude() const { return utils::referenceFlux / _calibrationMean; }
 
     /**
+     * Get the local calibration at a point.
+     *
+     * This value is defined such that:
+     * @f[
+     *   instFluxToNanojansky(instFlux, point) == localCalibration * inst
+     * @f]
+     *
+     * Use getCalibrationErr() to get the spatially constant error on the calibration.
+     *
+     * @param[in]  point      The position that magnitude is to be converted at.
+     *
+     * @see getCalibrationMean(), getCalibrationErr()
+     *
+     * @returns     The local calibration at a point.
+     */
+    double getLocalCalibration(lsst::geom::Point<double, 2> const &point) const { return evaluate(point); }
+
+    /**
      * Calculates the spatially-variable calibration, normalized by the mean in the valid domain.
      *
      * This value is defined, for instFlux at (x,y), such that:

--- a/python/lsst/afw/image/photoCalib.cc
+++ b/python/lsst/afw/image/photoCalib.cc
@@ -155,6 +155,7 @@ PYBIND11_MODULE(photoCalib, mod) {
     cls.def("getCalibrationMean", &PhotoCalib::getCalibrationMean);
     cls.def("getCalibrationErr", &PhotoCalib::getCalibrationErr);
     cls.def("getInstFluxAtZeroMagnitude", &PhotoCalib::getInstFluxAtZeroMagnitude);
+    cls.def("getLocalCalibration", &PhotoCalib::getLocalCalibration, "point"_a);
 
     cls.def("computeScaledCalibration", &PhotoCalib::computeScaledCalibration);
     cls.def("computeScalingTo", &PhotoCalib::computeScalingTo);

--- a/tests/test_photoCalib.py
+++ b/tests/test_photoCalib.py
@@ -258,6 +258,12 @@ class PhotoCalibTestCase(lsst.utils.tests.TestCase):
                                      photoCalib.magnitudeToInstFlux(mag, self.pointXShift),
                                      rtol=1e-15)
 
+        # test getLocalCalibration.
+        meas = photoCalib.instFluxToNanojansky(self.instFlux1, self.instFluxErr1, self.pointXShift)
+        localCalib = photoCalib.getLocalCalibration(self.pointXShift)
+        flux = localCalib * self.instFlux1
+        self.assertAlmostEqual(meas.value, flux)
+
         # test the deprecated interfaces that behave like the old Calib object
         self.checkDeprecatedCalibInterface(photoCalib)
 


### PR DESCRIPTION
Add localCalib unittest.

Fix flux names in local calib tests.

Add getLocalCalibration function to header.

Add pybindings.

Add test comment.

Remove superfluous test.

Debug getLocalCalibration

clang-format of .h file