### PR TITLE
Use uppercase hierarch keys for cfitsio 3.47

### DIFF
--- a/tests/test_exposure.py
+++ b/tests/test_exposure.py
@@ -476,7 +476,7 @@ class ExposureTestCase(lsst.utils.tests.TestCase):
 
             readInfo = readExposure.getInfo()
             for key, value in self.extras.items():
-                self.assertEqual(value, readInfo.getComponent(key))
+                self.assertEqual(value, readInfo.getComponent(key.upper()))
 
             psf = readExposure.getPsf()
             self.assertIsNotNone(psf)


### PR DESCRIPTION
This is a fix for cfitsio 3.47. The components are stored by cfitsio 3.47 as upper case (via `HIERARCH`, so to retrieve them the test needs to convert to upper case.