### PR TITLE
DM-21355: Try to prevent NaN values turning up in FITS headers

### DIFF
--- a/src/fits.cc
+++ b/src/fits.cc
@@ -66,10 +66,28 @@ std::string makeLimitedFitsHeaderImpl(std::vector<std::string> const &paramNames
         } else if (type == typeid(int)) {
             out += (boost::format("%20d") % metadata.get<int>(name)).str();
         } else if (type == typeid(double)) {
-            // use G because FITS wants uppercase E for exponents
-            out += (boost::format("%#20.17G") % metadata.get<double>(name)).str();
+            double value = metadata.get<double>(name);
+            if (!std::isnan(value)) {
+                // use G because FITS wants uppercase E for exponents
+                out += (boost::format("%#20.17G") % value).str();
+            } else {
+                LOGLS_WARN("afw.fits",
+                           boost::format("In %s, found NaN in metadata item '%s'") %
+                                         BOOST_CURRENT_FUNCTION % name);
+                // Convert it to FITS undefined
+                out += " ";
+            }
         } else if (type == typeid(float)) {
-            out += (boost::format("%#20.15G") % metadata.get<float>(name)).str();
+            float value = metadata.get<float>(name);
+            if (!std::isnan(value)) {
+                out += (boost::format("%#20.15G") % value).str();
+            } else {
+                LOGLS_WARN("afw.fits",
+                           boost::format("In %s, found NaN in metadata item '%s'") %
+                                         BOOST_CURRENT_FUNCTION % name);
+                // Convert it to FITS undefined
+                out += " ";
+            }
         } else if (type == typeid(std::nullptr_t)) {
             out += " ";
         } else if (type == typeid(std::string)) {

--- a/tests/test_frameSetUtils.py
+++ b/tests/test_frameSetUtils.py
@@ -73,6 +73,18 @@ class FrameSetUtilsTestCase(lsst.utils.tests.TestCase):
             metadata.getScalar("CRPIX2") + metadata.getScalar("CRVAL2A") - 1,
         )
 
+    def testIgnoreNan(self):
+        """Test that NaN in a property list does not crash the WCS extraction.
+        """
+        metadata = self.makeMetadata()
+        metadata["ISNAN"] = float("NaN")
+
+        # This will issue a warning from C++ but that warning can not be
+        # redirected to python logging machinery.
+        # This code causes a SIGABRT without DM-21355 implemented
+        frameSet1 = readFitsWcs(metadata, strip=False)
+        self.assertEqual(type(frameSet1), ast.FrameSet)
+
     def testReadFitsWcsStripMetadata(self):
         metadata = self.makeMetadata()
         nKeys = len(metadata.toList())

--- a/tests/test_makeLimitedFitsHeader.py
+++ b/tests/test_makeLimitedFitsHeader.py
@@ -101,6 +101,7 @@ class MakeLimitedFitsHeaderTestCase(lsst.utils.tests.TestCase):
             ("LONGSTR", "skip this item because the formatted value "
                 "is too long: longer than 80 characters "),
             ("ASTRING1", "value for string"),
+            ("ANAN", float("NaN"))
         ]
         for name, value in dataList:
             metadata.set(name, value)
@@ -117,6 +118,7 @@ class MakeLimitedFitsHeaderTestCase(lsst.utils.tests.TestCase):
             "LONGFLT = 0.0089626337538440005",
             "ANUNDEF =",
             "ASTRING1= 'value for string'",
+            "ANAN    =",
         ]
         expectedHeader = "".join("%-80s" % val for val in expectedLines)
 


### PR DESCRIPTION
The FITS standard doesn't allow NaN as a value. NaNs turning up in a PropertyList can confuse things so this change traps this and either drops the entire item or replaces with FITS undefined value.