### PR TITLE
capitalize on read and warn, warn when keywords are capitalized on write for fits files

### DIFF
--- a/src/fits.cc
+++ b/src/fits.cc
@@ -983,7 +983,7 @@ void writeKeyFromProperty(Fits &fits, daf::base::PropertySet const &metadata, st
     boost::to_upper(upperKey);
     if (upperKey.compare(key) != 0){
         LOGLS_WARN("afw.fits",
-                   boost::format("In %s, cfitsio>=3.38 will raise key case on write ('%s' -> '%s').") %
+                   boost::format("In %s, key '%s' may be standardized to uppercase '%s' on write.") %
                    BOOST_CURRENT_FUNCTION % key % upperKey);
     }
     std::type_info const &valueType = metadata.typeOf(key);

--- a/src/fits.cc
+++ b/src/fits.cc
@@ -796,8 +796,8 @@ void Fits::forEachKey(HeaderIterationFunctor &functor) {
         boost::to_upper(upperKey);
         if (upperKey.compare(key) != 0){
             LOGLS_WARN("afw.fits",
-                       boost::format("In %s, raising key case on read for key '%s' (for cfitsio>=3.38).") %
-                       BOOST_CURRENT_FUNCTION % key);
+                       boost::format("In %s, standardizing key '%s' to uppercase '%s' on read.") %
+                       BOOST_CURRENT_FUNCTION % key % upperKey);
         }
         keyStr = upperKey;
         valueStr = value;

--- a/src/fits.cc
+++ b/src/fits.cc
@@ -13,6 +13,7 @@ extern "C" {
 #include "fitsio2.h"
 }
 
+#include "boost/algorithm/string.hpp"
 #include "boost/regex.hpp"
 #include "boost/filesystem.hpp"
 #include "boost/preprocessor/seq/for_each.hpp"
@@ -789,7 +790,16 @@ void Fits::forEachKey(HeaderIterationFunctor &functor) {
     int i = 1;
     while (i <= nKeys) {
         fits_read_keyn(reinterpret_cast<fitsfile *>(fptr), i, key, value, comment, &status);
-        keyStr = key;
+        // fits_read_keyn does not convert the key case on read, like other fits methods in cfitsio>=3.38
+        // We uppercase to try to be more consistent.
+        std::string upperKey(key);
+        boost::to_upper(upperKey);
+        if (upperKey.compare(key) != 0){
+            LOGLS_WARN("afw.fits",
+                       boost::format("In %s, raising key case on read for key '%s' (for cfitsio>=3.38).") %
+                       BOOST_CURRENT_FUNCTION % key);
+        }
+        keyStr = upperKey;
         valueStr = value;
         commentStr = comment;
         ++i;
@@ -969,6 +979,13 @@ void MetadataIterationFunctor::operator()(std::string const &key, std::string co
 
 void writeKeyFromProperty(Fits &fits, daf::base::PropertySet const &metadata, std::string const &key,
                           char const *comment = 0) {
+    std::string upperKey(key);
+    boost::to_upper(upperKey);
+    if (upperKey.compare(key) != 0){
+        LOGLS_WARN("afw.fits",
+                   boost::format("In %s, cfitsio>=3.38 will raise key case on write ('%s' -> '%s').") %
+                   BOOST_CURRENT_FUNCTION % key % upperKey);
+    }
     std::type_info const &valueType = metadata.typeOf(key);
     if (valueType == typeid(bool)) {
         if (metadata.isArray(key)) {

--- a/tests/test_exposure.py
+++ b/tests/test_exposure.py
@@ -78,7 +78,7 @@ class ExposureTestCase(lsst.utils.tests.TestCase):
         self.md = maskedImageMD
         self.psf = DummyPsf(2.0)
         self.detector = DetectorWrapper().detector
-        self.extras = {"misc": DummyPsf(3.5)}
+        self.extras = {"MISC": DummyPsf(3.5)}
 
         self.exposureBlank = afwImage.ExposureF()
         self.exposureMiOnly = afwImage.makeExposure(maskedImage)


### PR DESCRIPTION
When reading from fits files from cfitsio>=3.38, cfitsio capitalizes keywords in some scenarios but not all. This PR normalizes capitalization when reading in all of those cases and warns the user this action has happened.

When writing to fits files, cfitsio>=3.38 will capitalize all keywords, including long ones. This PR will warn the user that this will be happening.