### PR TITLE
Update tickets associated with deprecations.

### DIFF
--- a/include/lsst/afw/geom/ellipses/GridTransform.h
+++ b/include/lsst/afw/geom/ellipses/GridTransform.h
@@ -72,7 +72,7 @@ public:
      * @deprecated invert is deprecated in favor of inverted
      */
     lsst::geom::LinearTransform inverted() const;
-    [[deprecated("Use `inverted` instead. To be removed after 20.0.0.")]]  // DM-22276
+    [[deprecated("Use `inverted` instead. To be removed after 20.0.0.")]]  // DM-22814
             lsst::geom::LinearTransform
             invert() const {
         return inverted();

--- a/include/lsst/afw/image/ImageBase.h
+++ b/include/lsst/afw/image/ImageBase.h
@@ -257,7 +257,7 @@ public:
      *
      * @deprecated use assign(rhs) instead
      */
-    [[deprecated("Use `assign` instead. To be removed after 20.0.0.")]]  // DM-22276
+    [[deprecated("Use `assign` instead. To be removed after 20.0.0.")]]  // DM-22814
             ImageBase&
             operator<<=(const ImageBase& rhs);
 
@@ -291,26 +291,26 @@ public:
      * @deprecated Deprecated in 16.0.  To be removed after 20.0.0.
      * Replaced by get(Point2I, ImageOrigin).
      */
-    [[deprecated("Use `operator[Point2I(x, y)]` instead. To be removed after 20.0.0.")]]  // DM-22276
+    [[deprecated("Use `operator[Point2I(x, y)]` instead. To be removed after 20.0.0.")]]  // DM-22814
             PixelConstReference
             get0(int x, int y) const {
         return operator()(x - getX0(), y - getY0());
     }
     [
             [deprecated("No replacement; `operator[Point2I(x, y)]` provides unchecked lookup. To be "
-                        "removed after 20.0.0.")]]  // DM-22276
+                        "removed after 20.0.0.")]]  // DM-22814
             PixelConstReference
             get0(int x, int y, CheckIndices const& check) const {
         return operator()(x - getX0(), y - getY0(), check);
     }
-    [[deprecated("Use `operator[Point2I(x, y)]` instead. To be removed after 20.0.0.")]]  // DM-22276
+    [[deprecated("Use `operator[Point2I(x, y)]` instead. To be removed after 20.0.0.")]]  // DM-22814
             void
             set0(int x, int y, const PixelT v) {
         operator()(x - getX0(), y - getY0()) = v;
     }
     [
             [deprecated("No replacement; `operator[Point2I(x, y)]` provides unchecked lookup. To be "
-                        "removed after 20.0.0.")]]  // DM-22276
+                        "removed after 20.0.0.")]]  // DM-22814
             void
             set0(int x, int y, const PixelT v, CheckIndices const& check) {
         operator()(x - getX0(), y - getY0(), check) = v;

--- a/include/lsst/afw/image/MaskedImage.h
+++ b/include/lsst/afw/image/MaskedImage.h
@@ -801,7 +801,7 @@ public:
      *
      * @note operator=() is not equivalent to this command
      */
-    [[deprecated("Use `assign` instead. To be removed after 20.0.0.")]]  // DM-22276
+    [[deprecated("Use `assign` instead. To be removed after 20.0.0.")]]  // DM-22814
             MaskedImage&
             operator<<=(MaskedImage const& rhs);
 

--- a/include/lsst/afw/image/Utils.h
+++ b/include/lsst/afw/image/Utils.h
@@ -60,7 +60,7 @@ namespace image {
  *  @param[in]    strip               If true, ignore special header keys usually managed by cfitsio
  *                                    (e.g. NAXIS).
  */
-[[deprecated("Use `afw::fits::readMetadata` instead. To be removed after 20.0.0.")]]  // DM-22276
+[[deprecated("Use `afw::fits::readMetadata` instead. To be removed after 20.0.0.")]]  // DM-22814
         inline std::shared_ptr<daf::base::PropertyList>
         readMetadata(std::string const& fileName, int hdu = fits::DEFAULT_HDU, bool strip = false) {
     return afw::fits::readMetadata(fileName, hdu, strip);

--- a/include/lsst/afw/math/Background.h
+++ b/include/lsst/afw/math/Background.h
@@ -118,7 +118,7 @@ public:
      */
     [[deprecated(
             "Omit `style` parameter, and pass it to `Background::getImage` instead. To be removed after "
-            "20.0.0.")]]  // DM-22276
+            "20.0.0.")]]  // DM-22814
             BackgroundControl(
                     Interpolate::Style const style, int const nxSample = 10, int const nySample = 10,
                     UndersampleStyle const undersampleStyle = THROW_EXCEPTION,
@@ -155,7 +155,7 @@ public:
      */
     [[deprecated(
             "Omit `style` parameter, and pass it to `Background::getImage` instead. To be removed after "
-            "20.0.0.")]]  // DM-22276
+            "20.0.0.")]]  // DM-22814
             BackgroundControl(std::string const& style, int const nxSample = 10, int const nySample = 10,
                               std::string const& undersampleStyle = "THROW_EXCEPTION",
                               StatisticsControl const sctrl = StatisticsControl(),
@@ -198,14 +198,14 @@ public:
     }
 
     [[deprecated(
-            "Replaced by passing style to `Background::getImage`. To be removed after 20.0.0.")]]  // DM-22276
+            "Replaced by passing style to `Background::getImage`. To be removed after 20.0.0.")]]  // DM-22814
             void
             setInterpStyle(Interpolate::Style const style) {
         _style = style;
     }
     // overload to take a string
     [[deprecated(
-            "Replaced by passing style to `Background::getImage`. To be removed after 20.0.0.")]]  // DM-22276
+            "Replaced by passing style to `Background::getImage`. To be removed after 20.0.0.")]]  // DM-22814
             void
             setInterpStyle(std::string const& style) {
         _style = math::stringToInterpStyle(style);
@@ -222,7 +222,7 @@ public:
     int getNxSample() const { return _nxSample; }
     int getNySample() const { return _nySample; }
     [[deprecated(
-            "Replaced by passing style to `Background::getImage`. To be removed after 20.0.0.")]]  // DM-22276
+            "Replaced by passing style to `Background::getImage`. To be removed after 20.0.0.")]]  // DM-22814
             Interpolate::Style
             getInterpStyle() const {
         if (_style < 0 || _style >= Interpolate::NUM_STYLES) {
@@ -244,7 +244,7 @@ public:
     std::shared_ptr<ApproximateControl const> getApproximateControl() const { return _actrl; }
 
 private:
-    // TODO: remove _style member in DM-22276
+    // TODO: remove _style member in DM-22814
     Interpolate::Style _style;           // style of interpolation to use
     int _nxSample;                       // number of grid squares to divide image into to sample in x
     int _nySample;                       // number of grid squares to divide image into to sample in y
@@ -357,7 +357,7 @@ public:
      */
     template <typename PixelT>
     [[deprecated(
-            "Call an overload with an `interpStyle` parameter. To be removed after 20.0.0.")]]  // DM-22276
+            "Call an overload with an `interpStyle` parameter. To be removed after 20.0.0.")]]  // DM-22814
             std::shared_ptr<lsst::afw::image::Image<PixelT>>
             getImage() const {
         return getImage<PixelT>(_bctrl->getInterpStyle(), _bctrl->getUndersampleStyle());
@@ -535,7 +535,7 @@ public:
      * This can be a very costly function to get a single pixel. If you want an image, use the getImage()
      * method.
      */
-    [[deprecated("Use `getImage` instead. To be removed after 20.0.0.")]]  // DM-22276
+    [[deprecated("Use `getImage` instead. To be removed after 20.0.0.")]]  // DM-22814
             double
             getPixel(Interpolate::Style const style, int const x, int const y) const;
     /**
@@ -545,7 +545,7 @@ public:
      *
      * @deprecated New code should specify the interpolation style in getPixel, not the ctor
      */
-    [[deprecated("Use `getImage` instead. To be removed after 20.0.0.")]]  // DM-22276
+    [[deprecated("Use `getImage` instead. To be removed after 20.0.0.")]]  // DM-22814
             double
             getPixel(int const x, int const y) const {
         // I think this should be LOCAL because the original getPixel used 0-based indices

--- a/include/lsst/afw/math/ConvolveImage.h
+++ b/include/lsst/afw/math/ConvolveImage.h
@@ -204,7 +204,7 @@ void convolve(OutImageT& convolvedImage, InImageT const& inImage, KernelT const&
  *                       copy edge pixels from input and set EDGE bit of mask
  */
 template <typename OutImageT, typename InImageT, typename KernelT>
-[[deprecated("Use `convolve` with a `ConvolutionControl` instead. To be removed after 20.0.0.")]]  // DM-22276
+[[deprecated("Use `convolve` with a `ConvolutionControl` instead. To be removed after 20.0.0.")]]  // DM-22814
         void
         convolve(OutImageT& convolvedImage, InImageT const& inImage, KernelT const& kernel, bool doNormalize,
                  bool doCopyEdge = false);

--- a/include/lsst/afw/math/Kernel.h
+++ b/include/lsst/afw/math/Kernel.h
@@ -239,7 +239,7 @@ public:
      *
      * @deprecated Use getCtr instead
      */
-    [[deprecated("Use `getCtr` instead. To be removed after 20.0.0.")]]  // DM-22276
+    [[deprecated("Use `getCtr` instead. To be removed after 20.0.0.")]]  // DM-22814
             inline int
             getCtrX() const {
         return _ctrX;
@@ -250,7 +250,7 @@ public:
      *
      * @deprecated Use getCtr instead
      */
-    [[deprecated("Use `getCtr` instead. To be removed after 20.0.0.")]]  // DM-22276
+    [[deprecated("Use `getCtr` instead. To be removed after 20.0.0.")]]  // DM-22814
             inline int
             getCtrY() const {
         return _ctrY;
@@ -343,7 +343,7 @@ public:
      *
      * @deprecated Use setCtr instead
      */
-    [[deprecated("Use `setCtr` instead. To be removed after 20.0.0.")]]  // DM-22276
+    [[deprecated("Use `setCtr` instead. To be removed after 20.0.0.")]]  // DM-22814
             inline void
             setCtrX(int ctrX) {
         _ctrX = ctrX;
@@ -355,7 +355,7 @@ public:
      *
      * @deprecated Use setCtr instead
      */
-    [[deprecated("Use `setCtr` instead. To be removed after 20.0.0.")]]  // DM-22276
+    [[deprecated("Use `setCtr` instead. To be removed after 20.0.0.")]]  // DM-22814
             inline void
             setCtrY(int ctrY) {
         _ctrY = ctrY;

--- a/include/lsst/afw/table/Match.h
+++ b/include/lsst/afw/table/Match.h
@@ -125,7 +125,7 @@ SourceMatchVector matchXy(
  * @param[in] radius   match radius (pixels)
  * @param[in] closest  if true then just return the closest match
  */
-[[deprecated("Use overloads that take `MatchControl` instead. To be removed after 20.0.0.")]]  // DM-22276
+[[deprecated("Use overloads that take `MatchControl` instead. To be removed after 20.0.0.")]]  // DM-22814
         SourceMatchVector
         matchXy(SourceCatalog const &cat1, SourceCatalog const &cat2, double radius, bool closest);
 
@@ -141,7 +141,7 @@ SourceMatchVector matchXy(
  * @param[in] symmetric    if cat to `true` symmetric matches are produced: i.e.
  *                         if (s1, s2, d) is reported, then so is (s2, s1, d).
  */
-[[deprecated("Use overloads that take `MatchControl` instead. To be removed after 20.0.0.")]]  // DM-22276
+[[deprecated("Use overloads that take `MatchControl` instead. To be removed after 20.0.0.")]]  // DM-22814
         SourceMatchVector
         matchXy(SourceCatalog const &cat, double radius, bool symmetric);
 
@@ -193,7 +193,7 @@ std::vector<Match<typename Cat::Record, typename Cat::Record> > matchRaDec(
  * This is instantiated for Simple-Simple, Simple-Source, and Source-Source catalog combinations.
  */
 template <typename Cat1, typename Cat2>
-[[deprecated("Use overloads that take `MatchControl` instead. To be removed after 20.0.0.")]]  // DM-22276
+[[deprecated("Use overloads that take `MatchControl` instead. To be removed after 20.0.0.")]]  // DM-22814
         std::vector<Match<typename Cat1::Record, typename Cat2::Record> >
         matchRaDec(Cat1 const &cat1, Cat2 const &cat2, lsst::geom::Angle radius, bool closest);
 
@@ -212,7 +212,7 @@ template <typename Cat1, typename Cat2>
  * This is instantiated for Simple and Source catalogs.
  */
 template <typename Cat>
-[[deprecated("Use overloads that take `MatchControl` instead. To be removed after 20.0.0.")]]  // DM-22276
+[[deprecated("Use overloads that take `MatchControl` instead. To be removed after 20.0.0.")]]  // DM-22814
         std::vector<Match<typename Cat::Record, typename Cat::Record> >
         matchRaDec(Cat const &cat, lsst::geom::Angle radius, bool symmetric);
 

--- a/include/lsst/afw/table/Source.h
+++ b/include/lsst/afw/table/Source.h
@@ -381,7 +381,7 @@ public:
      */
     [
             [deprecated("Use `getSchema().getAliasMap()->get(\"slot_Centroid\")` instead. To be removed "
-                        "after 20.0.0.")]]  // DM-22276
+                        "after 20.0.0.")]]  // DM-22814
             std::string
             getCentroidDefinition() const {
         return getSchema().getAliasMap()->get(getCentroidSlot().getAlias());
@@ -392,7 +392,7 @@ public:
      *
      *  @deprecated in favor of `getCentroidSlot().isValid()`.
      */
-    [[deprecated("Use `getCentroidSlot().isValid()` instead. To be removed after 20.0.0.")]]  // DM-22276
+    [[deprecated("Use `getCentroidSlot().isValid()` instead. To be removed after 20.0.0.")]]  // DM-22814
             bool
             hasCentroidSlot() const {
         return getCentroidSlot().isValid();
@@ -405,7 +405,7 @@ public:
      */
     [
             [deprecated("Use `getCentroidSlot().getMeasKey()` instead. To be removed after "
-                        "20.0.0.")]]  // DM-22276
+                        "20.0.0.")]]  // DM-22814
             CentroidSlotDefinition::MeasKey
             getCentroidKey() const {
         return getCentroidSlot().getMeasKey();
@@ -418,7 +418,7 @@ public:
      */
     [
             [deprecated("Use `getCentroidSlot().getErrKey()` instead. To be removed after "
-                        "20.0.0.")]]  // DM-22276
+                        "20.0.0.")]]  // DM-22814
             CentroidSlotDefinition::ErrKey
             getCentroidErrKey() const {
         return getCentroidSlot().getErrKey();
@@ -429,7 +429,7 @@ public:
      *
      *  @deprecated in favor of `getCentroidSlot().getFlagKey()`.
      */
-    [[deprecated("Use `getCentroidSlot().getFlagKey()` instead. To be removed after 20.0.0.")]]  // DM-22276
+    [[deprecated("Use `getCentroidSlot().getFlagKey()` instead. To be removed after 20.0.0.")]]  // DM-22814
             Key<Flag>
             getCentroidFlagKey() const {
         return getCentroidSlot().getFlagKey();
@@ -459,7 +459,7 @@ public:
      */
     [
             [deprecated("Use `getSchema().getAliasMap()->get(\"slot_Shape\")` instead. To be removed after "
-                        "20.0.0.")]]  // DM-22276
+                        "20.0.0.")]]  // DM-22814
             std::string
             getShapeDefinition() const {
         return getSchema().getAliasMap()->get(getShapeSlot().getAlias());
@@ -470,7 +470,7 @@ public:
      *
      *  @deprecated in favor of `getShapeSlot().isValid()`.
      */
-    [[deprecated("Use `getShapeSlot().isValid()` instead. To be removed after 20.0.0.")]]  // DM-22276
+    [[deprecated("Use `getShapeSlot().isValid()` instead. To be removed after 20.0.0.")]]  // DM-22814
             bool
             hasShapeSlot() const {
         return getShapeSlot().isValid();
@@ -481,7 +481,7 @@ public:
      *
      *  @deprecated in favor of `getShapeSlot().getMeasKey()`.
      */
-    [[deprecated("Use `getShapeSlot().getMeasKey()` instead. To be removed after 20.0.0.")]]  // DM-22276
+    [[deprecated("Use `getShapeSlot().getMeasKey()` instead. To be removed after 20.0.0.")]]  // DM-22814
             ShapeSlotDefinition::MeasKey
             getShapeKey() const {
         return getShapeSlot().getMeasKey();
@@ -492,7 +492,7 @@ public:
      *
      *  @deprecated in favor of `getShapeSlot().getErrKey()`.
      */
-    [[deprecated("Use `getShapeSlot().getErrKey()` instead. To be removed after 20.0.0.")]]  // DM-22276
+    [[deprecated("Use `getShapeSlot().getErrKey()` instead. To be removed after 20.0.0.")]]  // DM-22814
             ShapeSlotDefinition::ErrKey
             getShapeErrKey() const {
         return getShapeSlot().getErrKey();
@@ -503,7 +503,7 @@ public:
      *
      *  @deprecated in favor of `getShapeSlot().getFlagKey()`.
      */
-    [[deprecated("Use `getShapeSlot().getFlagKey()` instead. To be removed after 20.0.0.")]]  // DM-22276
+    [[deprecated("Use `getShapeSlot().getFlagKey()` instead. To be removed after 20.0.0.")]]  // DM-22814
             Key<Flag>
             getShapeFlagKey() const {
         return getShapeSlot().getFlagKey();

--- a/include/lsst/afw/table/io/python.h
+++ b/include/lsst/afw/table/io/python.h
@@ -60,7 +60,7 @@ namespace python {
  *               `PersistableFacade<suffix>`.
  */
 template <typename T>
-[[deprecated("Use `addPersistableMethods` instead. To be removed after 20.0.0.")]]  // DM-22276
+[[deprecated("Use `addPersistableMethods` instead. To be removed after 20.0.0.")]]  // DM-22814
         void
         declarePersistableFacade(pybind11::module &module, std::string const &suffix) {
     using namespace pybind11::literals;


### PR DESCRIPTION
DM-22276 was closed as a duplicate of DM-22814. This commit updates comments
referring to the former to point to the latter so that they are easier to find
in future.