### PR TITLE
DM-23651: ap_pipe calls some deprecated things

### DIFF
--- a/include/lsst/afw/math/ConvolveImage.h
+++ b/include/lsst/afw/math/ConvolveImage.h
@@ -145,10 +145,10 @@ inline typename OutImageT::SinglePixel convolveAtAPoint(
  * are set to the corresponding pixels of the input %image and (if there is a mask) the mask EDGE bit is set.
  *
  * The border of edge pixels has size:
- * - kernel.getCtrX() along the left edge
- * - kernel.getCtrY() along the bottom edge
- * - kernel.getWidth()  - 1 - kernel.getCtrX() along the right edge
- * - kernel.getHeight() - 1 - kernel.getCtrY() along the top edge
+ * - kernel.getCtr().getX() along the left edge
+ * - kernel.getCtr().getY() along the bottom edge
+ * - kernel.getWidth()  - 1 - kernel.getCtr().getX() along the right edge
+ * - kernel.getHeight() - 1 - kernel.getCtr().getY() along the top edge
  * You can obtain a bounding box for the good pixels in the convolved image
  * from a bounding box for the entire image using the Kernel method shrinkBBox.
  *

--- a/include/lsst/afw/math/detail/Convolve.h
+++ b/include/lsst/afw/math/detail/Convolve.h
@@ -49,10 +49,10 @@ namespace detail {
  *
  * convolvedImage must be the same size as inImage.
  * convolvedImage has a border in which the output pixels are not set. This border has size:
- * - kernel.getCtrX() along the left edge
- * - kernel.getCtrY() along the bottom edge
- * - kernel.getWidth()  - 1 - kernel.getCtrX() along the right edge
- * - kernel.getHeight() - 1 - kernel.getCtrY() along the top edge
+ * - kernel.getCtr().getX() along the left edge
+ * - kernel.getCtr().getY() along the bottom edge
+ * - kernel.getWidth()  - 1 - kernel.getCtr().getX() along the right edge
+ * - kernel.getHeight() - 1 - kernel.getCtr().getY() along the top edge
  *
  * @param[out] convolvedImage convolved %image
  * @param[in] inImage %image to convolve
@@ -126,10 +126,10 @@ void basicConvolve(OutImageT& convolvedImage, InImageT const& inImage,
  *
  * convolvedImage must be the same size as inImage.
  * convolvedImage has a border in which the output pixels are not set. This border has size:
- * - kernel.getCtrX() along the left edge
- * - kernel.getCtrY() along the bottom edge
- * - kernel.getWidth()  - 1 - kernel.getCtrX() along the right edge
- * - kernel.getHeight() - 1 - kernel.getCtrY() along the top edge
+ * - kernel.getCtr().getX() along the left edge
+ * - kernel.getCtr().getY() along the bottom edge
+ * - kernel.getWidth()  - 1 - kernel.getCtr().getX() along the right edge
+ * - kernel.getHeight() - 1 - kernel.getCtr().getY() along the top edge
  *
  * @param[out] convolvedImage convolved %image
  * @param[in] inImage %image to convolve

--- a/src/math/ConvolveImage.cc
+++ b/src/math/ConvolveImage.cc
@@ -69,8 +69,8 @@ inline void setEdgePixels(OutImageT& outImage, Kernel const& kernel, InImageT co
     const unsigned int imHeight = outImage.getHeight();
     const unsigned int kWidth = kernel.getWidth();
     const unsigned int kHeight = kernel.getHeight();
-    const unsigned int kCtrX = kernel.getCtrX();
-    const unsigned int kCtrY = kernel.getCtrY();
+    const unsigned int kCtrX = kernel.getCtr().getX();
+    const unsigned int kCtrY = kernel.getCtr().getY();
 
     const typename OutImageT::SinglePixel edgePixel =
             math::edgePixel<OutImageT>(typename image::detail::image_traits<OutImageT>::image_category());
@@ -121,8 +121,8 @@ inline void setEdgePixels(OutImageT& outImage, Kernel const& kernel, InImageT co
     const unsigned int imHeight = outImage.getHeight();
     const unsigned int kWidth = kernel.getWidth();
     const unsigned int kHeight = kernel.getHeight();
-    const unsigned int kCtrX = kernel.getCtrX();
-    const unsigned int kCtrY = kernel.getCtrY();
+    const unsigned int kCtrX = kernel.getCtr().getX();
+    const unsigned int kCtrY = kernel.getCtr().getY();
 
     const typename OutImageT::SinglePixel edgePixel =
             math::edgePixel<OutImageT>(typename image::detail::image_traits<OutImageT>::image_category());

--- a/src/math/Kernel.cc
+++ b/src/math/Kernel.cc
@@ -188,7 +188,7 @@ lsst::geom::Box2I Kernel::shrinkBBox(lsst::geom::Box2I const &bbox) const {
         throw LSST_EXCEPT(pexExcept::InvalidParameterError, os.str());
     }
     return lsst::geom::Box2I(
-            lsst::geom::Point2I(bbox.getMinX() + getCtrX(), bbox.getMinY() + getCtrY()),
+            lsst::geom::Point2I(bbox.getMin() + lsst::geom::Extent2I(getCtr())),
             lsst::geom::Extent2I(bbox.getWidth() + 1 - getWidth(), bbox.getHeight() + 1 - getHeight()));
 }
 

--- a/src/math/detail/BasicConvolve.cc
+++ b/src/math/detail/BasicConvolve.cc
@@ -189,8 +189,8 @@ void basicConvolve(OutImageT& convolvedImage, InImageT const& inImage,
     int const mImageHeight = inImage.getHeight();
     int const cnvWidth = mImageWidth + 1 - kernel.getWidth();
     int const cnvHeight = mImageHeight + 1 - kernel.getHeight();
-    int const cnvStartX = kernel.getCtrX();
-    int const cnvStartY = kernel.getCtrY();
+    int const cnvStartX = kernel.getCtr().getX();
+    int const cnvStartY = kernel.getCtr().getY();
     int const inStartX = kernel.getPixel().getX();
     int const inStartY = kernel.getPixel().getY();
 
@@ -375,8 +375,8 @@ void convolveWithBruteForce(OutImageT& convolvedImage, InImageT const& inImage, 
     int const kHeight = kernel.getHeight();
     int const cnvWidth = inImageWidth + 1 - kernel.getWidth();
     int const cnvHeight = inImageHeight + 1 - kernel.getHeight();
-    int const cnvStartX = kernel.getCtrX();
-    int const cnvStartY = kernel.getCtrY();
+    int const cnvStartX = kernel.getCtr().getX();
+    int const cnvStartY = kernel.getCtr().getY();
     int const cnvEndX = cnvStartX + cnvWidth;   // end index + 1
     int const cnvEndY = cnvStartY + cnvHeight;  // end index + 1
 

--- a/src/math/offsetImage.cc
+++ b/src/math/offsetImage.cc
@@ -94,10 +94,10 @@ std::shared_ptr<ImageT> offsetImage(ImageT const& inImage, float dx, float dy,
     // one to the right to center up the largest coefficients
     //
     if (dKerX < 0) {
-        offsetKernel->setCtrX(offsetKernel->getCtrX() + 1);
+        offsetKernel->setCtr(offsetKernel->getCtr() + lsst::geom::Extent2I(1, 0));
     }
     if (dKerY < 0) {
-        offsetKernel->setCtrY(offsetKernel->getCtrY() + 1);
+        offsetKernel->setCtr(offsetKernel->getCtr() + lsst::geom::Extent2I(0, 1));
     }
 
     offsetKernel->setKernelParameters(std::make_pair(dKerX, dKerY));

--- a/src/math/warpExposure.cc
+++ b/src/math/warpExposure.cc
@@ -63,7 +63,7 @@ namespace math {
 // the warping kernels are designed to work in two cases
 //    0 < x < 1  and ctrX=(size-1)/2
 //    -1 < x < 0  and ctrX=(size+1)/2
-// (and analogously for y).  Note that to get the second case, Kernel::setCtrX(1) must be
+// (and analogously for y).  Note that to get the second case, Kernel::setCtr(1, y) must be
 // called before calling Kernel::setKernelParameter().  [see afw::math::offsetImage() for
 // an example]
 //

--- a/tests/test_tableArchives.cc
+++ b/tests/test_tableArchives.cc
@@ -541,8 +541,7 @@ BOOST_AUTO_TEST_CASE(FixedKernel) {
     std::shared_ptr<afwMath::FixedKernel> p2 = roundtrip(p1.get());
     BOOST_CHECK_EQUAL(p1->getWidth(), p2->getWidth());
     BOOST_CHECK_EQUAL(p1->getHeight(), p2->getHeight());
-    BOOST_CHECK_EQUAL(p1->getCtrX(), p2->getCtrX());
-    BOOST_CHECK_EQUAL(p1->getCtrY(), p2->getCtrY());
+    BOOST_CHECK_EQUAL(p1->getCtr(), p2->getCtr());
     BOOST_CHECK_EQUAL(p1->getNSpatialParameters(), p2->getNSpatialParameters());
     BOOST_CHECK_EQUAL(p1->getNKernelParameters(), p2->getNKernelParameters());
     afwImage::Image<double> image2(p2->getDimensions());
@@ -560,8 +559,7 @@ BOOST_AUTO_TEST_CASE(AnalyticKernel1) {
     std::shared_ptr<afwMath::AnalyticKernel> p2 = roundtrip(p1.get());
     BOOST_CHECK_EQUAL(p1->getWidth(), p2->getWidth());
     BOOST_CHECK_EQUAL(p1->getHeight(), p2->getHeight());
-    BOOST_CHECK_EQUAL(p1->getCtrX(), p2->getCtrX());
-    BOOST_CHECK_EQUAL(p1->getCtrY(), p2->getCtrY());
+    BOOST_CHECK_EQUAL(p1->getCtr(), p2->getCtr());
     BOOST_CHECK_EQUAL(p1->getNSpatialParameters(), p2->getNSpatialParameters());
     BOOST_CHECK_EQUAL(p1->getNKernelParameters(), p2->getNKernelParameters());
     compareFunctions(*p1->getKernelFunction(), *p2->getKernelFunction());
@@ -585,8 +583,7 @@ BOOST_AUTO_TEST_CASE(AnalyticKernel2) {
     std::shared_ptr<afwMath::AnalyticKernel> p2 = roundtrip(p1.get());
     BOOST_CHECK_EQUAL(p1->getWidth(), p2->getWidth());
     BOOST_CHECK_EQUAL(p1->getHeight(), p2->getHeight());
-    BOOST_CHECK_EQUAL(p1->getCtrX(), p2->getCtrX());
-    BOOST_CHECK_EQUAL(p1->getCtrY(), p2->getCtrY());
+    BOOST_CHECK_EQUAL(p1->getCtr(), p2->getCtr());
     BOOST_CHECK_EQUAL(p1->getNSpatialParameters(), p2->getNSpatialParameters());
     BOOST_CHECK_EQUAL(p1->getNKernelParameters(), p2->getNKernelParameters());
     compareFunctions(*p1->getKernelFunction(), *p2->getKernelFunction());
@@ -620,8 +617,7 @@ BOOST_AUTO_TEST_CASE(LinearCombinationKernel1) {
     std::shared_ptr<afwMath::LinearCombinationKernel> p2 = roundtrip(p1.get());
     BOOST_CHECK_EQUAL(p1->getWidth(), p2->getWidth());
     BOOST_CHECK_EQUAL(p1->getHeight(), p2->getHeight());
-    BOOST_CHECK_EQUAL(p1->getCtrX(), p2->getCtrX());
-    BOOST_CHECK_EQUAL(p1->getCtrY(), p2->getCtrY());
+    BOOST_CHECK_EQUAL(p1->getCtr(), p2->getCtr());
     BOOST_CHECK_EQUAL(p1->getNSpatialParameters(), p2->getNSpatialParameters());
     BOOST_CHECK_EQUAL(p1->getNKernelParameters(), p2->getNKernelParameters());
     BOOST_CHECK(p1->getSpatialParameters() == p2->getSpatialParameters());
@@ -654,8 +650,7 @@ BOOST_AUTO_TEST_CASE(LinearCombinationKernel2) {
     std::shared_ptr<afwMath::LinearCombinationKernel> p2 = roundtrip(p1.get());
     BOOST_CHECK_EQUAL(p1->getWidth(), p2->getWidth());
     BOOST_CHECK_EQUAL(p1->getHeight(), p2->getHeight());
-    BOOST_CHECK_EQUAL(p1->getCtrX(), p2->getCtrX());
-    BOOST_CHECK_EQUAL(p1->getCtrY(), p2->getCtrY());
+    BOOST_CHECK_EQUAL(p1->getCtr(), p2->getCtr());
     BOOST_CHECK_EQUAL(p1->getNSpatialParameters(), p2->getNSpatialParameters());
     BOOST_CHECK_EQUAL(p1->getNKernelParameters(), p2->getNKernelParameters());
     BOOST_CHECK(p1->getSpatialParameters() == p2->getSpatialParameters());


### PR DESCRIPTION
This PR replaces calls to `Kernel.getCtrX` and `getCtrY` with `getCtr`, and calls to `setCtrX` and `setCtrY` with `setCtr`.