### PR TITLE
DM-21276: Add prescan/overscan bbox get/set alias methods.

### DIFF
--- a/include/lsst/afw/cameraGeom/Amplifier.h
+++ b/include/lsst/afw/cameraGeom/Amplifier.h
@@ -210,6 +210,30 @@ public:
      */
     lsst::geom::Box2I getRawPrescanBBox() const { return getFields().rawPrescanBBox; }
 
+    /**
+     * The bounding box of serial overscan pixels (equivalent to horizontal
+     * overscan pixels) in the assembled, untrimmed raw image. This duplicates
+     * the getRawHorizontalOverscanBBox method for legacy reasons.
+     */
+    lsst::geom::Box2I getRawSerialOverscanBBox() const { return getFields().rawHorizontalOverscanBBox; }
+
+    /**
+     * The bounding box of parallel overscan pixels (equivalent to vertical
+     * overscan pixels) in the assembled, untrimmed raw image. This duplicates
+     * the getRawVerticalOverscanBBox method for legacy reasons.
+     */
+    lsst::geom::Box2I getRawParallelOverscanBBox() const { return getFields().rawVerticalOverscanBBox; }
+
+    /**
+     * The bounding box of horizontal/serial prescan pixels in the assembled,
+     * untrimmed raw image. This duplicates the getRawPrescanBBox method for
+     * legacy reasons.
+     */
+    lsst::geom::Box2I getRawSerialPrescanBBox() const { return getFields().rawPrescanBBox; }
+
+    /// @copydoc Amplifier::getRawSerialPrescanBBox
+    lsst::geom::Box2I getRawHorizontalPrescanBBox() const { return getFields().rawPrescanBBox; }
+
 protected:
 
     struct Fields {
@@ -360,6 +384,26 @@ public:
 
     /// @copydoc Amplifier::getRawPrescanBBox
     void setRawPrescanBBox(lsst::geom::Box2I const &bbox) {
+        _fields.rawPrescanBBox = bbox;
+    }
+
+    /// @copydoc Amplifier::getRawSerialOverscanBBox
+    void setRawSerialOverscanBBox(lsst::geom::Box2I const &bbox) {
+        _fields.rawHorizontalOverscanBBox = bbox;
+    }
+
+    /// @copydoc Amplifier::getRawParallelOverscanBBox
+    void setRawParallelOverscanBBox(lsst::geom::Box2I const &bbox) {
+        _fields.rawVerticalOverscanBBox = bbox;
+    }
+
+    /// @copydoc Amplifier::getRawSerialPrescanBBox
+    void setRawSerialPrescanBBox(lsst::geom::Box2I const &bbox) {
+        _fields.rawPrescanBBox = bbox;
+    }
+
+    /// @copydoc Amplifier::getRawHorizontalPrescanBBox
+    void setRawHorizontalPrescanBBox(lsst::geom::Box2I const &bbox) {
         _fields.rawPrescanBBox = bbox;
     }
 

--- a/python/lsst/afw/cameraGeom/amplifier/amplifier.cc
+++ b/python/lsst/afw/cameraGeom/amplifier/amplifier.cc
@@ -73,6 +73,10 @@ PyAmplifier declarePyAmplifier(py::module & mod) {
     cls.def("getRawHorizontalOverscanBBox", &Amplifier::getRawHorizontalOverscanBBox);
     cls.def("getRawVerticalOverscanBBox", &Amplifier::getRawVerticalOverscanBBox);
     cls.def("getRawPrescanBBox", &Amplifier::getRawPrescanBBox);
+    cls.def("getRawSerialOverscanBBox", &Amplifier::getRawSerialOverscanBBox);
+    cls.def("getRawParallelOverscanBBox", &Amplifier::getRawParallelOverscanBBox);
+    cls.def("getRawSerialPrescanBBox", &Amplifier::getRawSerialPrescanBBox);
+    cls.def("getRawHorizontalPrescanBBox", &Amplifier::getRawHorizontalPrescanBBox);
     return cls;
 }
 
@@ -110,6 +114,10 @@ void declarePyAmplifierBuilder(PyAmplifier & parent) {
     cls.def("setRawHorizontalOverscanBBox", &Amplifier::Builder::setRawHorizontalOverscanBBox, "bbox"_a);
     cls.def("setRawVerticalOverscanBBox", &Amplifier::Builder::setRawVerticalOverscanBBox, "bbox"_a);
     cls.def("setRawPrescanBBox", &Amplifier::Builder::setRawPrescanBBox, "bbox"_a);
+    cls.def("setRawSerialOverscanBBox", &Amplifier::Builder::setRawSerialOverscanBBox, "bbox"_a);
+    cls.def("setRawParallelOverscanBBox", &Amplifier::Builder::setRawParallelOverscanBBox, "bbox"_a);
+    cls.def("setRawSerialPrescanBBox", &Amplifier::Builder::setRawSerialPrescanBBox, "bbox"_a);
+    cls.def("setRawHorizontalPrescanBBox", &Amplifier::Builder::setRawHorizontalPrescanBBox, "bbox"_a);
 }
 
 PYBIND11_MODULE(amplifier, mod) {

--- a/tests/test_amplifier.py
+++ b/tests/test_amplifier.py
@@ -88,9 +88,44 @@ class AmplifierTestCase(unittest.TestCase):
         self.assertEqual(rawVerticalOverscanBBox,
                          amplifier.getRawVerticalOverscanBBox())
         self.assertEqual(rawPrescanBBox, amplifier.getRawPrescanBBox())
+        self.assertEqual(rawHorizontalOverscanBBox,
+                         amplifier.getRawSerialOverscanBBox())
+        self.assertEqual(rawVerticalOverscanBBox,
+                         amplifier.getRawParallelOverscanBBox())
+        self.assertEqual(rawPrescanBBox, amplifier.getRawSerialPrescanBBox())
+        self.assertEqual(rawPrescanBBox,
+                         amplifier.getRawHorizontalPrescanBBox())
         self.assertEqual(rawFlipX, amplifier.getRawFlipX())
         self.assertEqual(rawFlipY, amplifier.getRawFlipY())
         self.assertEqual(rawXYOffset, amplifier.getRawXYOffset())
+
+        # Test get/set methods for overscan/prescan alias names.
+        # Change slightly, don't care about contiguity, make smaller.
+        newHorizontalOverscanBBox = lsst.geom.Box2I(
+            lsst.geom.Point2I(150, 29), lsst.geom.Extent2I(25, 306))
+        newVerticalOverscanBBox = lsst.geom.Box2I(
+            lsst.geom.Point2I(-2, 201), lsst.geom.Extent2I(123, 5))
+        newPrescanBBox = lsst.geom.Box2I(
+            lsst.geom.Point2I(-20, 2), lsst.geom.Extent2I(4, 306))
+
+        builder.setRawSerialOverscanBBox(newHorizontalOverscanBBox)
+        builder.setRawParallelOverscanBBox(newVerticalOverscanBBox)
+        builder.setRawSerialPrescanBBox(newPrescanBBox)
+        amplifier = builder.finish()
+
+        self.assertEqual(newHorizontalOverscanBBox,
+                         amplifier.getRawHorizontalOverscanBBox())
+        self.assertEqual(newVerticalOverscanBBox,
+                         amplifier.getRawVerticalOverscanBBox())
+        self.assertEqual(newPrescanBBox,
+                         amplifier.getRawPrescanBBox())
+
+        newPrescanBBox2 = lsst.geom.Box2I(
+            lsst.geom.Point2I(-20, 2), lsst.geom.Extent2I(5, 306))
+        builder.setRawHorizontalPrescanBBox(newPrescanBBox2)
+        amplifier = builder.finish()
+        self.assertEqual(newPrescanBBox2,
+                         amplifier.getRawPrescanBBox())
 
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
Amplifier BBoxes for prescan and overscan regions are elsewhere inconsistently
named serial/parallel vs horizontal/vertical. To ensure these are used
consistently, add methods to allow both conventions to work correctly.

Add unit tests to check the consistency of these methods.