### PR TITLE
DM-22260: Add metadata to temporary catalog to be persisted.

### DIFF
--- a/src/table/Exposure.cc
+++ b/src/table/Exposure.cc
@@ -228,6 +228,9 @@ void ExposureFitsWriter::_writeTable(std::shared_ptr<BaseTable const> const &t, 
     }
     _mapper = _helper.makeWriteMapper(inTable->getSchema());
     std::shared_ptr<BaseTable> outTable = BaseTable::make(_mapper.getOutputSchema());
+    // Put the metadata from inTable in outTable
+    std::shared_ptr<daf::base::PropertyList> metadata = inTable->getMetadata();
+    outTable->setMetadata(metadata);
     io::FitsWriter::_writeTable(outTable, nRows);
     _fits->writeKey("AFW_TYPE", "EXPOSURE", "Tells lsst::afw to load this as an Exposure table.");
     _fits->writeKey(EXPOSURE_TABLE_VERSION_KEY, EXPOSURE_TABLE_CURRENT_VERSION, "Exposure table version");

--- a/src/table/Exposure.cc
+++ b/src/table/Exposure.cc
@@ -229,8 +229,7 @@ void ExposureFitsWriter::_writeTable(std::shared_ptr<BaseTable const> const &t, 
     _mapper = _helper.makeWriteMapper(inTable->getSchema());
     std::shared_ptr<BaseTable> outTable = BaseTable::make(_mapper.getOutputSchema());
     // Put the metadata from inTable in outTable
-    std::shared_ptr<daf::base::PropertyList> metadata = inTable->getMetadata();
-    outTable->setMetadata(metadata);
+    outTable->setMetadata(inTable->getMetadata());
     io::FitsWriter::_writeTable(outTable, nRows);
     _fits->writeKey("AFW_TYPE", "EXPOSURE", "Tells lsst::afw to load this as an Exposure table.");
     _fits->writeKey(EXPOSURE_TABLE_VERSION_KEY, EXPOSURE_TABLE_CURRENT_VERSION, "Exposure table version");

--- a/tests/test_exposureTable.py
+++ b/tests/test_exposureTable.py
@@ -192,7 +192,10 @@ class ExposureTableTestCase(lsst.utils.tests.TestCase):
             self.assertIsNone(cat1[1].getVisitInfo())
             self.assertIsNone(cat1[0].getDetector())
             self.assertDetectorsEqual(cat1[1].getDetector(), self.detector)
-            for key in self.plist.keys():
+            # We are not checking for plist equality because reading from
+            # fits may add extra keys; for this test we care that the
+            # keys we set are properly round-tripped.
+            for key in self.plist:
                 self.assertEqual(self.plist[key], cat1.getMetadata()[key])
 
     def testGeometry(self):

--- a/tests/test_exposureTable.py
+++ b/tests/test_exposureTable.py
@@ -35,7 +35,7 @@ import numpy as np
 
 import lsst.utils.tests
 import lsst.pex.exceptions
-from lsst.daf.base import DateTime, PropertySet
+from lsst.daf.base import DateTime, PropertySet, PropertyList
 import lsst.geom
 import lsst.afw.table
 from lsst.afw.coord import Observatory, Weather
@@ -104,6 +104,9 @@ class ExposureTableTestCase(lsst.utils.tests.TestCase):
         self.ka = schema.addField("a", type=np.float64, doc="doc for a")
         self.kb = schema.addField("b", type=np.int64, doc="doc for b")
         self.cat = lsst.afw.table.ExposureCatalog(schema)
+        self.plist = PropertyList()
+        self.plist['VALUE'] = 1.0
+        self.cat.setMetadata(self.plist)
         self.wcs = self.createWcs()
         self.psf = DummyPsf(2.0)
         self.bbox0 = lsst.geom.Box2I(
@@ -189,6 +192,8 @@ class ExposureTableTestCase(lsst.utils.tests.TestCase):
             self.assertIsNone(cat1[1].getVisitInfo())
             self.assertIsNone(cat1[0].getDetector())
             self.assertDetectorsEqual(cat1[1].getDetector(), self.detector)
+            for key in self.plist.keys():
+                self.assertEqual(self.plist[key], cat1.getMetadata()[key])
 
     def testGeometry(self):
         bigBox = lsst.geom.Box2D(lsst.geom.Box2I(self.bbox0))


### PR DESCRIPTION
Also add a persistence test to confirm metadata is round-tripped.