### PR TITLE
DM-19582: Add cross-language GenericMap unit tests

### DIFF
--- a/include/lsst/afw/typehandling/GenericMap.h
+++ b/include/lsst/afw/typehandling/GenericMap.h
@@ -26,7 +26,6 @@
 #define LSST_AFW_TYPEHANDLING_GENERICMAP_H
 
 #include <algorithm>
-#include <cstdint>
 #include <functional>
 #include <ostream>
 #include <memory>
@@ -409,8 +408,9 @@ public:
      * type (which may be `void`). Through any combination of overloading or
      * templates, the visitor must accept values of the following types:
      *      * either `bool` or `bool const&`
-     *      * either `std::int32_t` or `std::int32_t const&`
-     *      * either `std::int64_t` or `std::int64_t const&`
+     *      * either `int` or `int const&`
+     *      * either `long` or `long const&`
+     *      * either `long long` or `long long const&`
      *      * either `float` or `float const&`
      *      * either `double` or `double const&`
      *      * `std::string const&`
@@ -499,7 +499,9 @@ protected:
      *
      * Keys of any subclass of Storable are implemented using PolymorphicValue to preserve type.
      */
-    using StorableType = boost::variant<bool, std::int32_t, std::int64_t, float, double, std::string,
+    // Use int, long, long long instead of int32_t, int64_t because C++ doesn't
+    // consider signed integers of the same length but different names equivalent
+    using StorableType = boost::variant<bool, int, long, long long, float, double, std::string,
                                         PolymorphicValue, std::shared_ptr<Storable const>>;
 
     /**

--- a/include/lsst/afw/typehandling/GenericMap.h
+++ b/include/lsst/afw/typehandling/GenericMap.h
@@ -237,7 +237,11 @@ public:
     /**
      * Return a reference to the mapped value of the element with key equal to `key`.
      *
-     * @tparam T the type of the element mapped to `key`
+     * @tparam T the type of the element mapped to `key`. It may be the exact
+     *           type of the element, if known, or any type to which its
+     *           references or pointers can be implicitly converted (e.g.,
+     *           a superclass). For example, references to built-in types are
+     *           not convertible, so you can't retrieve an `int` with `T=long`.
      * @param key the key of the element to find
      *
      * @return a reference to the `T` mapped to `key`, if one exists

--- a/include/lsst/afw/typehandling/python.h
+++ b/include/lsst/afw/typehandling/python.h
@@ -49,6 +49,8 @@ namespace typehandling {
 template <class Base = Storable>
 class StorableHelper : public Base {
 public:
+    using Base::Base;
+
     // Can't wrap clone(); PYBIND11_OVERLOAD chokes on unique_ptr return type
 
     std::string toString() const override {
@@ -59,7 +61,6 @@ public:
         PYBIND11_OVERLOAD_NAME(std::size_t, Base, "__hash__", hash_value, );
     }
 
-protected:
     bool equals(Base const& other) const noexcept override {
         PYBIND11_OVERLOAD_NAME(bool, Base, "__eq__", equals, other);
     }

--- a/include/lsst/afw/typehandling/test.h
+++ b/include/lsst/afw/typehandling/test.h
@@ -256,8 +256,9 @@ BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestConstVisitor, GenericMapFactory) {
 
         // Local classes can't have method templates
         void operator()(int, bool value) { results.push_back(universalToString(value)); }
-        void operator()(int, std::int32_t const& value) { results.push_back(universalToString(value)); }
-        void operator()(int, std::int64_t value) { results.push_back(universalToString(value)); }
+        void operator()(int, int const& value) { results.push_back(universalToString(value)); }
+        void operator()(int, long value) { results.push_back(universalToString(value)); }
+        void operator()(int, long long value) { results.push_back(universalToString(value)); }
         void operator()(int, float const& value) { results.push_back(universalToString(value)); }
         void operator()(int, double value) { results.push_back(universalToString(value)); }
         void operator()(int, std::string const& value) { results.push_back(universalToString(value)); }
@@ -293,8 +294,9 @@ BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestModifyingVoidVisitor, GenericMapFactory) {
     public:
         // Local classes can't have method templates
         void operator()(int, bool& value) { value = !value; }
-        void operator()(int, std::int32_t& value) { value *= 2; }
-        void operator()(int, std::int64_t& value) { value *= 2; }
+        void operator()(int, int& value) { value *= 2; }
+        void operator()(int, long& value) { value *= 2; }
+        void operator()(int, long long& value) { value *= 2; }
         void operator()(int, float& value) { value *= 2; }
         void operator()(int, double& value) { value *= 2; }
         void operator()(int, std::string& value) { value += "Appendix"; }
@@ -333,11 +335,15 @@ BOOST_TEST_CASE_TEMPLATE_FUNCTION(TestModifyingReturningVisitor, GenericMapFacto
             value = !value;
             return key;
         }
-        int operator()(int key, std::int32_t& value) {
+        int operator()(int key, int& value) {
             value *= 2;
             return key;
         }
-        int operator()(int key, std::int64_t& value) {
+        int operator()(int key, long& value) {
+            value *= 2;
+            return key;
+        }
+        int operator()(int key, long long& value) {
             value *= 2;
             return key;
         }

--- a/python/lsst/afw/typehandling/_GenericMap.cc
+++ b/python/lsst/afw/typehandling/_GenericMap.cc
@@ -176,7 +176,7 @@ void declareMutableGenericMap(utils::python::WrapperCollection& wrappers, std::s
     wrappers.wrapType(PyClass(wrappers.module, className.c_str(), docstring.c_str()),
                       [](auto& mod, auto& cls) {
                           // Don't rewrap members of GenericMap
-                          declareMutableGenericMapTypedMethods<std::shared_ptr<Storable>>(cls);
+                          declareMutableGenericMapTypedMethods<std::shared_ptr<Storable const>>(cls);
                           declareMutableGenericMapTypedMethods<bool>(cls);
                           // TODO: int32 and float are suppressed for now, see DM-21268
                           declareMutableGenericMapTypedMethods<std::int64_t>(cls);  // chosen for builtins.int

--- a/python/lsst/afw/typehandling/_GenericMap.cc
+++ b/python/lsst/afw/typehandling/_GenericMap.cc
@@ -169,10 +169,11 @@ void declareMutableGenericMap(utils::python::WrapperCollection& wrappers, std::s
                           // Don't rewrap members of GenericMap
                           declareMutableGenericMapTypedMethods<std::shared_ptr<Storable>>(cls);
                           declareMutableGenericMapTypedMethods<bool>(cls);
+                          // TODO: int32 and float are suppressed for now, see DM-21268
+                          declareMutableGenericMapTypedMethods<std::int64_t>(cls);  // chosen for builtins.int
                           declareMutableGenericMapTypedMethods<std::int32_t>(cls);
-                          declareMutableGenericMapTypedMethods<std::int64_t>(cls);
+                          declareMutableGenericMapTypedMethods<double>(cls);  // chosen for builtins.float
                           declareMutableGenericMapTypedMethods<float>(cls);
-                          declareMutableGenericMapTypedMethods<double>(cls);
                           declareMutableGenericMapTypedMethods<std::string>(cls);
                           cls.def("__delitem__",
                                   [](Class& self, K const& key) {

--- a/python/lsst/afw/typehandling/_GenericMap.cc
+++ b/python/lsst/afw/typehandling/_GenericMap.cc
@@ -74,7 +74,18 @@ template <typename K>
 py::object get(GenericMap<K>& self, K const& key) {
     auto callable = static_cast<typename Publicist<K>::ConstValueReference (GenericMap<K>::*)(K) const>(
             &Publicist<K>::unsafeLookup);
-    return py::cast((self.*callable)(key));
+    auto variant = (self.*callable)(key);
+
+    // py::cast can't convert PolymorphicValue to Storable; do it by hand
+    PolymorphicValue const* storableHolder = boost::get<PolymorphicValue const&>(&variant);
+    if (storableHolder) {
+        Storable const& value = *storableHolder;
+        // Prevent segfaults when assigning a Key<Storable> to Python variable, then deleting from map
+        // No existing code depends on being able to modify an item stored by value
+        return py::cast(value.cloneStorable());
+    } else {
+        return py::cast(variant);
+    }
 };
 
 template <typename K>
@@ -109,9 +120,7 @@ void declareGenericMap(utils::python::WrapperCollection& wrappers, std::string c
                         std::throw_with_nested(py::key_error(buffer.str()));
                     }
                 },
-                // Prevent segfaults when assigning a key<Storable> to Python variable, then deleting from map
-                // No existing code depends on being able to modify an item stored by value
-                "key"_a, py::return_value_policy::copy);
+                "key"_a);
         cls.def("get",
                 [](Class& self, K const& key, py::object const& def) {
                     try {

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -1,7 +1,7 @@
 # -*- python -*-
 from lsst.sconsUtils import scripts, env, targets
 
-pybind11_test_modules = ['testTableArchivesLib']
+pybind11_test_modules = ['testTableArchivesLib', 'testGenericMapLib']
 
 scripts.BasicSConscript.pybind11(pybind11_test_modules, addUnderscore=False)
 

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -11,7 +11,6 @@ if afwdataDir:
     env["ENV"]["AFWDATA_DIR"] = afwdataDir
 
 scripts.BasicSConscript.tests(pyList=[],
-                              noBuildList=[name + '.cc' for name in pybind11_test_modules],
-                              ignoreList=[name + '.py' for name in pybind11_test_modules])
+                              noBuildList=[name + '.cc' for name in pybind11_test_modules])
 
 env.Clean(targets["tests"], "#testTable.fits")

--- a/tests/testGenericMapLib.cc
+++ b/tests/testGenericMapLib.cc
@@ -29,10 +29,12 @@
 #include "lsst/pex/exceptions.h"
 
 #include "lsst/afw/typehandling/GenericMap.h"
+#include "lsst/afw/typehandling/SimpleGenericMap.h"
 #include "lsst/afw/typehandling/Storable.h"
 
 namespace py = pybind11;
 using namespace pybind11::literals;
+using namespace std::string_literals;
 
 namespace lsst {
 namespace afw {
@@ -72,6 +74,23 @@ void assertKeyValue(GenericMap<std::string> const& map, std::string const& key, 
     }
 }
 
+/**
+ * Create a MutableGenericMap that can be passed to Python for testing.
+ *
+ * @returns a map containing the state `{"one": 1, "pi": 3.1415927,
+ *          "string": "neither a number nor NaN"}`. This state is hardcoded
+ *          into the Python test code, and should be changed with caution.
+ */
+std::shared_ptr<MutableGenericMap<std::string>> makeInitialMap() {
+    auto map = std::make_unique<SimpleGenericMap<std::string>>();
+    // TODO: workaround for DM-21268
+    map->insert("one", std::int64_t(1));
+    map->insert("pi", 3.1415927);
+    // TODO: workaround for DM-21216
+    map->insert("string", "neither a number nor NaN"s);
+    return map;
+}
+
 }  // namespace
 
 namespace {
@@ -90,9 +109,11 @@ void declareAnyTypeFunctions(py::module& mod) {
 PYBIND11_MODULE(testGenericMapLib, mod) {
     py::module::import("lsst.afw.typehandling");
 
-    declareAnyTypeFunctions<long>(mod);
+    declareAnyTypeFunctions<std::int64_t>(mod);
     declareAnyTypeFunctions<double>(mod);
     declareAnyTypeFunctions<std::string>(mod);
+
+    mod.def("makeInitialMap", &makeInitialMap);
 }
 
 }  // namespace typehandling

--- a/tests/testGenericMapLib.cc
+++ b/tests/testGenericMapLib.cc
@@ -91,6 +91,31 @@ std::shared_ptr<MutableGenericMap<std::string>> makeInitialMap() {
     return map;
 }
 
+/**
+ * Change the values in a GenericMap.
+ *
+ * @param testmap the map to update. Assumed to be in the state created by
+ *                makeInitialMap.
+ *
+ * This function performs changes equivalent to the following Python:
+ *
+ *     testmap['answer'] = 42
+ *     testmap['pi'] = 3.0
+ *     testmap['string'] = False
+ *
+ * This difference is hardcoded into the Python test code, and should be
+ * changed with caution.
+ */
+void makeCppUpdates(MutableGenericMap<std::string>& testmap) {
+    // TODO: workaround for DM-21268
+    testmap.insert("answer", std::int64_t(42));
+
+    testmap.at(makeKey<double>("pi"s)) = 3.0;
+
+    testmap.erase(makeKey<std::string>("string"s));
+    testmap.insert("string", false);
+}
+
 }  // namespace
 
 namespace {
@@ -115,6 +140,7 @@ PYBIND11_MODULE(testGenericMapLib, mod) {
     declareAnyTypeFunctions<std::string>(mod);
 
     mod.def("makeInitialMap", &makeInitialMap);
+    mod.def("makeCppUpdates", &makeCppUpdates, "testmap"_a);
 }
 
 }  // namespace typehandling

--- a/tests/testGenericMapLib.cc
+++ b/tests/testGenericMapLib.cc
@@ -24,12 +24,77 @@
 #include <pybind11/pybind11.h>
 
 #include <memory>
+#include <sstream>
+
+#include "lsst/pex/exceptions.h"
 
 #include "lsst/afw/typehandling/GenericMap.h"
 #include "lsst/afw/typehandling/Storable.h"
 
 namespace py = pybind11;
+using namespace pybind11::literals;
 
-namespace {}  // namespace
+namespace lsst {
+namespace afw {
+namespace typehandling {
 
-PYBIND11_MODULE(testGenericMapLib, mod) { py::module::import("lsst.afw.typehandling"); }
+namespace {
+
+/**
+ * Test whether a map contains a key-value pair.
+ *
+ * @param map The map to test
+ * @param key, value The key-value pair to test.
+ *
+ * @throws pex::exceptions::NotFoundError Thrown if the key is not present in
+ *      the map, or maps to a different value.
+ */
+template <typename T>
+void assertKeyValue(GenericMap<std::string> const& map, std::string const& key, T const& value) {
+    using lsst::pex::exceptions::NotFoundError;
+
+    if (!map.contains(key)) {
+        throw LSST_EXCEPT(NotFoundError, "Map does not contain key " + key);
+    }
+
+    auto typedKey = makeKey<T>(key);
+    if (!map.contains(typedKey)) {
+        std::stringstream buffer;
+        buffer << "Map maps " << key << " to a different type than " << typedKey;
+        throw LSST_EXCEPT(NotFoundError, buffer.str());
+    }
+
+    T const& mapValue = map.at(typedKey);
+    if (mapValue != value) {
+        std::stringstream buffer;
+        buffer << "Map maps " << typedKey << " to " << mapValue << ", expected " << value;
+        throw LSST_EXCEPT(NotFoundError, buffer.str());
+    }
+}
+
+}  // namespace
+
+namespace {
+
+// Functions for working with values of arbitrary type
+template <typename T>
+void declareAnyTypeFunctions(py::module& mod) {
+    mod.def("assertKeyValue",
+            static_cast<void (*)(GenericMap<std::string> const&, std::string const&, T const&)>(
+                    &assertKeyValue),
+            "map"_a, "key"_a, "value"_a);
+}
+
+}  // namespace
+
+PYBIND11_MODULE(testGenericMapLib, mod) {
+    py::module::import("lsst.afw.typehandling");
+
+    declareAnyTypeFunctions<long>(mod);
+    declareAnyTypeFunctions<double>(mod);
+    declareAnyTypeFunctions<std::string>(mod);
+}
+
+}  // namespace typehandling
+}  // namespace afw
+}  // namespace lsst

--- a/tests/testGenericMapLib.cc
+++ b/tests/testGenericMapLib.cc
@@ -274,6 +274,25 @@ void addCppStorable(MutableGenericMap<std::string>& testmap) {
     testmap.insert("cppPointer", std::make_shared<CppStorable>("pointer"));
 }
 
+/**
+ * Store and retrieve a Storable in C++.
+ *
+ * To avoid cluttering testGenericMapLib with a special holder class, this
+ * function conflates two actions. When called with a Storable, it puts a
+ * pointer to it in internal storage. When called with no arguments, it
+ * returns the pointer it has been keeping.
+ *
+ * @param storable The Storable to assign to the pointer [optional].
+ * @returns The currently held pointer.
+ */
+std::shared_ptr<Storable> keepStaticStorable(std::shared_ptr<Storable> storable = nullptr) {
+    static std::shared_ptr<Storable> longLived = nullptr;
+    if (storable) {
+        longLived = storable;
+    }
+    return longLived;
+}
+
 }  // namespace
 
 namespace {
@@ -309,6 +328,7 @@ PYBIND11_MODULE(testGenericMapLib, mod) {
     mod.def("makeInitialMap", &makeInitialMap);
     mod.def("makeCppUpdates", &makeCppUpdates, "testmap"_a);
     mod.def("addCppStorable", &addCppStorable, "testmap"_a);
+    mod.def("keepStaticStorable", &keepStaticStorable, "storable"_a = nullptr);
 
     py::class_<CppStorable, std::shared_ptr<CppStorable>, Storable> cls(mod, "CppStorable");
     cls.def(py::init<std::string>());

--- a/tests/testGenericMapLib.cc
+++ b/tests/testGenericMapLib.cc
@@ -1,0 +1,35 @@
+/*
+ * This file is part of afw.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <pybind11/pybind11.h>
+
+#include <memory>
+
+#include "lsst/afw/typehandling/GenericMap.h"
+#include "lsst/afw/typehandling/Storable.h"
+
+namespace py = pybind11;
+
+namespace {}  // namespace
+
+PYBIND11_MODULE(testGenericMapLib, mod) { py::module::import("lsst.afw.typehandling"); }

--- a/tests/testGenericMapLib.cc
+++ b/tests/testGenericMapLib.cc
@@ -109,6 +109,7 @@ void declareAnyTypeFunctions(py::module& mod) {
 PYBIND11_MODULE(testGenericMapLib, mod) {
     py::module::import("lsst.afw.typehandling");
 
+    declareAnyTypeFunctions<bool>(mod);
     declareAnyTypeFunctions<std::int64_t>(mod);
     declareAnyTypeFunctions<double>(mod);
     declareAnyTypeFunctions<std::string>(mod);

--- a/tests/test_Storable.py
+++ b/tests/test_Storable.py
@@ -25,6 +25,7 @@ import unittest
 import lsst.utils.tests
 
 from lsst.afw.typehandling import Storable
+import testGenericMapLib as cppLib
 
 
 class DemoStorable(Storable):
@@ -53,7 +54,7 @@ class DemoStorable(Storable):
         return self._state == other._state
 
 
-class PointyStorableTestSuite(lsst.utils.tests.TestCase):
+class PythonStorableTestSuite(lsst.utils.tests.TestCase):
 
     def setUp(self):
         self.aList = [42]
@@ -85,6 +86,25 @@ class PointyStorableTestSuite(lsst.utils.tests.TestCase):
     def testEq(self):
         self.assertEqual(self.testbed, DemoStorable([42]))
         self.assertNotEqual(self.testbed, DemoStorable(0))
+
+
+class CppStorableTestSuite(lsst.utils.tests.TestCase):
+
+    def setUp(self):
+        self.initstr = "Just a string"
+        self.testbed = cppLib.CppStorable(self.initstr)
+
+    def testNewValue(self):
+        """Test a Python-side state change in both C++ and Python.
+        """
+        self.assertEqual(self.testbed.value, self.initstr)
+        cppLib.assertCppValue(self.testbed, self.initstr)
+
+        newstr = "Stringly typed"
+        self.testbed.value = newstr
+
+        self.assertEqual(self.testbed.value, newstr)
+        cppLib.assertCppValue(self.testbed, newstr)
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_Storable.py
+++ b/tests/test_Storable.py
@@ -20,6 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import copy
+import gc
 import unittest
 
 import lsst.utils.tests
@@ -87,6 +88,17 @@ class PythonStorableTestSuite(lsst.utils.tests.TestCase):
     def testEq(self):
         self.assertEqual(self.testbed, DemoStorable([42]))
         self.assertNotEqual(self.testbed, DemoStorable(0))
+
+    @unittest.skip("TODO: Fix this bug in DM-21314")
+    def testGarbageCollection(self):
+        cppLib.keepStaticStorable(DemoStorable(3))
+
+        gc.collect()
+
+        retrieved = cppLib.keepStaticStorable()
+        self.assertIsInstance(retrieved, Storable)
+        self.assertIsInstance(retrieved, DemoStorable)
+        self.assertEqual(retrieved, DemoStorable(3))
 
 
 class CppStorableTestSuite(lsst.utils.tests.TestCase):

--- a/tests/test_Storable.py
+++ b/tests/test_Storable.py
@@ -78,6 +78,7 @@ class PythonStorableTestSuite(lsst.utils.tests.TestCase):
 
     def testRepr(self):
         self.assertEqual(repr(self.testbed), "DemoStorable([42])")
+        cppLib.assertPythonStorable(self.testbed, "DemoStorable([42])")
 
     def testHash(self):
         with self.assertRaises(TypeError):

--- a/tests/test_simpleGenericMap.py
+++ b/tests/test_simpleGenericMap.py
@@ -225,6 +225,7 @@ class SimpleGenericMapCppTestSuite(lsst.utils.tests.TestCase):
                      'string': 'neither a number nor NaN',
                      }
         self.pymap = SimpleGenericMap(self.data)
+        self.cppmap = cppLib.makeInitialMap()
 
     def testPythonValues(self):
         """Check that built-in types added in Python are visible in C++.
@@ -234,6 +235,15 @@ class SimpleGenericMapCppTestSuite(lsst.utils.tests.TestCase):
         # Ensure the test isn't giving false negatives
         with self.assertRaises(pexExcept.NotFoundError):
             cppLib.assertKeyValue(self.pymap, "NotAKey", 42)
+
+    def testCppValues(self):
+        """Check that built-in types added in C++ are visible in Python.
+        """
+        for key, value in self.data.items():
+            self.assertIn(key, self.cppmap)
+            self.assertEqual(value, self.cppmap[key], msg="key=" + key)
+        # Ensure the test isn't giving false negatives
+        self.assertNotIn("NotAKey", self.cppmap)
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_simpleGenericMap.py
+++ b/tests/test_simpleGenericMap.py
@@ -245,6 +245,28 @@ class SimpleGenericMapCppTestSuite(lsst.utils.tests.TestCase):
         # Ensure the test isn't giving false negatives
         self.assertNotIn("NotAKey", self.cppmap)
 
+    def _checkPythonUpdates(self, testmap, msg=''):
+        for key, value in self.data.items():
+            self.assertIn(key, testmap, msg=msg)
+            self.assertEqual(value, testmap[key], msg='key=' + key + ', ' + msg)
+            cppLib.assertKeyValue(testmap, key, value)
+        testmap['answer'] = 42  # New key-value pair
+        testmap['pi'] = 3.0  # Replace `float` with `float`
+        testmap['string'] = False  # Replace `str` with `bool`
+
+        for key, value in {'answer': 42, 'pi': 3.0, 'string': False}.items():
+            # Test both Python and C++ state
+            self.assertIn(key, testmap, msg=msg)
+            self.assertEqual(value, testmap[key], msg='key=' + key + ', ' + msg)
+            cppLib.assertKeyValue(testmap, key, value)
+
+    def testPythonUpdates(self):
+        """Check that changes to built-in types made in Python are visible in
+        both languages.
+        """
+        self._checkPythonUpdates(self.pymap, msg='map=pymap')
+        self._checkPythonUpdates(self.cppmap, msg='map=cppmap')
+
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):
     pass

--- a/tests/test_simpleGenericMap.py
+++ b/tests/test_simpleGenericMap.py
@@ -267,6 +267,26 @@ class SimpleGenericMapCppTestSuite(lsst.utils.tests.TestCase):
         self._checkPythonUpdates(self.pymap, msg='map=pymap')
         self._checkPythonUpdates(self.cppmap, msg='map=cppmap')
 
+    def _checkCppUpdates(self, testmap, msg=''):
+        for key, value in self.data.items():
+            self.assertIn(key, testmap, msg=msg)
+            self.assertEqual(value, testmap[key], msg='key=' + key + ', ' + msg)
+            cppLib.assertKeyValue(testmap, key, value)
+        cppLib.makeCppUpdates(testmap)
+
+        for key, value in {'answer': 42, 'pi': 3.0, 'string': False}.items():
+            # Test both Python and C++ state
+            self.assertIn(key, testmap, msg=msg)
+            self.assertEqual(value, testmap[key], msg='key=' + key + ', ' + msg)
+            cppLib.assertKeyValue(testmap, key, value)
+
+    def testCppUpdates(self):
+        """Check that changes to built-in types made in C++ are visible in
+        both languages.
+        """
+        self._checkCppUpdates(self.pymap, msg='map=pymap')
+        self._checkCppUpdates(self.cppmap, msg='map=cppmap')
+
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):
     pass

--- a/tests/test_simpleGenericMap.py
+++ b/tests/test_simpleGenericMap.py
@@ -287,6 +287,32 @@ class SimpleGenericMapCppTestSuite(lsst.utils.tests.TestCase):
         self._checkCppUpdates(self.pymap, msg='map=pymap')
         self._checkCppUpdates(self.cppmap, msg='map=cppmap')
 
+    def _checkPythonStorableUpdates(self, testmap, msg=''):
+        cppLib.addCppStorable(testmap)
+        self.assertIn('cppValue', testmap, msg=msg)
+        self.assertEqual(testmap['cppValue'], cppLib.CppStorable('value'), msg=msg)
+        self.assertIn('cppPointer', testmap, msg=msg)
+        self.assertEqual(testmap['cppPointer'], cppLib.CppStorable('pointer'), msg=msg)
+
+        # should have no effect because pybind11 copies Storable values for safety
+        testmap['cppValue'].value = 'new_value'
+        testmap['cppPointer'].value = 'extra_pointy'
+
+        for key, value in {'cppValue': cppLib.CppStorable('value'),
+                           'cppPointer': cppLib.CppStorable('extra_pointy'),
+                           }.items():
+            # Test both Python and C++ state
+            self.assertIn(key, testmap, msg=msg)
+            self.assertEqual(value, testmap[key], msg='key=' + key + ', ' + msg)
+            cppLib.assertKeyValue(testmap, key, value)
+
+    def testPythonStorableUpdates(self):
+        """Check that changes to Storables made in Python are visible in
+        both languages.
+        """
+        self._checkPythonStorableUpdates(self.pymap, msg='map=pymap')
+        self._checkPythonStorableUpdates(self.cppmap, msg='map=cppmap')
+
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):
     pass

--- a/tests/test_simpleGenericMap.py
+++ b/tests/test_simpleGenericMap.py
@@ -23,9 +23,11 @@ from collections.abc import MutableMapping
 import unittest
 
 import lsst.utils.tests
+import lsst.pex.exceptions as pexExcept
 
 from lsst.afw.typehandling import SimpleGenericMap
 from lsst.afw.typehandling.testUtils import MutableGenericMapTestBaseClass
+import testGenericMapLib as cppLib
 
 
 class SimpleGenericMapTestSuite(MutableGenericMapTestBaseClass):
@@ -214,6 +216,24 @@ class SimpleGenericMapTestSuite(MutableGenericMapTestBaseClass):
         for target in self.targets:
             for keyType in self.getValidKeys(target):
                 self.checkClear(target, self.getTestData(keyType), msg=str(target))
+
+
+class SimpleGenericMapCppTestSuite(lsst.utils.tests.TestCase):
+    def setUp(self):
+        self.data = {'one': 1,
+                     'pi': 3.1415927,
+                     'string': 'neither a number nor NaN',
+                     }
+        self.pymap = SimpleGenericMap(self.data)
+
+    def testPythonValues(self):
+        """Check that built-in types added in Python are visible in C++.
+        """
+        for key, value in self.data.items():
+            cppLib.assertKeyValue(self.pymap, key, value)
+        # Ensure the test isn't giving false negatives
+        with self.assertRaises(pexExcept.NotFoundError):
+            cppLib.assertKeyValue(self.pymap, "NotAKey", 42)
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
This PR adds unit tests to `GenericMap` that pass objects from Python to C++ and/or vice versa. This exposes behavior that was not adequately tested with previous tests.

Bugs fixed:
- Building `afw` with Scons no longer issues an "ignoring a non-existent file" warning
- `GenericMap`'s policy on type conversions is now explicitly described in the API docs
- Python builtin integers are no longer demoted to `int`, nor Python floats to `float`, when inserted into a `GenericMap` (but see DM-21268, below)
- `Storable` values (i.e., non-pointers) can now be retrieved from a `GenericMap` in Python
- Storage and retrieval of integers in C++ now work consistently across platforms

Bugs deferred:
- `GenericMap`'s weakly-typed `insert` method turns C-strings into `bool` [[DM-21216](https://jira.lsstcorp.org/browse/DM-21216)].
- `GenericMap` cannot consistently handle integers and floats from Python, particularly Numpy's explicit-length types [[DM-21268](https://jira.lsstcorp.org/browse/DM-21268)].
- A Python `Storable` may be prematurely garbage-collected [[DM-21314](https://jira.lsstcorp.org/browse/DM-21314)].