### PR TITLE
DM-21314: Investigate GC problems with Storable

### DIFF
--- a/examples/convolveLinear.cc
+++ b/examples/convolveLinear.cc
@@ -51,7 +51,7 @@ int main(int argc, char **argv) {
         try {
             std::string dataDir = lsst::utils::getPackageDir("afwdata");
             inImagePath = dataDir + "/data/med.fits";
-        } catch (lsst::pex::exceptions::NotFoundError) {
+        } catch (lsst::pex::exceptions::NotFoundError const&) {
             std::cerr << "Usage: linearConvolve [fitsFile]" << std::endl;
             std::cerr << "fitsFile is the path to a masked image" << std::endl;
             std::cerr << "\nError: setup afwdata or specify fitsFile.\n" << std::endl;

--- a/examples/decoratedImage.cc
+++ b/examples/decoratedImage.cc
@@ -64,7 +64,7 @@ int main(int argc, char* argv[]) {
         try {
             std::string dataDir = lsst::utils::getPackageDir("afwdata");
             file_u16 = dataDir + "/data/small.fits";
-        } catch (lsst::pex::exceptions::NotFoundError) {
+        } catch (lsst::pex::exceptions::NotFoundError const&) {
             std::cerr << "Error: provide fits file path as argument or setup afwdata.\n" << std::endl;
             exit(EXIT_FAILURE);
         }

--- a/examples/mask.cc
+++ b/examples/mask.cc
@@ -76,7 +76,7 @@ int main() {
     try {
         std::string dataDir = lsst::utils::getPackageDir("afwdata");
         inImagePath = dataDir + "/data/small.fits";
-    } catch (lsst::pex::exceptions::NotFoundError) {
+    } catch (lsst::pex::exceptions::NotFoundError const&) {
         std::cerr << "Usage: mask [fitsFile]" << std::endl;
         std::cerr << "fitsFile is the path to a masked image" << std::endl;
         std::cerr << "\nError: setup afwdata or specify fitsFile.\n" << std::endl;

--- a/examples/maskedImageFitsIo.cc
+++ b/examples/maskedImageFitsIo.cc
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
         try {
             std::string dataDir = lsst::utils::getPackageDir("afwdata");
             inImagePath = dataDir + "/data/small.fits";
-        } catch (lsst::pex::exceptions::NotFoundError) {
+        } catch (lsst::pex::exceptions::NotFoundError const&) {
             std::cerr << "Usage: maskedImageFitsIO [fitsFile]" << std::endl;
             std::cerr << "fitsFile is the path to a masked image" << std::endl;
             std::cerr << "\nError: setup afwdata or specify fitsFile.\n" << std::endl;

--- a/examples/simpleConvolve.cc
+++ b/examples/simpleConvolve.cc
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
         try {
             std::string dataDir = lsst::utils::getPackageDir("afwdata");
             inImagePath = dataDir + "/data/small.fits";
-        } catch (lsst::pex::exceptions::NotFoundError) {
+        } catch (lsst::pex::exceptions::NotFoundError const&) {
             std::cerr << "Usage: simpleConvolve [fitsFile [sigma]]" << std::endl;
             std::cerr << "fitsFile is the path to a masked image" << std::endl;
             std::cerr << "sigma (default " << DefSigma << ") is the width of the gaussian kernel, in pixels"

--- a/examples/spatiallyVaryingConvolve.cc
+++ b/examples/spatiallyVaryingConvolve.cc
@@ -57,7 +57,7 @@ int main(int argc, char **argv) {
         try {
             std::string dataDir = lsst::utils::getPackageDir("afwdata");
             inImagePath = dataDir + "/data/small.fits";
-        } catch (lsst::pex::exceptions::NotFoundError) {
+        } catch (lsst::pex::exceptions::NotFoundError const&) {
             std::cerr << "Usage: spatiallyVaryingConvolve [fitsFile]" << std::endl;
             std::cerr << "fitsFile is the path to a masked image" << std::endl;
             std::cerr << "\nError: setup afwdata or specify fitsFile.\n" << std::endl;

--- a/examples/timeConvolve.cc
+++ b/examples/timeConvolve.cc
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
         try {
             std::string dataDir = lsst::utils::getPackageDir("afwdata");
             inImagePath = dataDir + "/data/small.fits";
-        } catch (lsst::pex::exceptions::NotFoundError) {
+        } catch (lsst::pex::exceptions::NotFoundError const&) {
             std::cerr << "Usage: timeConvolve [fitsFile [nIter]]" << std::endl;
             std::cerr << "fitsFile is the path to a masked image" << std::endl;
             std::cerr << "nIter (default " << DefNIter << ") is the number of iterations per kernel size"

--- a/examples/timeWcs.cc
+++ b/examples/timeWcs.cc
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
         try {
             std::string dataDir = lsst::utils::getPackageDir("afwdata");
             inImagePath = dataDir + "/ImSim/calexp/v85408556-fr/R23/S11.fits";
-        } catch (lsst::pex::exceptions::NotFoundError) {
+        } catch (lsst::pex::exceptions::NotFoundError const&) {
             std::cerr << "Usage: timeWcs [fitsFile [nIter]]" << std::endl;
             std::cerr << "fitsFile is the path to an exposure" << std::endl;
             std::cerr << "nIter (default " << DefNIter << ") is the number of iterations" << std::endl;

--- a/examples/wcsTest.cc
+++ b/examples/wcsTest.cc
@@ -57,7 +57,7 @@ int main(int argc, char **argv) {
         try {
             std::string dataDir = lsst::utils::getPackageDir("afwdata");
             inImagePath = dataDir + "/data/medexp.fits";
-        } catch (lsst::pex::exceptions::NotFoundError) {
+        } catch (lsst::pex::exceptions::NotFoundError const&) {
             std::cerr << "Usage: wcsTest [fitsFile]" << std::endl;
             std::cerr << "fitsFile is the path to an exposure" << std::endl;
             std::cerr << "\nError: setup afwdata or specify fitsFile.\n" << std::endl;

--- a/include/lsst/afw/typehandling/Storable.h
+++ b/include/lsst/afw/typehandling/Storable.h
@@ -69,6 +69,9 @@ public:
      *
      * @note If this class supports a `clone` operation, the two should behave
      *       identically except for the formal return type.
+     *
+     * @note When called on Python classes, this method delegates to
+     *       `__deepcopy__` if it exists.
      */
     // Return shared_ptr to work around https://github.com/pybind/pybind11/issues/1138
     virtual std::shared_ptr<Storable> cloneStorable() const;
@@ -77,6 +80,9 @@ public:
      * Create a string representation of this object (optional operation).
      *
      * @throws UnsupportedOperationException Thrown if this object does not have a string representation.
+     *
+     * @note When called on Python classes, this method delegates to
+     *       `__repr__`.
      */
     virtual std::string toString() const;
 
@@ -85,7 +91,11 @@ public:
      *
      * @throws UnsupportedOperationException Thrown if this object is not hashable.
      *
-     * @note Subclass authors are responsible for any associated specializations of std::hash.
+     * @note C++ subclass authors are responsible for any associated
+     *       specializations of std::hash.
+     *
+     * @note When called on Python classes, this method delegates to `__hash__`
+     *       if it exists.
      */
     virtual std::size_t hash_value() const;
 
@@ -105,6 +115,9 @@ public:
      * compile-time types of the left- and right-hand sides are.
      *
      * @see singleClassEquals
+     *
+     * @note When called on Python classes, this method delegates to `__eq__`
+     *       if it exists.
      */
     virtual bool equals(Storable const& other) const noexcept;
 

--- a/include/lsst/afw/typehandling/Storable.h
+++ b/include/lsst/afw/typehandling/Storable.h
@@ -51,7 +51,9 @@ LSST_EXCEPTION_TYPE(UnsupportedOperationException, pex::exceptions::RuntimeError
  * Storable may be subclassed by either C++ or Python classes. Many operations defined by Storable are
  * optional, and may throw UnsupportedOperationException if they are not defined.
  *
- * @see StorableHelper
+ * @note Any C++ subclass `X` of Storable that supports Python subclasses must
+ *       have a %pybind11 wrapper that uses `StorableHelper<X>` (or a subclass)
+ *       and lsst::utils::python::PySharedPtr.
  */
 class Storable : public table::io::Persistable {
 public:

--- a/include/lsst/afw/typehandling/python.h
+++ b/include/lsst/afw/typehandling/python.h
@@ -61,7 +61,7 @@ public:
         PYBIND11_OVERLOAD_NAME(std::size_t, Base, "__hash__", hash_value, );
     }
 
-    bool equals(Base const& other) const noexcept override {
+    bool equals(Storable const& other) const noexcept override {
         PYBIND11_OVERLOAD_NAME(bool, Base, "__eq__", equals, other);
     }
 };

--- a/include/lsst/afw/typehandling/python.h
+++ b/include/lsst/afw/typehandling/python.h
@@ -51,7 +51,12 @@ class StorableHelper : public Base {
 public:
     using Base::Base;
 
-    // Can't wrap clone(); PYBIND11_OVERLOAD chokes on unique_ptr return type
+    std::shared_ptr<Storable> cloneStorable() const override {
+        /* __deepcopy__ takes an optional dict, but PYBIND11_OVERLOAD_* won't
+         * compile unless you give it arguments that work for the C++ method
+         */
+        PYBIND11_OVERLOAD_NAME(std::shared_ptr<Storable>, Base, "__deepcopy__", cloneStorable, );
+    }
 
     std::string toString() const override {
         PYBIND11_OVERLOAD_NAME(std::string, Base, "__repr__", toString, );

--- a/python/lsst/afw/typehandling/_Storable.cc
+++ b/python/lsst/afw/typehandling/_Storable.cc
@@ -24,6 +24,7 @@
 #include "pybind11/pybind11.h"
 
 #include "lsst/utils/python.h"
+#include "lsst/utils/python/PySharedPtr.h"
 
 #include "lsst/afw/typehandling/Storable.h"
 #include "lsst/afw/typehandling/python.h"
@@ -31,11 +32,13 @@
 namespace py = pybind11;
 using namespace py::literals;
 
+using lsst::utils::python::PySharedPtr;
+
 namespace lsst {
 namespace afw {
 namespace typehandling {
 
-using PyStorable = py::class_<Storable, std::shared_ptr<Storable>, table::io::Persistable, StorableHelper<>>;
+using PyStorable = py::class_<Storable, PySharedPtr<Storable>, table::io::Persistable, StorableHelper<>>;
 
 void wrapStorable(utils::python::WrapperCollection& wrappers) {
     wrappers.addInheritanceDependency("lsst.afw.table.io");

--- a/src/geom/SpanSet.cc
+++ b/src/geom/SpanSet.cc
@@ -919,7 +919,7 @@ void SpanSet::setImage(image::Image<ImageT>& image, ImageT val, lsst::geom::Box2
         } else {
             applyFunctor(setterFunc, image, val);
         }
-    } catch (pex::exceptions::OutOfRangeError e) {
+    } catch (pex::exceptions::OutOfRangeError const&) {
         throw LSST_EXCEPT(pex::exceptions::OutOfRangeError,
                           "Footprint Bounds Outside image, set doClip to true");
     }

--- a/src/geom/detail/frameSetUtils.cc
+++ b/src/geom/detail/frameSetUtils.cc
@@ -106,7 +106,7 @@ std::shared_ptr<ast::FrameSet> readFitsWcs(daf::base::PropertySet& metadata, boo
     std::shared_ptr<ast::Object> obj;
     try {
         obj = channel.read();
-    } catch (std::runtime_error) {
+    } catch (std::runtime_error const&) {
         throw LSST_EXCEPT(pex::exceptions::TypeError, "The metadata does not describe an AST object");
     }
 

--- a/src/image/ExposureFitsReader.cc
+++ b/src/image/ExposureFitsReader.cc
@@ -70,7 +70,7 @@ public:
         // Try to read WCS from image metadata, and if found, strip the keywords used
         try {
             wcs = afw::geom::makeSkyWcs(*imageMetadata, true);
-        } catch (lsst::pex::exceptions::TypeError) {
+        } catch (lsst::pex::exceptions::TypeError const&) {
             LOGLS_DEBUG(_log, "No WCS found in FITS metadata");
         }
         if (wcs && any(xy0.ne(lsst::geom::Point2I(0, 0)))) {

--- a/src/image/ExposureInfo.cc
+++ b/src/image/ExposureInfo.cc
@@ -279,7 +279,7 @@ ExposureInfo::FitsWriteData ExposureInfo::_startWriteFits(lsst::geom::Point2I co
         std::shared_ptr<daf::base::PropertyList> wcsMetadata;
         try {
             wcsMetadata = newWcs->getFitsMetadata(true);
-        } catch (pex::exceptions::RuntimeError) {
+        } catch (pex::exceptions::RuntimeError const&) {
             // cannot represent this WCS as FITS-WCS; don't write its metadata
         }
         if (wcsMetadata) {

--- a/src/image/MaskedImageFitsReader.cc
+++ b/src/image/MaskedImageFitsReader.cc
@@ -89,7 +89,7 @@ void checkExtType(ImageBaseFitsReader const & reader, std::shared_ptr<daf::base:
                                reader.getFileName() % reader.getHdu() % expected % exttype));
         }
         metadata->remove("EXTTYPE");
-    } catch (pex::exceptions::NotFoundError) {
+    } catch (pex::exceptions::NotFoundError const&) {
         LOGL_WARN("afw.image.MaskedImageFitsReader", "Expected extension type not found: %s",
                   expected.c_str());
     }

--- a/src/image/PhotoCalib.cc
+++ b/src/image/PhotoCalib.cc
@@ -510,7 +510,7 @@ public:
         int tableVersion = 1;
         try {
             catalogs.front().getSchema().find<double>(EXPTIME_FIELD_NAME);
-        } catch (pex::exceptions::NotFoundError) {
+        } catch (pex::exceptions::NotFoundError const&) {
             tableVersion = CALIB_TABLE_CURRENT_VERSION;
         }
 

--- a/src/math/warpExposure.cc
+++ b/src/math/warpExposure.cc
@@ -301,7 +301,7 @@ int warpImage(DestImageT &destImage, SrcImageT const &srcImage,
     std::shared_ptr<SeparableKernel> warpingKernelPtr = control.getWarpingKernel();
     try {
         warpingKernelPtr->shrinkBBox(srcImage.getBBox(image::LOCAL));
-    } catch (lsst::pex::exceptions::InvalidParameterError) {
+    } catch (lsst::pex::exceptions::InvalidParameterError const&) {
         for (int y = 0, height = destImage.getHeight(); y < height; ++y) {
             for (typename DestImageT::x_iterator destPtr = destImage.row_begin(y), end = destImage.row_end(y);
                  destPtr != end; ++destPtr) {

--- a/tests/background.cc
+++ b/tests/background.cc
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(BackgroundTestImages,
         std::string afwdata_dir;
         try {
             afwdata_dir = lsst::utils::getPackageDir("afwdata");
-        } catch (lsst::pex::exceptions::NotFoundError) {
+        } catch (lsst::pex::exceptions::NotFoundError const&) {
             cerr << "Skipping: Test requires afwdata to be available" << endl;
             return;
         }

--- a/tests/maskedImage1.cc
+++ b/tests/maskedImage1.cc
@@ -46,7 +46,7 @@ int test(int argc, char **argv) {
                                                                  // twice in the previous avatar.
             outImagePath1 = "tests/file:maskedImage1_output_1.fits";
             outImagePath2 = "tests/file:maskedImage1_output_2.fits";
-        } catch (lsst::pex::exceptions::NotFoundError) {
+        } catch (lsst::pex::exceptions::NotFoundError const&) {
             cerr << "Usage: inputBaseName1 inputBaseName2 outputBaseName1  outputBaseName2" << endl;
             cerr << "Warning: tests not run! Setup afwdata if you wish to use the default fitsFile." << endl;
             return EXIT_SUCCESS;

--- a/tests/ramFitsIO.cc
+++ b/tests/ramFitsIO.cc
@@ -173,7 +173,7 @@ string GetGFilenamePath(int argc, char **argv) {
             // inImagePath = dataDir + "/data/fpC-002570-r6-0199_sub.fits"; //Also works - this one was not
             // used at all in the previous avatar of this test.
             inImagePath = dataDir + "/data/fpC-005902-r6-0677_sub.fits";
-        } catch (lsst::pex::exceptions::NotFoundError) {
+        } catch (lsst::pex::exceptions::NotFoundError const&) {
             cerr << "Usage: maskedImage1 [inputBaseName1] [inputBaseName2] [outputBaseName1] "
                     "[outputBaseName2]"
                  << endl;

--- a/tests/statistics.cc
+++ b/tests/statistics.cc
@@ -260,7 +260,7 @@ BOOST_AUTO_TEST_CASE(StatisticsTestImages,
         std::string afwdata_dir;
         try {
             afwdata_dir = lsst::utils::getPackageDir("afwdata");
-        } catch (lsst::pex::exceptions::NotFoundError) {
+        } catch (lsst::pex::exceptions::NotFoundError const&) {
             cerr << "Skipping: Test requires afwdata to be available" << endl;
             return;
         }

--- a/tests/testGenericMapLib.cc
+++ b/tests/testGenericMapLib.cc
@@ -295,6 +295,14 @@ std::shared_ptr<Storable> keepStaticStorable(std::shared_ptr<Storable> storable 
     return longLived;
 }
 
+/**
+ * Copy a Storable in C++.
+ *
+ * @param input The Storable to copy.
+ * @returns An identical but independent Storable.
+ */
+std::shared_ptr<Storable> duplicate(std::shared_ptr<Storable> input) { return input->cloneStorable(); }
+
 }  // namespace
 
 namespace {
@@ -333,6 +341,7 @@ PYBIND11_MODULE(testGenericMapLib, mod) {
     mod.def("makeCppUpdates", &makeCppUpdates, "testmap"_a);
     mod.def("addCppStorable", &addCppStorable, "testmap"_a);
     mod.def("keepStaticStorable", &keepStaticStorable, "storable"_a = nullptr);
+    mod.def("duplicate", &duplicate, "input"_a);
 
     py::class_<CppStorable, PySharedPtr<CppStorable>, Storable, StorableHelper<CppStorable>> cls(
             mod, "CppStorable");

--- a/tests/testGenericMapLib.cc
+++ b/tests/testGenericMapLib.cc
@@ -26,11 +26,13 @@
 #include <memory>
 #include <sstream>
 
+#include "lsst/utils/python/PySharedPtr.h"
 #include "lsst/pex/exceptions.h"
 
 #include "lsst/afw/typehandling/GenericMap.h"
 #include "lsst/afw/typehandling/SimpleGenericMap.h"
 #include "lsst/afw/typehandling/Storable.h"
+#include "lsst/afw/typehandling/python.h"
 
 namespace py = pybind11;
 using namespace pybind11::literals;
@@ -309,6 +311,8 @@ void declareAnyTypeFunctions(py::module& mod) {
 }  // namespace
 
 PYBIND11_MODULE(testGenericMapLib, mod) {
+    using lsst::utils::python::PySharedPtr;
+
     py::module::import("lsst.afw.typehandling");
 
     declareAnyTypeFunctions<bool>(mod);
@@ -330,7 +334,8 @@ PYBIND11_MODULE(testGenericMapLib, mod) {
     mod.def("addCppStorable", &addCppStorable, "testmap"_a);
     mod.def("keepStaticStorable", &keepStaticStorable, "storable"_a = nullptr);
 
-    py::class_<CppStorable, std::shared_ptr<CppStorable>, Storable> cls(mod, "CppStorable");
+    py::class_<CppStorable, PySharedPtr<CppStorable>, Storable, StorableHelper<CppStorable>> cls(
+            mod, "CppStorable");
     cls.def(py::init<std::string>());
     cls.def("__eq__", &CppStorable::operator==, py::is_operator());
     cls.def("__ne__", &CppStorable::operator!=, py::is_operator());

--- a/tests/test_Storable.py
+++ b/tests/test_Storable.py
@@ -32,6 +32,7 @@ import testGenericMapLib as cppLib
 class DemoStorable(Storable):
     """Test that we can inherit from Storable in Python.
     """
+
     def __init__(self, state):
         super().__init__()
         self._state = state
@@ -53,6 +54,15 @@ class DemoStorable(Storable):
 
     def __eq__(self, other):
         return self._state == other._state
+
+
+class SpecializedStorable(cppLib.CppStorable):
+    """Test that we can inherit from C++ subclasses of Storable that
+    are not Storable itself.
+    """
+
+    def __repr__(self):
+        return "Pythonic " + super().__repr__()
 
 
 class PythonStorableTestSuite(lsst.utils.tests.TestCase):
@@ -98,6 +108,18 @@ class PythonStorableTestSuite(lsst.utils.tests.TestCase):
         self.assertIsInstance(retrieved, Storable)
         self.assertIsInstance(retrieved, DemoStorable)
         self.assertEqual(retrieved, DemoStorable(3))
+
+    def testInheritedGarbageCollection(self):
+        cppLib.keepStaticStorable(SpecializedStorable("Foo"))
+
+        gc.collect()
+
+        retrieved = cppLib.keepStaticStorable()
+        self.assertIsInstance(retrieved, Storable)
+        self.assertIsInstance(retrieved, cppLib.CppStorable)
+        self.assertIsInstance(retrieved, SpecializedStorable)
+        self.assertEqual(repr(retrieved), "Pythonic Foo")
+        cppLib.assertPythonStorable(retrieved, "Pythonic Foo")
 
 
 class CppStorableTestSuite(lsst.utils.tests.TestCase):

--- a/tests/test_Storable.py
+++ b/tests/test_Storable.py
@@ -89,7 +89,6 @@ class PythonStorableTestSuite(lsst.utils.tests.TestCase):
         self.assertEqual(self.testbed, DemoStorable([42]))
         self.assertNotEqual(self.testbed, DemoStorable(0))
 
-    @unittest.skip("TODO: Fix this bug in DM-21314")
     def testGarbageCollection(self):
         cppLib.keepStaticStorable(DemoStorable(3))
 

--- a/tests/test_Storable.py
+++ b/tests/test_Storable.py
@@ -80,9 +80,16 @@ class PythonStorableTestSuite(lsst.utils.tests.TestCase):
         self.assertIsNot(deep, self.testbed)
         self.assertEqual(deep, self.testbed)
 
+        cpp = cppLib.duplicate(self.testbed)
+        self.assertIsInstance(cpp, Storable)
+        self.assertIsInstance(cpp, DemoStorable)
+        self.assertIsNot(cpp, self.testbed)
+        self.assertEqual(cpp, self.testbed)
+
         self.aList.append(43)
         self.assertEqual(shallow, DemoStorable([42, 43]))
         self.assertEqual(deep, DemoStorable([42]))
+        self.assertEqual(cpp, DemoStorable([42]))
 
     def testStr(self):
         self.assertEqual(str(self.testbed), "value = [42]")


### PR DESCRIPTION
This PR fixes a bug that prevented `Storable` objects from being usable unless they were continuously referenced by Python code. The fix depends on lsst/utils#75.

It also implements and tests cloning of Python `Storable`s, which was left unsupported due to an oversight.