### PR TITLE
DM-21327: Replace ExposureInfo implementation with homogeneous map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,7 +142,7 @@ tests/test_cameraSys
 tests/test_coord
 tests/test_endpoint
 tests/test_functorKeys
-tests/test_genericmap
+tests/test_genericmapkey
 tests/test_imageHash
 tests/test_key
 tests/test_polygon

--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,7 @@ tests/test_key
 tests/test_polygon
 tests/test_spherePoint
 tests/test_storable
+tests/test_storablemap
 tests/test_transform
 tests/test_trapezoidalPacker
 tests/test_warpGpu

--- a/include/lsst/afw/image/ExposureInfo.h
+++ b/include/lsst/afw/image/ExposureInfo.h
@@ -1,10 +1,12 @@
 // -*- LSST-C++ -*- // fixed format comment for emacs
 /*
- * LSST Data Management System
- * Copyright 2008-2013 LSST Corporation.
+ * This file is part of afw.
  *
- * This product includes software developed by the
- * LSST Project (http://www.lsst.org/).
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,9 +18,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the LSST License Statement and
- * the GNU General Public License along with this program.  If not,
- * see <http://www.lsstcorp.org/LegalNotices/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef LSST_AFW_IMAGE_ExposureInfo_h_INCLUDED

--- a/include/lsst/afw/image/ExposureInfo.h
+++ b/include/lsst/afw/image/ExposureInfo.h
@@ -252,7 +252,7 @@ public:
         static_assert(std::is_base_of<typehandling::Storable, T>::value, "T must be a Storable");
         // "No data" always represented internally by absent key-value pair, not by mapping to null
         if (object != nullptr) {
-            _setStorableComponent(key, object);
+            _setComponent(key, object);
         } else {
             removeComponent(key);
         }
@@ -426,7 +426,8 @@ private:
 
     // Implementation of setComponent
     template <class T>
-    void _setStorableComponent(typehandling::Key<std::string, T> const& key, T const& object) {
+    void _setComponent(typehandling::Key<std::string, std::shared_ptr<T>> const& key,
+                       std::shared_ptr<T> const& object) {
         if (_components->contains(key)) {
             _components->erase(key);
         } else if (_components->contains(key.getId())) {

--- a/include/lsst/afw/image/detail/StorableMap.h
+++ b/include/lsst/afw/image/detail/StorableMap.h
@@ -1,0 +1,153 @@
+// -*- LSST-C++ -*-
+/*
+ * This file is part of afw.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef LSST_AFW_IMAGE_DETAIL_STORABLEMAP_H
+#define LSST_AFW_IMAGE_DETAIL_STORABLEMAP_H
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "lsst/pex/exceptions.h"
+#include "lsst/afw/typehandling/Key.h"
+#include "lsst/afw/typehandling/Storable.h"
+
+namespace lsst {
+namespace afw {
+namespace image {
+namespace detail {
+
+/**
+ * A map of Storable supporting strongly-typed access.
+ *
+ * A Key for the map is parameterized by both the key type `K` and a
+ * corresponding value type `V`. The map is indexed uniquely by a value of type
+ * `K`; no two entries in the map may have identical values of Key::getId().
+ *
+ * All operations are sensitive to the value type of the key: a
+ * @ref contains(Key<std::shared_ptr<T>> const&) const "contains" call
+ * requesting a SkyWcs labeled "value", for example, will report no such
+ * object if instead there is a Psf labeled "value". At present, a StorableMap
+ * does not store type information internally, instead relying on RTTI for
+ * type checking.
+ */
+class StorableMap final {
+public:
+    using mapped_type = std::shared_ptr<typehandling::Storable const>;
+    using key_type = typehandling::Key<std::string, mapped_type>;
+    using value_type = std::pair<key_type const, mapped_type>;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using reference = value_type&;
+    using const_reference = value_type const&;
+    using pointer = value_type*;
+    using const_pointer = value_type const*;
+
+    StorableMap();
+    StorableMap(StorableMap const& other);
+    StorableMap(StorableMap&& other);
+    StorableMap& operator=(StorableMap const& other);
+    StorableMap& operator=(StorableMap&& other);
+    ~StorableMap() noexcept;
+
+    /**
+     * Construct a map from an initializer list.
+     *
+     * @param init an initializer list of key-value pairs. The keys and values
+     *             may be of any type that can be converted to
+     *             `std::shared_ptr<typehandling::Storable const>`.
+     *
+     * @note If `init` contains any keys with the same ID, it is unspecified
+     *       which will be inserted.
+     *
+     * @see std::map::map
+     */
+    StorableMap(std::initializer_list<value_type> init);
+
+    /// Return the number of key-value pairs in the map.
+    size_type size() const noexcept;
+
+    /// Return `true` if this map contains no key-value pairs.
+    bool empty() const noexcept;
+
+    /**
+     * Return the maximum number of elements the container is able to hold due
+     * to system or library implementation limitations.
+     *
+     * @note This value typically reflects the theoretical limit on the size
+     *       of the container. At runtime, the size of the container may be
+     *       limited to a value smaller than max_size() by the amount of
+     *       RAM available.
+     */
+    size_type max_size() const noexcept;
+
+    /**
+     * Return `true` if this map contains a mapping whose key has the
+     * specified label.
+     *
+     * More formally, this method returns `true` if and only if this map
+     * contains a mapping with a key `k` such that `k.getId() == key`. There
+     * can be at most one such mapping.
+     *
+     * @param key the weakly-typed key to search for
+     *
+     * @return `true` if this map contains a mapping for `key`, regardless of
+     *         value type.
+     *
+     * @exceptsafe Provides strong exception safety.
+     */
+    bool contains(std::string const& key) const;
+
+    /**
+     * Test for map equality.
+     *
+     * Two StorableMap objects are considered equal if they map the same keys
+     * to the same values.
+     *
+     * @{
+     */
+    bool operator==(StorableMap const& other) const noexcept;
+
+    bool operator!=(StorableMap const& other) const noexcept { return !(*this == other); }
+
+    /** @} */
+
+    /**
+     * Remove all of the mappings from this map.
+     *
+     * After this call, the map will be empty.
+     */
+    void clear() noexcept;
+
+private:
+    std::unordered_map<key_type, mapped_type> _contents;
+};
+
+}  // namespace detail
+}  // namespace image
+}  // namespace afw
+}  // namespace lsst
+
+#endif

--- a/include/lsst/afw/image/detail/StorableMap.h
+++ b/include/lsst/afw/image/detail/StorableMap.h
@@ -288,6 +288,24 @@ public:
         return result;
     }
 
+    /**
+     * Remove the mapping for a key from this map, if it exists.
+     *
+     * @tparam T the type of value the key maps to
+     * @param key the key to remove
+     *
+     * @return `true` if `key` was removed, `false` if it was not present.
+     */
+    template <typename T>
+    bool erase(Key<T> const& key) noexcept {
+        // unordered_map::erase(Key<Storable>) does no type checking.
+        if (this->contains(key)) {
+            return _contents.erase(key) > 0;
+        } else {
+            return false;
+        }
+    }
+
 private:
     std::unordered_map<key_type, mapped_type> _contents;
 };

--- a/include/lsst/afw/image/detail/StorableMap.h
+++ b/include/lsst/afw/image/detail/StorableMap.h
@@ -68,6 +68,17 @@ public:
     using pointer = value_type*;
     using const_pointer = value_type const*;
 
+private:
+    using _Impl = std::unordered_map<key_type, mapped_type>;
+
+public:
+    // These definitions may be replaced with adapters if we need
+    // StorableMap's iterators to behave differently from _Impl's.
+    using const_iterator = _Impl::const_iterator;
+    using iterator = _Impl::iterator;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
     template <typename V>
     using Key = lsst::afw::typehandling::Key<std::string, V>;
     using Storable = lsst::afw::typehandling::Storable;
@@ -306,8 +317,36 @@ public:
         }
     }
 
+    /**
+     * Return an iterator to the first element of the map.
+     *
+     * @return An iterator that dereferences to a value_type, i.e. a pair of
+     *         `const` Key and shared pointer to `const` Storable.
+     *
+     * @{
+     */
+    iterator begin() noexcept;
+    const_iterator begin() const noexcept;
+    const_iterator cbegin() const noexcept { return begin(); }
+
+    /** @} */
+
+    /**
+     * Return an iterator to the element past the end of the map.
+     *
+     * @return An iterator that dereferences to a value_type, i.e. a pair of
+     *         `const` Key and shared pointer to `const` Storable.
+     *
+     * @{
+     */
+    iterator end() noexcept;
+    const_iterator end() const noexcept;
+    const_iterator cend() const noexcept { return end(); }
+
+    /** @} */
+
 private:
-    std::unordered_map<key_type, mapped_type> _contents;
+    _Impl _contents;
 };
 
 }  // namespace detail

--- a/include/lsst/afw/typehandling/GenericMap.h
+++ b/include/lsst/afw/typehandling/GenericMap.h
@@ -26,168 +26,23 @@
 #define LSST_AFW_TYPEHANDLING_GENERICMAP_H
 
 #include <algorithm>
-#include <functional>
-#include <ostream>
 #include <memory>
 #include <sstream>
-#include <typeinfo>
+#include <string>
 #include <type_traits>
-#include <unordered_set>
+#include <utility>
 #include <vector>
 
-#include "boost/core/demangle.hpp"
 #include "boost/variant.hpp"
 
 #include "lsst/pex/exceptions.h"
+#include "lsst/afw/typehandling/Key.h"
 #include "lsst/afw/typehandling/Storable.h"
 #include "lsst/afw/typehandling/PolymorphicValue.h"
 
 namespace lsst {
 namespace afw {
 namespace typehandling {
-
-/**
- * Key for type-safe lookup in a GenericMap.
- *
- * @tparam K the logical type of the key (e.g., a string)
- * @tparam V the type of the value mapped to this key
- *
- * Key objects are equality-comparable, hashable, sortable, or printable if and only if `K` is comparable,
- * hashable, sortable, or printable, respectively. Key can be used in compile-time expressions if and only
- * if `K` can (in particular, `Key<std::string, V>` cannot).
- *
- * @note Objects of this type are immutable.
- */
-template <typename K, typename V>
-class Key final {
-public:
-    using KeyType = K;
-    using ValueType = V;
-
-    /**
-     * Construct a new key.
-     *
-     * @param id
-     *          the identifier of the field. For most purposes, this value is
-     *          the actual key; it can be retrieved by calling getId().
-     *
-     * @exceptsafe Provides the same exception safety as the copy-constructor of `K`.
-     *
-     * @see makeKey
-     */
-    constexpr Key(K id) : id(id) {}
-
-    Key(Key const&) = default;
-    Key(Key&&) = default;
-    Key& operator=(Key const&) = delete;
-    Key& operator=(Key&&) = delete;
-
-    /**
-     * Return the identifier of this field.
-     *
-     * The identifier serves as the "key" for the map abstraction
-     * represented by GenericMap.
-     *
-     * @returns the unique key defining this field
-     */
-    constexpr K const& getId() const noexcept { return id; }
-
-    /**
-     * Test for key equality.
-     *
-     * A key is considered equal to another key if and only if their getId() are equal and their value
-     * types are exactly the same (including const/volatile qualifications).
-     *
-     * @{
-     */
-    constexpr bool operator==(Key<K, V> const& other) const noexcept { return this->id == other.id; }
-
-    template <typename U>
-    constexpr std::enable_if_t<!std::is_same<U, V>::value, bool> operator==(Key<K, U> const&) const noexcept {
-        return false;
-    }
-
-    template <typename U>
-    constexpr bool operator!=(Key<K, U> const& other) const noexcept {
-        return !(*this == other);
-    }
-
-    /** @} */
-
-    /**
-     * Define sort order for Keys.
-     *
-     * This must be expressed as `operator<` instead of std::less because only std::less<void> supports
-     * arguments of mixed types, and it cannot be specialized.
-     *
-     * @param other the key, possibly of a different type, to compare to
-     * @return equivalent to `this->getId() < other.getId()`
-     *
-     * @warning this comparison operator provides a strict weak ordering so long as `K` does, but is *not*
-     * consistent with equality. In particular, keys with the same value of `getId()` but different types will
-     * be equivalent but not equal.
-     */
-    template <typename U>
-    constexpr bool operator<(Key<K, U> const& other) const noexcept {
-        const std::less<K> comparator;
-        return comparator(this->getId(), other.getId());
-    }
-
-    /// Return a hash of this object.
-    std::size_t hash_value() const noexcept { return std::hash<K>()(id); }
-
-private:
-    /** The logical key. */
-    K const id;
-};
-
-/**
- * Factory function for Key, to enable type parameter inference.
- *
- * @param id the key ID to create.
- *
- * @returns a key of the desired type
- *
- * @exceptsafe Provides the same exception safety as the copy-constructor of `K`.
- *
- * @relatesalso Key
- *
- * Calling this function prevents you from having to explicitly name the key type:
- *
- *     auto key = makeKey<int>("foo");
- */
-// template parameters must be reversed for inference to work correctly
-template <typename V, typename K>
-constexpr Key<K, V> makeKey(K const& id) {
-    return Key<K, V>(id);
-}
-
-/**
- * Output operator for Key.
- *
- * The output will use C++ template notation for the key; for example, a key "foo" pointing to an `int` may
- * print as `"foo<int>"`.
- *
- * @param os the desired output stream
- * @param key the key to print
- *
- * @returns a reference to `os`
- *
- * @exceptsafe Provides basic exception safety if the output operator of `K` is exception-safe.
- *
- * @warning the type name is compiler-specific and may be mangled or unintuitive; for example, some compilers
- * say "i" instead of "int"
- *
- * @relatesalso Key
- */
-template <typename K, typename V>
-std::ostream& operator<<(std::ostream& os, Key<K, V> const& key) {
-    static const std::string typeStr = boost::core::demangle(typeid(V).name());
-    static const std::string constStr = std::is_const<V>::value ? " const" : "";
-    static const std::string volatileStr = std::is_volatile<V>::value ? " volatile" : "";
-    os << key.getId() << "<" << typeStr << constStr << volatileStr << ">";
-    return os;
-}
 
 // Test for smart pointers as "any type with an element_type member"
 // Second template parameter is a dummy to let us do some metaprogramming
@@ -871,14 +726,5 @@ protected:
 }  // namespace typehandling
 }  // namespace afw
 }  // namespace lsst
-
-namespace std {
-template <typename K, typename V>
-struct hash<typename lsst::afw::typehandling::Key<K, V>> {
-    using argument_type = typename lsst::afw::typehandling::Key<K, V>;
-    using result_type = size_t;
-    size_t operator()(argument_type const& obj) const noexcept { return obj.hash_value(); }
-};
-}  // namespace std
 
 #endif

--- a/include/lsst/afw/typehandling/GenericMap.h
+++ b/include/lsst/afw/typehandling/GenericMap.h
@@ -36,6 +36,7 @@
 #include "boost/variant.hpp"
 
 #include "lsst/pex/exceptions.h"
+#include "lsst/afw/typehandling/detail/type_traits.h"
 #include "lsst/afw/typehandling/Key.h"
 #include "lsst/afw/typehandling/Storable.h"
 #include "lsst/afw/typehandling/PolymorphicValue.h"
@@ -43,13 +44,6 @@
 namespace lsst {
 namespace afw {
 namespace typehandling {
-
-// Test for smart pointers as "any type with an element_type member"
-// Second template parameter is a dummy to let us do some metaprogramming
-template <typename, typename = void>
-constexpr bool IS_SMART_PTR = false;
-template <typename T>
-constexpr bool IS_SMART_PTR<T, std::enable_if_t<std::is_object<typename T::element_type>::value>> = true;
 
 /**
  * Interface for a heterogeneous map.
@@ -110,13 +104,13 @@ public:
      *
      * @{
      */
-    template <typename T, typename std::enable_if_t<!IS_SMART_PTR<T>, int> = 0>
+    template <typename T, typename std::enable_if_t<!detail::IS_SMART_PTR<T>, int> = 0>
     T& at(Key<K, T> const& key) {
         // Both casts are safe; see Effective C++, Item 3
         return const_cast<T&>(static_cast<const GenericMap&>(*this).at(key));
     }
 
-    template <typename T, typename std::enable_if_t<!IS_SMART_PTR<T>, int> = 0>
+    template <typename T, typename std::enable_if_t<!detail::IS_SMART_PTR<T>, int> = 0>
     T const& at(Key<K, T> const& key) const {
         // Delegate to private methods to hide further special-casing of T
         return _at(key);

--- a/include/lsst/afw/typehandling/Key.h
+++ b/include/lsst/afw/typehandling/Key.h
@@ -65,7 +65,7 @@ public:
      *
      * @see makeKey
      */
-    constexpr Key(K id) : id(id) {}
+    constexpr explicit Key(K id) : id(id) {}
 
     Key(Key const&) = default;
     Key(Key&&) = default;

--- a/include/lsst/afw/typehandling/Key.h
+++ b/include/lsst/afw/typehandling/Key.h
@@ -47,8 +47,6 @@ namespace typehandling {
  * Key objects are equality-comparable, hashable, sortable, or printable if and only if `K` is comparable,
  * hashable, sortable, or printable, respectively. Key can be used in compile-time expressions if and only
  * if `K` can (in particular, `Key<std::string, V>` cannot).
- *
- * @note Objects of this type are immutable.
  */
 template <typename K, typename V>
 class Key final {
@@ -71,8 +69,8 @@ public:
 
     Key(Key const&) = default;
     Key(Key&&) = default;
-    Key& operator=(Key const&) = delete;
-    Key& operator=(Key&&) = delete;
+    Key& operator=(Key const&) = default;
+    Key& operator=(Key&&) = default;
 
     /**
      * Convert a key to a different key that could retrieve the same values.
@@ -152,7 +150,7 @@ public:
 
 private:
     /** The logical key. */
-    K const id;
+    K id;
 };
 
 /**

--- a/include/lsst/afw/typehandling/Key.h
+++ b/include/lsst/afw/typehandling/Key.h
@@ -1,0 +1,195 @@
+// -*- LSST-C++ -*-
+/*
+ * This file is part of afw.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef LSST_AFW_TYPEHANDLING_KEY_H
+#define LSST_AFW_TYPEHANDLING_KEY_H
+
+#include <functional>
+#include <ostream>
+#include <string>
+#include <type_traits>
+
+#include "boost/core/demangle.hpp"
+
+namespace lsst {
+namespace afw {
+namespace typehandling {
+
+/**
+ * Key for type-safe lookup in a GenericMap.
+ *
+ * @tparam K the logical type of the key (e.g., a string)
+ * @tparam V the type of the value mapped to this key
+ *
+ * Key objects are equality-comparable, hashable, sortable, or printable if and only if `K` is comparable,
+ * hashable, sortable, or printable, respectively. Key can be used in compile-time expressions if and only
+ * if `K` can (in particular, `Key<std::string, V>` cannot).
+ *
+ * @note Objects of this type are immutable.
+ */
+template <typename K, typename V>
+class Key final {
+public:
+    using KeyType = K;
+    using ValueType = V;
+
+    /**
+     * Construct a new key.
+     *
+     * @param id
+     *          the identifier of the field. For most purposes, this value is
+     *          the actual key; it can be retrieved by calling getId().
+     *
+     * @exceptsafe Provides the same exception safety as the copy-constructor of `K`.
+     *
+     * @see makeKey
+     */
+    constexpr Key(K id) : id(id) {}
+
+    Key(Key const&) = default;
+    Key(Key&&) = default;
+    Key& operator=(Key const&) = delete;
+    Key& operator=(Key&&) = delete;
+
+    /**
+     * Return the identifier of this field.
+     *
+     * The identifier serves as the "key" for the map abstraction
+     * represented by GenericMap.
+     *
+     * @returns the unique key defining this field
+     */
+    constexpr K const& getId() const noexcept { return id; }
+
+    /**
+     * Test for key equality.
+     *
+     * A key is considered equal to another key if and only if their getId() are equal and their value
+     * types are exactly the same (including const/volatile qualifications).
+     *
+     * @{
+     */
+    constexpr bool operator==(Key<K, V> const& other) const noexcept { return this->id == other.id; }
+
+    template <typename U>
+    constexpr std::enable_if_t<!std::is_same<U, V>::value, bool> operator==(Key<K, U> const&) const noexcept {
+        return false;
+    }
+
+    template <typename U>
+    constexpr bool operator!=(Key<K, U> const& other) const noexcept {
+        return !(*this == other);
+    }
+
+    /** @} */
+
+    /**
+     * Define sort order for Keys.
+     *
+     * This must be expressed as `operator<` instead of std::less because only std::less<void> supports
+     * arguments of mixed types, and it cannot be specialized.
+     *
+     * @param other the key, possibly of a different type, to compare to
+     * @return equivalent to `this->getId() < other.getId()`
+     *
+     * @warning this comparison operator provides a strict weak ordering so long as `K` does, but is *not*
+     * consistent with equality. In particular, keys with the same value of `getId()` but different types will
+     * be equivalent but not equal.
+     */
+    template <typename U>
+    constexpr bool operator<(Key<K, U> const& other) const noexcept {
+        const std::less<K> comparator;
+        return comparator(this->getId(), other.getId());
+    }
+
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept { return std::hash<K>()(id); }
+
+private:
+    /** The logical key. */
+    K const id;
+};
+
+/**
+ * Factory function for Key, to enable type parameter inference.
+ *
+ * @param id the key ID to create.
+ *
+ * @returns a key of the desired type
+ *
+ * @exceptsafe Provides the same exception safety as the copy-constructor of `K`.
+ *
+ * @relatesalso Key
+ *
+ * Calling this function prevents you from having to explicitly name the key type:
+ *
+ *     auto key = makeKey<int>("foo");
+ */
+// template parameters must be reversed for inference to work correctly
+template <typename V, typename K>
+constexpr Key<K, V> makeKey(K const& id) {
+    return Key<K, V>(id);
+}
+
+/**
+ * Output operator for Key.
+ *
+ * The output will use C++ template notation for the key; for example, a key "foo" pointing to an `int` may
+ * print as `"foo<int>"`.
+ *
+ * @param os the desired output stream
+ * @param key the key to print
+ *
+ * @returns a reference to `os`
+ *
+ * @exceptsafe Provides basic exception safety if the output operator of `K` is exception-safe.
+ *
+ * @warning the type name is compiler-specific and may be mangled or unintuitive; for example, some compilers
+ * say "i" instead of "int"
+ *
+ * @relatesalso Key
+ */
+template <typename K, typename V>
+std::ostream& operator<<(std::ostream& os, Key<K, V> const& key) {
+    static const std::string typeStr = boost::core::demangle(typeid(V).name());
+    static const std::string constStr = std::is_const<V>::value ? " const" : "";
+    static const std::string volatileStr = std::is_volatile<V>::value ? " volatile" : "";
+    os << key.getId() << "<" << typeStr << constStr << volatileStr << ">";
+    return os;
+}
+
+}  // namespace typehandling
+}  // namespace afw
+}  // namespace lsst
+
+namespace std {
+template <typename K, typename V>
+struct hash<typename lsst::afw::typehandling::Key<K, V>> {
+    using argument_type = typename lsst::afw::typehandling::Key<K, V>;
+    using result_type = size_t;
+    size_t operator()(argument_type const& obj) const noexcept { return obj.hash_value(); }
+};
+}  // namespace std
+
+#endif

--- a/include/lsst/afw/typehandling/detail/type_traits.h
+++ b/include/lsst/afw/typehandling/detail/type_traits.h
@@ -1,0 +1,47 @@
+// -*- LSST-C++ -*-
+/*
+ * This file is part of afw.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef LSST_AFW_TYPEHANDLING_DETAIL_TYPETRAITS_H
+#define LSST_AFW_TYPEHANDLING_DETAIL_TYPETRAITS_H
+
+#include <type_traits>
+
+namespace lsst {
+namespace afw {
+namespace typehandling {
+namespace detail {
+
+// Test for smart pointers as "any type with an element_type member"
+// Second template parameter is a dummy to let us do some metaprogramming
+template <typename, typename = void>
+constexpr bool IS_SMART_PTR = false;
+template <typename T>
+constexpr bool IS_SMART_PTR<T, std::enable_if_t<std::is_object<typename T::element_type>::value>> = true;
+
+}  // namespace detail
+}  // namespace typehandling
+}  // namespace afw
+}  // namespace lsst
+
+#endif

--- a/src/image/ExposureInfo.cc
+++ b/src/image/ExposureInfo.cc
@@ -1,10 +1,12 @@
 // -*- LSST-C++ -*- // fixed format comment for emacs
 /*
- * LSST Data Management System
- * Copyright 2008, 2009, 2010 LSST Corporation.
+ * This file is part of afw.
  *
- * This product includes software developed by the
- * LSST Project (http://www.lsst.org/).
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,9 +18,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the LSST License Statement and
- * the GNU General Public License along with this program.  If not,
- * see <http://www.lsstcorp.org/LegalNotices/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include "lsst/pex/exceptions.h"

--- a/src/image/ExposureInfo.cc
+++ b/src/image/ExposureInfo.cc
@@ -33,14 +33,13 @@
 #include "lsst/afw/cameraGeom/Detector.h"
 #include "lsst/afw/image/TransmissionCurve.h"
 #include "lsst/afw/fits.h"
-#include "lsst/afw/typehandling/SimpleGenericMap.h"
 
 using namespace std::string_literals;
 
 namespace {
 LOG_LOGGER _log = LOG_GET("afw.image.ExposureInfo");
 
-using MapClass = lsst::afw::typehandling::SimpleGenericMap<std::string>;
+using MapClass = lsst::afw::image::detail::StorableMap;
 }  // namespace
 
 namespace lsst {
@@ -224,39 +223,15 @@ int ExposureInfo::_addToArchive(FitsWriteData& data,
     return componentId;
 }
 
-class ExposureInfo::StorablePersister final {
-public:
-    explicit StorablePersister(FitsWriteData& data) : data(data) {}
+// Standardized strings for _startWriteFits
+namespace {
+std::string _getOldHeaderKey(std::string mapKey) { return mapKey + "_ID"; }
+std::string _getNewHeaderKey(std::string mapKey) { return "ARCHIVE_ID_" + mapKey; }
 
-    void operator()(std::string key, std::shared_ptr<typehandling::Storable const> const& object) {
-        if (object && object->isPersistable()) {
-            std::string comment = _getHeaderComment(key);
-            // Store archive ID in two header keys:
-            //     - old-style key for backwards compatibility,
-            //     - and new-style key because it's much safer to parse
-            int id = _addToArchive(data, object, _getOldHeaderKey(key), comment);
-            data.metadata->set(_getNewHeaderKey(key), id, comment);
-        }
-    }
-
-    template <typename T>
-    void operator()(std::string key, T const&) {
-        std::stringstream buffer;
-        buffer << "ExposureInfo::_components may only contain shared_ptr<Storable> values. "
-               << "Invalid key: " << key;
-        throw LSST_EXCEPT(pex::exceptions::LogicError, buffer.str());
-    }
-
-private:
-    std::string _getOldHeaderKey(std::string mapKey) { return mapKey + "_ID"; }
-    std::string _getNewHeaderKey(std::string mapKey) { return "ARCHIVE_ID_" + mapKey; }
-
-    std::string _getHeaderComment(std::string mapKey) {
-        return "archive ID for generic component '" + mapKey + "'";
-    }
-
-    FitsWriteData& data;
-};
+std::string _getHeaderComment(std::string mapKey) {
+    return "archive ID for generic component '" + mapKey + "'";
+}
+}  // namespace
 
 ExposureInfo::FitsWriteData ExposureInfo::_startWriteFits(lsst::geom::Point2I const& xy0) const {
     FitsWriteData data;
@@ -277,7 +252,19 @@ ExposureInfo::FitsWriteData ExposureInfo::_startWriteFits(lsst::geom::Point2I co
     // this is still the case so we're setting AR_HDU to 5 == 4 + 1
     //
     data.metadata->set("AR_HDU", 5, "HDU (1-indexed) containing the archive used to store ancillary objects");
-    _components->apply(StorablePersister(data));
+    for (auto const& keyValue : *_components) {
+        std::string const& key = keyValue.first.getId();
+        std::shared_ptr<typehandling::Storable const> const& object = keyValue.second;
+
+        if (object && object->isPersistable()) {
+            std::string comment = _getHeaderComment(key);
+            // Store archive ID in two header keys:
+            //     - old-style key for backwards compatibility,
+            //     - and new-style key because it's much safer to parse
+            int id = _addToArchive(data, object, _getOldHeaderKey(key), comment);
+            data.metadata->set(_getNewHeaderKey(key), id, comment);
+        }
+    }
 
     // LSST convention is that Wcs is in pixel coordinates (i.e relative to bottom left
     // corner of parent image, if any). The Wcs/Fits convention is that the Wcs is in

--- a/src/image/detail/StorableMap.cc
+++ b/src/image/detail/StorableMap.cc
@@ -53,6 +53,16 @@ bool StorableMap::operator==(StorableMap const& other) const noexcept { return _
 
 void StorableMap::clear() noexcept { _contents.clear(); }
 
+StorableMap::const_iterator StorableMap::begin() const noexcept {
+    return StorableMap::const_iterator(_contents.begin());
+}
+StorableMap::const_iterator StorableMap::end() const noexcept {
+    return StorableMap::const_iterator(_contents.end());
+};
+
+StorableMap::iterator StorableMap::begin() noexcept { return StorableMap::iterator(_contents.begin()); };
+StorableMap::iterator StorableMap::end() noexcept { return StorableMap::iterator(_contents.end()); };
+
 }  // namespace detail
 }  // namespace image
 }  // namespace afw

--- a/src/image/detail/StorableMap.cc
+++ b/src/image/detail/StorableMap.cc
@@ -1,0 +1,59 @@
+// -*- LSST-C++ -*-
+/*
+ * This file is part of afw.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <unordered_map>
+#include <utility>
+
+#include "lsst/afw/image/detail/StorableMap.h"
+
+namespace lsst {
+namespace afw {
+namespace image {
+namespace detail {
+
+StorableMap::StorableMap() = default;
+StorableMap::StorableMap(StorableMap const& other) = default;
+StorableMap::StorableMap(StorableMap&& other) = default;
+StorableMap& StorableMap::operator=(StorableMap const& other) = default;
+StorableMap& StorableMap::operator=(StorableMap&& other) = default;
+StorableMap::~StorableMap() noexcept = default;
+
+StorableMap::StorableMap(std::initializer_list<value_type> init) : _contents(init){};
+
+StorableMap::size_type StorableMap::size() const noexcept { return _contents.size(); }
+
+bool StorableMap::empty() const noexcept { return _contents.empty(); }
+
+StorableMap::size_type StorableMap::max_size() const noexcept { return _contents.max_size(); }
+
+bool StorableMap::contains(std::string const& key) const { return _contents.count(key_type(key)) == 1; }
+
+bool StorableMap::operator==(StorableMap const& other) const noexcept { return _contents == other._contents; }
+
+void StorableMap::clear() noexcept { _contents.clear(); }
+
+}  // namespace detail
+}  // namespace image
+}  // namespace afw
+}  // namespace lsst

--- a/tests/test_exposure.py
+++ b/tests/test_exposure.py
@@ -1,9 +1,10 @@
+# This file is part of afw.
 #
-# LSST Data Management System
-# Copyright 2008, 2009, 2010 LSST Corporation.
-#
-# This product includes software developed by the
-# LSST Project (http://www.lsst.org/).
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,10 +16,8 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the LSST License Statement and
-# the GNU General Public License along with this program.  If not,
-# see <http://www.lsstcorp.org/LegalNotices/>.
-#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """
 Test lsst.afw.image.Exposure

--- a/tests/test_genericmapkey.cc
+++ b/tests/test_genericmapkey.cc
@@ -23,7 +23,7 @@
  */
 
 #define BOOST_TEST_DYN_LINK
-#define BOOST_TEST_MODULE GenericMapCpp
+#define BOOST_TEST_MODULE GenericMapKeyCpp
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-variable"
 #include "boost/test/unit_test.hpp"
@@ -35,7 +35,7 @@
 #include "lsst/utils/tests.h"
 
 #include "lsst/afw/math/ChebyshevBoundedField.h"
-#include "lsst/afw/typehandling/GenericMap.h"
+#include "lsst/afw/typehandling/Key.h"
 
 using namespace std::string_literals;
 

--- a/tests/test_storablemap.cc
+++ b/tests/test_storablemap.cc
@@ -381,6 +381,51 @@ BOOST_AUTO_TEST_CASE(TestInsertEraseInsert) {
                ComplexStorable(PI));
 }
 
+BOOST_AUTO_TEST_CASE(TestIteration) {
+    // Copy to get a non-const map.
+    StorableMap map = *makePrefilledMap();
+
+    shared_ptr<typehandling::Storable const> dummy = make_shared<OtherStorable>();
+
+    for (auto& keyValue : map) {
+        auto& value = keyValue.second;
+
+        if (value == nullptr) {
+            value = dummy;
+        }
+    }
+
+    for (auto it = begin(map); it != end(map); ++it) {
+        auto& key = it->first;
+        auto& value = it->second;
+
+        if (key == KEY_NULL) {
+            BOOST_TEST(value == dummy);
+        } else {
+            BOOST_TEST(value != dummy);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(TestConstIteration) {
+    unique_ptr<StorableMap const> map = makePrefilledMap();
+
+    unordered_map<string, string> expected({make_pair(KEY_SIMPLE.getId(), VALUE_SIMPLE->toString()),
+                                            make_pair(KEY_COMPLEX.getId(), VALUE_COMPLEX->toString()),
+                                            make_pair(KEY_NULL.getId(), "null"),
+                                            make_pair(KEY_MIXED.getId(), VALUE_MIXED->toString())});
+
+    unordered_map<string, string> result;
+    for (auto it = cbegin(*map); it != cend(*map); ++it) {
+        auto const& key = it->first;
+        auto const& value = it->second;
+
+        result.emplace(key.getId(), value ? value->toString() : "null");
+    }
+
+    BOOST_TEST(expected == result);
+}
+
 }  // namespace detail
 }  // namespace image
 }  // namespace afw

--- a/tests/test_storablemap.cc
+++ b/tests/test_storablemap.cc
@@ -1,0 +1,157 @@
+// -*- LSST-C++ -*-
+/*
+ * This file is part of afw.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE StorableMapCpp
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
+#include "boost/test/unit_test.hpp"
+#pragma clang diagnostic pop
+
+#include <memory>
+#include <numeric>
+#include <set>
+#include <sstream>
+#include <string>
+
+#include "lsst/pex/exceptions.h"
+#include "lsst/utils/tests.h"
+
+#include "lsst/afw/typehandling/Key.h"
+#include "lsst/afw/image/detail/StorableMap.h"
+
+using namespace std;
+using namespace string_literals;
+
+namespace lsst {
+namespace afw {
+namespace image {
+namespace detail {
+
+namespace {
+class SimpleStorable : public typehandling::Storable {
+public:
+    virtual ~SimpleStorable() = default;
+
+    shared_ptr<typehandling::Storable> cloneStorable() const override {
+        return make_shared<SimpleStorable>();
+    }
+
+    string toString() const override { return "Simplest possible representation"; }
+
+    bool equals(Storable const& other) const noexcept override { return singleClassEquals(*this, other); }
+    virtual bool operator==(SimpleStorable const& other) const { return true; }
+    bool operator!=(SimpleStorable const& other) const { return !(*this == other); }
+};
+
+class ComplexStorable final : public SimpleStorable {
+public:
+    constexpr ComplexStorable(double storage) : SimpleStorable(), storage(storage) {}
+
+    ComplexStorable& operator=(double newValue) {
+        storage = newValue;
+        return *this;
+    }
+
+    shared_ptr<typehandling::Storable> cloneStorable() const override {
+        return make_shared<ComplexStorable>(storage);
+    }
+
+    string toString() const override { return "ComplexStorable(" + to_string(storage) + ")"; }
+
+    size_t hash_value() const noexcept override { return hash<double>()(storage); }
+
+    // Warning: violates both substitution and equality symmetry!
+    bool equals(Storable const& other) const noexcept override {
+        auto complexOther = dynamic_cast<ComplexStorable const*>(&other);
+        if (complexOther) {
+            return this->storage == complexOther->storage;
+        } else {
+            return false;
+        }
+    }
+    bool operator==(SimpleStorable const& other) const override { return this->equals(other); }
+
+private:
+    double storage;
+};
+
+class OtherStorable final : public typehandling::Storable {};
+
+auto const KEY_SIMPLE = typehandling::makeKey<shared_ptr<SimpleStorable const>>("key0"s);
+auto const VALUE_SIMPLE = make_shared<SimpleStorable const>();
+auto const KEY_COMPLEX = typehandling::makeKey<shared_ptr<ComplexStorable const>>("key1"s);
+auto const VALUE_COMPLEX = make_shared<ComplexStorable const>(-100.0);
+auto const KEY_NULL = typehandling::makeKey<shared_ptr<typehandling::Storable const>>("key2"s);
+auto const VALUE_NULL = shared_ptr<typehandling::Storable const>();
+auto const KEY_MIXED = typehandling::makeKey<shared_ptr<SimpleStorable const>>("key3"s);
+auto const VALUE_MIXED = make_shared<ComplexStorable const>(42.0);
+auto const KEY_BAD = typehandling::makeKey<shared_ptr<typehandling::Storable const>>("NotAKey"s);
+
+unique_ptr<StorableMap const> makePrefilledMap() {
+    // Can't use auto here
+    initializer_list<StorableMap::value_type> contents = {
+            make_pair(KEY_SIMPLE, VALUE_SIMPLE), make_pair(KEY_COMPLEX, VALUE_COMPLEX),
+            make_pair(KEY_NULL, VALUE_NULL), make_pair(KEY_MIXED, VALUE_MIXED)};
+    return make_unique<StorableMap>(contents);
+}
+
+}  // namespace
+
+BOOST_AUTO_TEST_CASE(TestEquals) {
+    auto map1 = makePrefilledMap();
+
+    // Use BOOST_CHECK to avoid BOOST_TEST bug from StorableMap being unprintable
+    BOOST_CHECK(*map1 == *map1);
+}
+
+BOOST_AUTO_TEST_CASE(TestSize) {
+    auto demoMap = makePrefilledMap();
+
+    BOOST_TEST(demoMap->size() == 4);
+    BOOST_TEST(!demoMap->empty());
+}
+
+BOOST_AUTO_TEST_CASE(TestWeakContains) {
+    auto demoMap = makePrefilledMap();
+
+    BOOST_TEST(demoMap->contains(KEY_SIMPLE.getId()));
+    BOOST_TEST(demoMap->contains(KEY_COMPLEX.getId()));
+    BOOST_TEST(demoMap->contains(KEY_NULL.getId()));
+    BOOST_TEST(demoMap->contains(KEY_MIXED.getId()));
+    BOOST_TEST(!demoMap->contains(KEY_BAD.getId()));
+}
+
+BOOST_AUTO_TEST_CASE(TestClearIdempotent) {
+    auto demoMap = make_unique<StorableMap>();
+
+    BOOST_TEST_REQUIRE(demoMap->empty());
+    demoMap->clear();
+    BOOST_TEST(demoMap->empty());
+}
+
+}  // namespace detail
+}  // namespace image
+}  // namespace afw
+}  // namespace lsst

--- a/tests/test_storablemap.cc
+++ b/tests/test_storablemap.cc
@@ -119,6 +119,33 @@ unique_ptr<StorableMap const> makePrefilledMap() {
 
 }  // namespace
 
+BOOST_AUTO_TEST_CASE(TestAt) {
+    auto demoMap = makePrefilledMap();
+
+    BOOST_TEST(demoMap->at(KEY_SIMPLE) == VALUE_SIMPLE);
+
+    BOOST_TEST(demoMap->at(KEY_COMPLEX) == VALUE_COMPLEX);
+    BOOST_TEST(demoMap->at(typehandling::makeKey<shared_ptr<typehandling::Storable const>>(
+                       KEY_COMPLEX.getId())) == VALUE_COMPLEX);
+
+    BOOST_TEST(demoMap->at(KEY_NULL) == VALUE_NULL);
+
+    BOOST_TEST(demoMap->at(KEY_MIXED) == VALUE_MIXED);
+    using ExactType = std::decay_t<decltype(VALUE_MIXED)>;
+    BOOST_TEST(demoMap->at(typehandling::makeKey<ExactType>(KEY_MIXED.getId())) == VALUE_MIXED);
+
+    BOOST_CHECK_THROW(
+            demoMap->at(typehandling::makeKey<shared_ptr<ComplexStorable const>>(KEY_SIMPLE.getId())),
+            pex::exceptions::OutOfRangeError);
+    BOOST_CHECK_THROW(demoMap->at(KEY_BAD), pex::exceptions::OutOfRangeError);
+
+    // None of these should compile, because they're not shared pointers to Storable const.
+    // demoMap->at(typehandling::makeKey<int>("InvalidKey"s));
+    // demoMap->at(typehandling::makeKey<SimpleStorable>("InvalidKey"s));
+    // demoMap->at(typehandling::makeKey<shared_ptr<SimpleStorable>>("InvalidKey"s));
+    // demoMap->at(typehandling::makeKey<shared_ptr<string const>>("InvalidKey"s));
+}
+
 BOOST_AUTO_TEST_CASE(TestEquals) {
     auto map1 = makePrefilledMap();
 


### PR DESCRIPTION
This PR creates a simplified version of `afw::typehandling::GenericMap` called `afw::image::detail::StorableMap`, which does not try to provide any compile-time heterogeneity but keeps an API based on `afw::typehandling::Key`. It then replaces the use of `GenericMap` inside `ExposureInfo`.