### PR TITLE
DM-24565: Un-deprecate old APIs related to afw.math.Background

### DIFF
--- a/examples/imageBackground.cc
+++ b/examples/imageBackground.cc
@@ -91,8 +91,8 @@ int main() {
     std::shared_ptr<math::Background> back = math::makeBackground(img, bgCtrl);
 
     // can get an individual pixel or a whole frame.
-    float const MID = std::dynamic_pointer_cast<math::BackgroundMI>(back)->getPixel(xcen, ycen);
     std::shared_ptr<ImageF> bg = back->getImage<ImageF::Pixel>();
+    float const MID = (*bg)(xcen, ycen);
 
     // create a background-subtracted image
     ImageF sub(img.getDimensions());

--- a/examples/imageBackground.cc
+++ b/examples/imageBackground.cc
@@ -73,10 +73,13 @@ int main() {
         }
     }
 
-    // declare a background control object with 10x10 samples
-    math::BackgroundControl bgCtrl(10, 10);
+    // declare a background control object for a natural spline
+    math::BackgroundControl bgCtrl(math::Interpolate::NATURAL_SPLINE);
 
-    // we can change the background estimate
+    // could also use a string! (commented-out, but will work)
+    // math::BackgroundControl bgCtrl("NATURAL_SPLINE");
+
+    // we can control the background estimate
     bgCtrl.setNxSample(5);
     bgCtrl.setNySample(5);
 
@@ -87,11 +90,9 @@ int main() {
     // initialize a background object
     std::shared_ptr<math::Background> back = math::makeBackground(img, bgCtrl);
 
-    // can get an interpolated frame. We use a natural spline.
-    std::shared_ptr<ImageF> bg = back->getImage<ImageF::Pixel>(math::Interpolate::NATURAL_SPLINE);
-    float const MID = (*bg)(xcen, ycen);
-    // could also use a string! (commented-out, but will work)
-    // std::shared_ptr<ImageF> bg = back->getImage<ImageF::Pixel>("NATURAL_SPLINE");
+    // can get an individual pixel or a whole frame.
+    float const MID = std::dynamic_pointer_cast<math::BackgroundMI>(back)->getPixel(xcen, ycen);
+    std::shared_ptr<ImageF> bg = back->getImage<ImageF::Pixel>();
 
     // create a background-subtracted image
     ImageF sub(img.getDimensions());

--- a/include/lsst/afw/math/Background.h
+++ b/include/lsst/afw/math/Background.h
@@ -104,9 +104,8 @@ public:
                                   nySample));
         }
     }
-    // And now the two old APIs (preserved for backward compatibility)
     /**
-     * @deprecated New code should specify the interpolation style in getImage, not the BackgroundControl ctor
+     * Overload constructor to provide interp style.
      *
      * @param style Style of the interpolation
      * @param nxSample Num. grid samples in x
@@ -138,8 +137,6 @@ public:
 
     /**
      * Overload constructor to handle strings for both interp and undersample styles.
-     *
-     * @deprecated New code should specify the interpolation style in getImage, not the BackgroundControl ctor
      *
      * @param style Style of the interpolation
      * @param nxSample num. grid samples in x
@@ -243,10 +240,6 @@ protected:
      * Estimate the statistical properties of the Image in a grid of cells;  we'll later call
      * getImage() to interpolate those values, creating an image the same size as the original
      *
-     * @note The old and deprecated API specified the interpolation style as part of the BackgroundControl
-     * object passed to this ctor.  This is still supported, but the work isn't done until the getImage()
-     * method is called
-     *
      * @param img ImageT (or MaskedImage) whose properties we want
      * @param bgCtrl Control how the Background is estimated
      */
@@ -331,7 +324,6 @@ public:
 
     /**
      * Method to interpolate and return the background for entire image
-     * @deprecated New code should specify the interpolation style in getImage, not the ctor
      */
     template <typename PixelT>
     std::shared_ptr<lsst::afw::image::Image<PixelT>> getImage() const {
@@ -434,7 +426,6 @@ private:
  *     // get a whole background image
  *     Image<PixelT> back = backobj->getImage<PixelT>(math::Interpolate::NATURAL_SPLINE);
  *
- * @deprecated
  * there is also
  *
  *     // get the background at a pixel at i_x,i_y
@@ -463,11 +454,6 @@ public:
      *     bkgdImage = bkgd.getImageF(afwMath.Interpolate.NATURAL_SPLINE, afwMath.REDUCE_INTERP_ORDER)
      *
      * There is a ticket (#2825) to allow getImage to specify a default value to use when interpolation fails
-     *
-     * @deprecated The old and deprecated API specified the interpolation style as part of the
-     * BackgroundControl
-     * object passed to this ctor.  This is still supported, but the work isn't done until the getImage()
-     * method is called
      */
     explicit BackgroundMI(ImageT const& img, BackgroundControl const& bgCtrl);
     /**
@@ -517,8 +503,6 @@ public:
      * Return the background value at a point
      *
      * @warning This is very inefficient -- only use it for debugging, if then.
-     *
-     * @deprecated New code should specify the interpolation style in getPixel, not the ctor
      */
     [[deprecated("Use `getImage` instead. To be removed after 20.0.0.")]]  // DM-22814
             double

--- a/include/lsst/afw/math/Background.h
+++ b/include/lsst/afw/math/Background.h
@@ -116,16 +116,12 @@ public:
      * @param prop statistical property to use for grid points
      * @param actrl configuration for approx to be computed
      */
-    [[deprecated(
-            "Omit `style` parameter, and pass it to `Background::getImage` instead. To be removed after "
-            "20.0.0.")]]  // DM-22814
-            BackgroundControl(
-                    Interpolate::Style const style, int const nxSample = 10, int const nySample = 10,
-                    UndersampleStyle const undersampleStyle = THROW_EXCEPTION,
-                    StatisticsControl const sctrl = StatisticsControl(), Property const prop = MEANCLIP,
-                    ApproximateControl const actrl = ApproximateControl(ApproximateControl::UNKNOWN, 1)
+    BackgroundControl(Interpolate::Style const style, int const nxSample = 10, int const nySample = 10,
+                      UndersampleStyle const undersampleStyle = THROW_EXCEPTION,
+                      StatisticsControl const sctrl = StatisticsControl(), Property const prop = MEANCLIP,
+                      ApproximateControl const actrl = ApproximateControl(ApproximateControl::UNKNOWN, 1)
 
-                            )
+                              )
             : _style(style),
               _nxSample(nxSample),
               _nySample(nySample),
@@ -153,15 +149,11 @@ public:
      * @param prop statistical property to use for grid points
      * @param actrl configuration for approx to be computed
      */
-    [[deprecated(
-            "Omit `style` parameter, and pass it to `Background::getImage` instead. To be removed after "
-            "20.0.0.")]]  // DM-22814
-            BackgroundControl(std::string const& style, int const nxSample = 10, int const nySample = 10,
-                              std::string const& undersampleStyle = "THROW_EXCEPTION",
-                              StatisticsControl const sctrl = StatisticsControl(),
-                              std::string const& prop = "MEANCLIP",
-                              ApproximateControl const actrl = ApproximateControl(ApproximateControl::UNKNOWN,
-                                                                                  1))
+    BackgroundControl(std::string const& style, int const nxSample = 10, int const nySample = 10,
+                      std::string const& undersampleStyle = "THROW_EXCEPTION",
+                      StatisticsControl const sctrl = StatisticsControl(),
+                      std::string const& prop = "MEANCLIP",
+                      ApproximateControl const actrl = ApproximateControl(ApproximateControl::UNKNOWN, 1))
             : _style(math::stringToInterpStyle(style)),
               _nxSample(nxSample),
               _nySample(nySample),
@@ -197,19 +189,9 @@ public:
         _nySample = nySample;
     }
 
-    [[deprecated(
-            "Replaced by passing style to `Background::getImage`. To be removed after 20.0.0.")]]  // DM-22814
-            void
-            setInterpStyle(Interpolate::Style const style) {
-        _style = style;
-    }
+    void setInterpStyle(Interpolate::Style const style) { _style = style; }
     // overload to take a string
-    [[deprecated(
-            "Replaced by passing style to `Background::getImage`. To be removed after 20.0.0.")]]  // DM-22814
-            void
-            setInterpStyle(std::string const& style) {
-        _style = math::stringToInterpStyle(style);
-    }
+    void setInterpStyle(std::string const& style) { _style = math::stringToInterpStyle(style); }
 
     void setUndersampleStyle(UndersampleStyle const undersampleStyle) {
         _undersampleStyle = undersampleStyle;
@@ -221,10 +203,7 @@ public:
 
     int getNxSample() const { return _nxSample; }
     int getNySample() const { return _nySample; }
-    [[deprecated(
-            "Replaced by passing style to `Background::getImage`. To be removed after 20.0.0.")]]  // DM-22814
-            Interpolate::Style
-            getInterpStyle() const {
+    Interpolate::Style getInterpStyle() const {
         if (_style < 0 || _style >= Interpolate::NUM_STYLES) {
             throw LSST_EXCEPT(lsst::pex::exceptions::InvalidParameterError,
                               str(boost::format("Style %d is invalid") % _style));
@@ -244,7 +223,6 @@ public:
     std::shared_ptr<ApproximateControl const> getApproximateControl() const { return _actrl; }
 
 private:
-    // TODO: remove _style member in DM-22814
     Interpolate::Style _style;           // style of interpolation to use
     int _nxSample;                       // number of grid squares to divide image into to sample in x
     int _nySample;                       // number of grid squares to divide image into to sample in y
@@ -356,10 +334,7 @@ public:
      * @deprecated New code should specify the interpolation style in getImage, not the ctor
      */
     template <typename PixelT>
-    [[deprecated(
-            "Call an overload with an `interpStyle` parameter. To be removed after 20.0.0.")]]  // DM-22814
-            std::shared_ptr<lsst::afw::image::Image<PixelT>>
-            getImage() const {
+    std::shared_ptr<lsst::afw::image::Image<PixelT>> getImage() const {
         return getImage<PixelT>(_bctrl->getInterpStyle(), _bctrl->getUndersampleStyle());
     }
     /**
@@ -535,9 +510,7 @@ public:
      * This can be a very costly function to get a single pixel. If you want an image, use the getImage()
      * method.
      */
-    [[deprecated("Use `getImage` instead. To be removed after 20.0.0.")]]  // DM-22814
-            double
-            getPixel(Interpolate::Style const style, int const x, int const y) const;
+    double getPixel(Interpolate::Style const style, int const x, int const y) const;
     /**
      * Return the background value at a point
      *
@@ -545,11 +518,7 @@ public:
      *
      * @deprecated New code should specify the interpolation style in getPixel, not the ctor
      */
-    [[deprecated("Use `getImage` instead. To be removed after 20.0.0.")]]  // DM-22814
-            double
-            getPixel(int const x, int const y) const {
-        return getPixel(_bctrl->getInterpStyle(), x, y);
-    }
+    double getPixel(int const x, int const y) const { return getPixel(_bctrl->getInterpStyle(), x, y); }
     /**
      * Return the image of statistical quantities extracted from the image
      */

--- a/include/lsst/afw/math/Background.h
+++ b/include/lsst/afw/math/Background.h
@@ -548,9 +548,7 @@ public:
     [[deprecated("Use `getImage` instead. To be removed after 20.0.0.")]]  // DM-22814
             double
             getPixel(int const x, int const y) const {
-        // I think this should be LOCAL because the original getPixel used 0-based indices
-        return getImage<float>(_bctrl->getInterpStyle(), _bctrl->getUndersampleStyle())
-                ->get(lsst::geom::Point2I(x, y), image::LOCAL);
+        return getPixel(_bctrl->getInterpStyle(), x, y);
     }
     /**
      * Return the image of statistical quantities extracted from the image

--- a/include/lsst/afw/math/Background.h
+++ b/include/lsst/afw/math/Background.h
@@ -523,7 +523,8 @@ public:
     [[deprecated("Use `getImage` instead. To be removed after 20.0.0.")]]  // DM-22814
             double
             getPixel(int const x, int const y) const {
-        return getPixel(_bctrl->getInterpStyle(), x, y);
+        // I think this should be LOCAL because the original getPixel used 0-based indices
+        return getImage<float>()->get(lsst::geom::Point2I(x, y), image::LOCAL);
     }
     /**
      * Return the image of statistical quantities extracted from the image

--- a/include/lsst/afw/math/Background.h
+++ b/include/lsst/afw/math/Background.h
@@ -510,7 +510,9 @@ public:
      * This can be a very costly function to get a single pixel. If you want an image, use the getImage()
      * method.
      */
-    double getPixel(Interpolate::Style const style, int const x, int const y) const;
+    [[deprecated("Use `getImage` instead. To be removed after 20.0.0.")]]  // DM-22814
+            double
+            getPixel(Interpolate::Style const style, int const x, int const y) const;
     /**
      * Return the background value at a point
      *
@@ -518,7 +520,11 @@ public:
      *
      * @deprecated New code should specify the interpolation style in getPixel, not the ctor
      */
-    double getPixel(int const x, int const y) const { return getPixel(_bctrl->getInterpStyle(), x, y); }
+    [[deprecated("Use `getImage` instead. To be removed after 20.0.0.")]]  // DM-22814
+            double
+            getPixel(int const x, int const y) const {
+        return getPixel(_bctrl->getInterpStyle(), x, y);
+    }
     /**
      * Return the image of statistical quantities extracted from the image
      */

--- a/python/lsst/afw/math/background/backgroundContinued.py
+++ b/python/lsst/afw/math/background/backgroundContinued.py
@@ -20,8 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from lsst.utils import continueClass
-from lsst.utils.deprecated import deprecate_pybind11
-from .background import Background, BackgroundControl, BackgroundMI
+from .background import Background
 
 __all__ = []  # import this module only for its side effects
 
@@ -31,22 +30,3 @@ class Background:
     def __reduce__(self):
         """Pickling"""
         return self.__class__, (self.getImageBBox(), self.getStatsImage())
-
-
-BackgroundControl.__init__ = deprecate_pybind11(
-    BackgroundControl.__init__,
-    reason='Overloads that take a ``style`` parameter are deprecated; the style must be '
-           'passed to `Background.getImageF` instead. To be removed after 20.0.0.')
-Background.getImageF = deprecate_pybind11(
-    Background.getImageF,
-    reason='Zero-argument overload is deprecated; use one that takes an ``interpStyle`` instead. '
-           'To be removed after 20.0.0.')
-BackgroundControl.getInterpStyle = deprecate_pybind11(
-    BackgroundControl.getInterpStyle,
-    reason='Replaced by passing style to `Background.getImageF`. To be removed after 20.0.0.')
-BackgroundControl.setInterpStyle = deprecate_pybind11(
-    BackgroundControl.setInterpStyle,
-    reason='Replaced by passing style to `Background.getImageF`. To be removed after 20.0.0.')
-BackgroundMI.getPixel = deprecate_pybind11(
-    BackgroundMI.getPixel,
-    reason='Use `getImageF` instead. To be removed after 20.0.0.')

--- a/python/lsst/afw/math/background/backgroundContinued.py
+++ b/python/lsst/afw/math/background/backgroundContinued.py
@@ -20,7 +20,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from lsst.utils import continueClass
-from .background import Background
+from lsst.utils.deprecated import deprecate_pybind11
+from .background import Background, BackgroundMI
 
 __all__ = []  # import this module only for its side effects
 
@@ -30,3 +31,8 @@ class Background:
     def __reduce__(self):
         """Pickling"""
         return self.__class__, (self.getImageBBox(), self.getStatsImage())
+
+
+BackgroundMI.getPixel = deprecate_pybind11(
+    BackgroundMI.getPixel,
+    reason='Use `getImageF` instead. To be removed after 20.0.0.')

--- a/python/lsst/afw/math/background/backgroundContinued.py
+++ b/python/lsst/afw/math/background/backgroundContinued.py
@@ -19,29 +19,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import warnings
-
 from lsst.utils import continueClass
 from lsst.utils.deprecated import deprecate_pybind11
 from .background import Background, BackgroundControl, BackgroundMI
-from ..interpolate import Interpolate
 
 __all__ = []  # import this module only for its side effects
-
-
-@continueClass  # noqa: F811
-class BackgroundControl:
-    _init = BackgroundControl.__init__
-
-    def __init__(self, *args, **kwargs):
-        # This constructor called dozens of times; warn only for invalid use
-        if (args and (isinstance(args[0], str) or isinstance(args[0], Interpolate.Style))) \
-                or "style" in kwargs:
-            warnings.warn('Call to deprecated method __init__. (Overloads that take a ``style`` parameter '
-                          'are deprecated; the style must be passed to `Background.getImageF` instead. '
-                          'To be removed after 20.0.0.)',
-                          FutureWarning, stacklevel=2)
-        self._init(*args, **kwargs)
 
 
 @continueClass  # noqa: F811
@@ -50,17 +32,15 @@ class Background:
         """Pickling"""
         return self.__class__, (self.getImageBBox(), self.getStatsImage())
 
-    _getImageF = Background.getImageF
 
-    def getImageF(self, *args, **kwargs):
-        # This method called hundreds of times; warn only for invalid use
-        if not args and not kwargs:
-            warnings.warn('Call to deprecated method getImageF(). (Zero-argument overload is deprecated; '
-                          'use one that takes an ``interpStyle`` instead. To be removed after 20.0.0.)',
-                          FutureWarning, stacklevel=2)
-        return self._getImageF(*args, **kwargs)
-
-
+BackgroundControl.__init__ = deprecate_pybind11(
+    BackgroundControl.__init__,
+    reason='Overloads that take a ``style`` parameter are deprecated; the style must be '
+           'passed to `Background.getImageF` instead. To be removed after 20.0.0.')
+Background.getImageF = deprecate_pybind11(
+    Background.getImageF,
+    reason='Zero-argument overload is deprecated; use one that takes an ``interpStyle`` instead. '
+           'To be removed after 20.0.0.')
 BackgroundControl.getInterpStyle = deprecate_pybind11(
     BackgroundControl.getInterpStyle,
     reason='Replaced by passing style to `Background.getImageF`. To be removed after 20.0.0.')

--- a/python/lsst/afw/math/backgroundList.py
+++ b/python/lsst/afw/math/backgroundList.py
@@ -22,7 +22,6 @@
 __all__ = ["BackgroundList"]
 
 import os
-import warnings
 import lsst.daf.base as dafBase
 import lsst.geom
 import lsst.afw.image as afwImage
@@ -88,10 +87,6 @@ class BackgroundList:
             bkgd, interpStyle, undersampleStyle, approxStyle, \
                 approxOrderX, approxOrderY, approxWeighting = val
         except TypeError:
-            warnings.warn("Passing Background objects to BackgroundList is deprecated; "
-                          "use a (Background, Interpolation.Style, UndersampleStyle, "
-                          "ApproximateControl.Style, int, int, bool) tuple instead.",
-                          category=FutureWarning, stacklevel=2)
             bkgd = val
             interpStyle = None
             undersampleStyle = None

--- a/python/lsst/afw/math/backgroundList.py
+++ b/python/lsst/afw/math/backgroundList.py
@@ -38,10 +38,8 @@ class BackgroundList:
     ----------
     *args : `tuple` or `~lsst.afw.math.Background`
         A sequence of arguments, each of which becomes an element of the list.
-        In deference to the deprecated-but-not-yet-removed
-        `~lsst.afw.math.Background.getImageF()` API, we also accept a single
-        `lsst.afw.math.Background` and extract the ``interpStyle`` and
-        ``undersampleStyle`` from the as-used values.
+        We also accept a single `lsst.afw.math.Background` and extract the
+        ``interpStyle`` and ``undersampleStyle`` from the as-used values.
     """
 
     def __init__(self, *args):

--- a/tests/background.cc
+++ b/tests/background.cc
@@ -69,13 +69,11 @@ BOOST_AUTO_TEST_CASE(BackgroundBasic) { /* parasoft-suppress  LsstDm-3-2a LsstDm
         bgCtrl.getStatisticsControl()->setNumSigmaClip(3);
         bgCtrl.getStatisticsControl()->setNumIter(3);
         std::shared_ptr<math::Background> back = math::makeBackground(img, bgCtrl);
-        double const TESTVAL = std::dynamic_pointer_cast<math::BackgroundMI>(back)->getPixel(xcen, ycen);
 
         std::shared_ptr<image::Image<float>> bImage = back->getImage<float>();
         Image::Pixel const testFromImage = *(bImage->xy_at(xcen, ycen));
 
-        BOOST_CHECK_EQUAL(TESTVAL, pixVal);
-        BOOST_CHECK_EQUAL(TESTVAL, testFromImage);
+        BOOST_CHECK_EQUAL(pixVal, testFromImage);
     }
 }
 
@@ -123,13 +121,8 @@ BOOST_AUTO_TEST_CASE(BackgroundTestImages,
             bctrl.setNySample(5);
             float stdevSubimg = reqStdev / sqrt(width * height / (bctrl.getNxSample() * bctrl.getNySample()));
 
-            // run the background constructor and call the getPixel() and getImage() functions.
+            // run the background constructor and call the getImage() function.
             std::shared_ptr<math::Background> backobj = math::makeBackground(*img, bctrl);
-
-            // test getPixel()
-            float testval =
-                    std::dynamic_pointer_cast<math::BackgroundMI>(backobj)->getPixel(width / 2, height / 2);
-            BOOST_REQUIRE(fabs(testval - reqMean) < 2.0 * stdevSubimg);
 
             // test getImage() by checking the center pixel
             std::shared_ptr<image::Image<float>> bimg = backobj->getImage<float>();
@@ -175,7 +168,7 @@ BOOST_AUTO_TEST_CASE(BackgroundRamp) { /* parasoft-suppress  LsstDm-3-2a LsstDm-
             int xpix = i * (nX - 1) / (ntest - 1);
             for (int j = 0; j < ntest; ++j) {
                 int ypix = j * (nY - 1) / (ntest - 1);
-                double testval = backobj->getPixel(xpix, ypix);
+                double testval = (*(backobj->getImage<float>()))(xpix, ypix);
                 double realval = *rampimg.xy_at(xpix, ypix);
                 BOOST_CHECK_CLOSE(testval / realval, 1.0, 2.5e-5);
             }
@@ -218,7 +211,7 @@ BOOST_AUTO_TEST_CASE(BackgroundParabola) { /* parasoft-suppress  LsstDm-3-2a Lss
             int xpix = i * (nX - 1) / (ntest - 1);
             for (int j = 0; j < ntest; ++j) {
                 int ypix = j * (nY - 1) / (ntest - 1);
-                double testval = backobj->getPixel(xpix, ypix);
+                double testval = (*(backobj->getImage<float>()))(xpix, ypix);
                 double realval = *parabimg.xy_at(xpix, ypix);
                 // print xpix, ypix, testval, realval
                 // quadratic terms skew the averages of the subimages and the clipped mean for

--- a/tests/background.cc
+++ b/tests/background.cc
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(BackgroundBasic) { /* parasoft-suppress  LsstDm-3-2a LsstDm
     {
         int xcen = nX / 2;
         int ycen = nY / 2;
-        math::BackgroundControl bgCtrl(10, 10);
+        math::BackgroundControl bgCtrl("AKIMA_SPLINE");
         // test methods native BackgroundControl
         bgCtrl.setNxSample(5);
         bgCtrl.setNySample(5);
@@ -69,9 +69,9 @@ BOOST_AUTO_TEST_CASE(BackgroundBasic) { /* parasoft-suppress  LsstDm-3-2a LsstDm
         bgCtrl.getStatisticsControl()->setNumSigmaClip(3);
         bgCtrl.getStatisticsControl()->setNumIter(3);
         std::shared_ptr<math::Background> back = math::makeBackground(img, bgCtrl);
-        double const TESTVAL = (*back->getImage<float>("AKIMA_SPLINE"))(xcen, ycen);
+        double const TESTVAL = std::dynamic_pointer_cast<math::BackgroundMI>(back)->getPixel(xcen, ycen);
 
-        std::shared_ptr<image::Image<float>> bImage = back->getImage<float>("AKIMA_SPLINE");
+        std::shared_ptr<image::Image<float>> bImage = back->getImage<float>();
         Image::Pixel const testFromImage = *(bImage->xy_at(xcen, ycen));
 
         BOOST_CHECK_EQUAL(TESTVAL, pixVal);
@@ -118,15 +118,21 @@ BOOST_AUTO_TEST_CASE(BackgroundTestImages,
             int const height = img->getHeight();
 
             // create a background control object
-            math::BackgroundControl bctrl(5, 5);
+            math::BackgroundControl bctrl(math::Interpolate::AKIMA_SPLINE);
+            bctrl.setNxSample(5);
+            bctrl.setNySample(5);
             float stdevSubimg = reqStdev / sqrt(width * height / (bctrl.getNxSample() * bctrl.getNySample()));
 
-            // run the background constructor and call the getImage() function.
+            // run the background constructor and call the getPixel() and getImage() functions.
             std::shared_ptr<math::Background> backobj = math::makeBackground(*img, bctrl);
 
+            // test getPixel()
+            float testval =
+                    std::dynamic_pointer_cast<math::BackgroundMI>(backobj)->getPixel(width / 2, height / 2);
+            BOOST_REQUIRE(fabs(testval - reqMean) < 2.0 * stdevSubimg);
+
             // test getImage() by checking the center pixel
-            std::shared_ptr<image::Image<float>> bimg =
-                    backobj->getImage<float>(math::Interpolate::AKIMA_SPLINE);
+            std::shared_ptr<image::Image<float>> bimg = backobj->getImage<float>();
             float testImgval = static_cast<float>(*(bimg->xy_at(width / 2, height / 2)));
             BOOST_REQUIRE(fabs(testImgval - reqMean) < 2.0 * stdevSubimg);
         }
@@ -154,7 +160,9 @@ BOOST_AUTO_TEST_CASE(BackgroundRamp) { /* parasoft-suppress  LsstDm-3-2a LsstDm-
         }
 
         // check corner, edge, and center pixels
-        math::BackgroundControl bctrl = math::BackgroundControl(6, 6);
+        math::BackgroundControl bctrl = math::BackgroundControl(math::Interpolate::AKIMA_SPLINE);
+        bctrl.setNxSample(6);
+        bctrl.setNySample(6);
         bctrl.getStatisticsControl()->setNumSigmaClip(
                 20.0);  // something large enough to avoid clipping entirely
         bctrl.getStatisticsControl()->setNumIter(1);
@@ -167,7 +175,7 @@ BOOST_AUTO_TEST_CASE(BackgroundRamp) { /* parasoft-suppress  LsstDm-3-2a LsstDm-
             int xpix = i * (nX - 1) / (ntest - 1);
             for (int j = 0; j < ntest; ++j) {
                 int ypix = j * (nY - 1) / (ntest - 1);
-                double testval = (*backobj->getImage<float>(math::Interpolate::AKIMA_SPLINE))(xpix, ypix);
+                double testval = backobj->getPixel(xpix, ypix);
                 double realval = *rampimg.xy_at(xpix, ypix);
                 BOOST_CHECK_CLOSE(testval / realval, 1.0, 2.5e-5);
             }
@@ -196,7 +204,9 @@ BOOST_AUTO_TEST_CASE(BackgroundParabola) { /* parasoft-suppress  LsstDm-3-2a Lss
         }
 
         // check corner, edge, and center pixels
-        math::BackgroundControl bctrl = math::BackgroundControl(24, 24);
+        math::BackgroundControl bctrl = math::BackgroundControl(math::Interpolate::CUBIC_SPLINE);
+        bctrl.setNxSample(24);
+        bctrl.setNySample(24);
         bctrl.getStatisticsControl()->setNumSigmaClip(10.0);
         bctrl.getStatisticsControl()->setNumIter(1);
         std::shared_ptr<math::BackgroundMI> backobj =
@@ -208,7 +218,7 @@ BOOST_AUTO_TEST_CASE(BackgroundParabola) { /* parasoft-suppress  LsstDm-3-2a Lss
             int xpix = i * (nX - 1) / (ntest - 1);
             for (int j = 0; j < ntest; ++j) {
                 int ypix = j * (nY - 1) / (ntest - 1);
-                double testval = (*backobj->getImage<float>(math::Interpolate::CUBIC_SPLINE))(xpix, ypix);
+                double testval = backobj->getPixel(xpix, ypix);
                 double realval = *parabimg.xy_at(xpix, ypix);
                 // print xpix, ypix, testval, realval
                 // quadratic terms skew the averages of the subimages and the clipped mean for

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -673,9 +673,7 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
                 backgroundList.append((bkgd, interpStyle, undersampleStyle,
                                        approxStyle, approxOrderX, approxOrderY, approxWeighting))
             else:
-                # Relies on having called getImage; deprecated
-                with self.assertWarns(FutureWarning):
-                    backgroundList.append(bkgd)
+                backgroundList.append(bkgd)
 
         def assertBackgroundList(bgl):
             self.assertEqual(len(bgl), 2)  # check that len() works
@@ -785,9 +783,7 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
                     backgroundList.append((bkgd, interpStyle, undersampleStyle,
                                            astyle, approxOrderX, approxOrderY, approxWeighting))
                 else:
-                    # Relies on having called getImage; deprecated
-                    with self.assertWarns(FutureWarning):
-                        backgroundList.append(bkgd)
+                    backgroundList.append(bkgd)
 
                 backImage += bkgd.getImageF(interpStyle, undersampleStyle)
 

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -71,8 +71,10 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
         """
         W, H = 2, 99
         image = afwImage.ImageF(lsst.geom.Extent2I(W, H))
+        bgCtrl = afwMath.BackgroundControl(afwMath.Interpolate.LINEAR)
+        bgCtrl.setNxSample(2)
         NY = 10
-        bgCtrl = afwMath.BackgroundControl(2, NY)
+        bgCtrl.setNySample(NY)
         for y in range(H):
             for x in range(W):
                 B = 89
@@ -81,7 +83,7 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
                 else:
                     image[x, y, afwImage.LOCAL] = B + (y-B)*-1.
         bobj = afwMath.makeBackground(image, bgCtrl)
-        back = bobj.getImageF(afwMath.Interpolate.LINEAR)
+        back = bobj.getImageF()
 
         for iy, by in zip([image[0, y, afwImage.LOCAL] for y in range(H)],
                           [back[0, y, afwImage.LOCAL] for y in range(H)]):
@@ -97,8 +99,7 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
         bgCtrl.getStatisticsControl().setNumSigmaClip(3)
         back = afwMath.makeBackground(self.image, bgCtrl)
 
-        with self.assertWarns(FutureWarning):
-            self.assertEqual(back.getPixel(xcen, ycen), self.val)
+        self.assertEqual(back.getPixel(xcen, ycen), self.val)
 
     @unittest.skipIf(AfwdataDir is None, "afwdata not setup")
     def testBackgroundTestImages(self):
@@ -123,17 +124,25 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
             naxis2 = img.getHeight()
 
             # create a background control object
-            bctrl = afwMath.BackgroundControl(5, 5)
+            bctrl = afwMath.BackgroundControl(afwMath.Interpolate.AKIMA_SPLINE)
+            bctrl.setNxSample(5)
+            bctrl.setNySample(5)
 
-            # run the background constructor and call the getImage() function.
+            # run the background constructor and call the getPixel() and
+            # getImage() functions.
             backobj = afwMath.makeBackground(img, bctrl)
 
             pixPerSubimage = img.getWidth()*img.getHeight() / \
                 (bctrl.getNxSample()*bctrl.getNySample())
             stdevInterp = reqStdev/math.sqrt(pixPerSubimage)
 
+            # test getPixel()
+            testval = backobj.getPixel(naxis1//2, naxis2//2)
+            self.assertAlmostEqual(testval/centerValue, 1, places=7)
+            self.assertLess(abs(testval - reqMean), 2*stdevInterp)
+
             # test getImage() by checking the center pixel
-            bimg = backobj.getImageF(afwMath.Interpolate.AKIMA_SPLINE)
+            bimg = backobj.getImageF()
             testImgval = bimg[naxis1//2, naxis2//2, afwImage.LOCAL]
             self.assertLess(abs(testImgval - reqMean), 2*stdevInterp)
 
@@ -153,6 +162,7 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
 
         # check corner, edge, and center pixels
         bctrl = afwMath.BackgroundControl(10, 10)
+        bctrl.setInterpStyle(afwMath.Interpolate.CUBIC_SPLINE)
         bctrl.setNxSample(6)
         bctrl.setNySample(6)
         # large enough to entirely avoid clipping
@@ -186,7 +196,7 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
         ypixels = [0, ny//2, ny - 1]
         for xpix in xpixels:
             for ypix in ypixels:
-                testval = backobj.getImageF(afwMath.Interpolate.CUBIC_SPLINE)[xpix, ypix, afwImage.LOCAL]
+                testval = backobj.getPixel(xpix, ypix)
                 self.assertAlmostEqual(testval/rampimg[xpix, ypix, afwImage.LOCAL], 1, 6)
 
         # Test pickle
@@ -220,14 +230,19 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
             AfwdataDir, "DC3a-Sim", "sci", "v5-e0", "v5-e0-c011-a00.sci.fits")
         mimg = afwImage.MaskedImageF(imagePath)
         binsize = 512
+        bctrl = afwMath.BackgroundControl("NATURAL_SPLINE")
+
+        # note: by default undersampleStyle is THROW_EXCEPTION
+        bctrl.setUndersampleStyle(afwMath.REDUCE_INTERP_ORDER)
+
         nx = int(mimg.getWidth()/binsize) + 1
         ny = int(mimg.getHeight()/binsize) + 1
-        bctrl = afwMath.BackgroundControl(nx, ny)
 
+        bctrl.setNxSample(nx)
+        bctrl.setNySample(ny)
         image = mimg.getImage()
         backobj = afwMath.makeBackground(image, bctrl)
-        # note: by default undersampleStyle is THROW_EXCEPTION
-        image -= backobj.getImageF("NATURAL_SPLINE", "REDUCE_INTERP_ORDER")
+        image -= backobj.getImageF()
 
     def testTicket1781(self):
         """Test an unusual-sized image"""
@@ -236,7 +251,9 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
 
         parabimg = self.getParabolaImage(nx, ny)
 
-        bctrl = afwMath.BackgroundControl(16, 4)
+        bctrl = afwMath.BackgroundControl(afwMath.Interpolate.CUBIC_SPLINE)
+        bctrl.setNxSample(16)
+        bctrl.setNySample(4)
         bctrl.getStatisticsControl().setNumSigmaClip(10.0)
         bctrl.getStatisticsControl().setNumIter(1)
         afwMath.makeBackground(parabimg, bctrl)
@@ -249,7 +266,9 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
         parabimg = self.getParabolaImage(nx, ny)
 
         # check corner, edge, and center pixels
-        bctrl = afwMath.BackgroundControl(24, 24)
+        bctrl = afwMath.BackgroundControl(afwMath.Interpolate.CUBIC_SPLINE)
+        bctrl.setNxSample(24)
+        bctrl.setNySample(24)
         bctrl.getStatisticsControl().setNumSigmaClip(10.0)
         bctrl.getStatisticsControl().setNumIter(1)
         backobj = afwMath.makeBackground(parabimg, bctrl)
@@ -259,7 +278,7 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
         ypixels = [segmentCenter, ny//2, ny - segmentCenter]
         for xpix in xpixels:
             for ypix in ypixels:
-                testval = backobj.getImageF(afwMath.Interpolate.CUBIC_SPLINE)[xpix, ypix]
+                testval = backobj.getPixel(bctrl.getInterpStyle(), xpix, ypix)
                 realval = parabimg[xpix, ypix, afwImage.LOCAL]
                 # quadratic terms skew the averages of the subimages and the clipped mean for
                 # a subimage != value of center pixel.  1/20 counts on a 10000 count sky
@@ -276,7 +295,9 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
                                         lsst.geom.Point2I(2079, 4609)),
                         afwImage.LOCAL)
 
-        bctrl = afwMath.BackgroundControl(16, 16)
+        bctrl = afwMath.BackgroundControl(afwMath.Interpolate.AKIMA_SPLINE)
+        bctrl.setNxSample(16)
+        bctrl.setNySample(16)
         bctrl.getStatisticsControl().setNumSigmaClip(3.0)
         bctrl.getStatisticsControl().setNumIter(2)
         backobj = afwMath.makeBackground(mi.getImage(), bctrl)
@@ -285,7 +306,7 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
             afwDisplay.Display(frame=0).mtv(mi, title=self._testMethodName + " image")
 
         im = mi.getImage()
-        im -= backobj.getImageF(afwMath.Interpolate.AKIMA_SPLINE)
+        im -= backobj.getImageF()
 
         if debugMode:
             afwDisplay.Display(frame=1).mtv(mi, title=self._testMethodName + " image-back")
@@ -315,7 +336,7 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
             bctrl = afwMath.BackgroundControl(
                 mi.getWidth()//128, mi.getHeight()//128)
             backobj = afwMath.makeBackground(mi.getImage(), bctrl)
-            bgImage = backobj.getImageF(afwMath.Interpolate.AKIMA_SPLINE)
+            bgImage = backobj.getImageF()
             self.assertEqual(bgImage.getBBox(), mi.getBBox())
             bgImageList.append(bgImage)
 
@@ -343,12 +364,12 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
         subBBox = lsst.geom.Box2I(lsst.geom.Point2I(1000, 3000),
                                   lsst.geom.Extent2I(100, 100))
 
-        bgFullImage = backobj.getImageF(afwMath.Interpolate.AKIMA_SPLINE)
+        bgFullImage = backobj.getImageF()
         self.assertEqual(bgFullImage.getBBox(), mi.getBBox())
 
         subFullArr = afwImage.ImageF(bgFullImage, subBBox).getArray()
 
-        bgSubImage = backobj.getImageF(subBBox, afwMath.Interpolate.AKIMA_SPLINE)
+        bgSubImage = backobj.getImageF(subBBox, bctrl.getInterpStyle())
         subArr = bgSubImage.getArray()
 
         # the pixels happen to be identical but it is safer not to rely on
@@ -390,6 +411,7 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
 
         # make a background control object
         bctrl = afwMath.BackgroundControl(10, 10)
+        bctrl.setInterpStyle(afwMath.Interpolate.CUBIC_SPLINE)
         bctrl.setNxSample(3)
         bctrl.setNySample(3)
 
@@ -397,11 +419,15 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
         # linear
         bctrl.setNxSample(2)
         bctrl.setNySample(2)
+        bctrl.setUndersampleStyle("REDUCE_INTERP_ORDER")
         backobj = afwMath.makeBackground(img, bctrl)
         # Need to interpolate background to discover what we actually needed
-        backobj.getImageF(afwMath.Interpolate.CUBIC_SPLINE, afwMath.UndersampleStyle.REDUCE_INTERP_ORDER)
+        backobj.getImageF()
         self.assertEqual(backobj.getAsUsedInterpStyle(),
                          afwMath.Interpolate.LINEAR)
+
+        # put interp style back up to cspline and see if it throws an exception
+        bctrl.setUndersampleStyle("THROW_EXCEPTION")
 
         def tst(img, bctrl):
             backobj = afwMath.makeBackground(img, bctrl)
@@ -425,6 +451,7 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
 
         # make a background control object
         bctrl = afwMath.BackgroundControl(10, 10)
+        bctrl.setInterpStyle(afwMath.Interpolate.CONSTANT)
         bctrl.setNxSample(1)
         bctrl.setNySample(1)
         bctrl.setUndersampleStyle(afwMath.THROW_EXCEPTION)
@@ -434,7 +461,7 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
         ypixels = [0, ny//2, ny - 1]
         for xpix in xpixels:
             for ypix in ypixels:
-                testval = backobj.getImageF(afwMath.Interpolate.CONSTANT)[xpix, ypix]
+                testval = backobj.getPixel(bctrl.getInterpStyle(), xpix, ypix)
                 self.assertAlmostEqual(testval/mean, 1)
 
     def testAdjustLevel(self):
@@ -443,20 +470,20 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
         im = afwImage.ImageF(40, 40)
         im.set(sky)
         nx, ny = im.getWidth()//2, im.getHeight()//2
-        bctrl = afwMath.BackgroundControl(nx, ny)
+        bctrl = afwMath.BackgroundControl("LINEAR", nx, ny)
         bkd = afwMath.makeBackground(im, bctrl)
 
         self.assertEqual(
-            afwMath.makeStatistics(bkd.getImageF("LINEAR"), afwMath.MEAN).getValue(),
+            afwMath.makeStatistics(bkd.getImageF(), afwMath.MEAN).getValue(),
             sky)
 
         delta = 123
         bkd += delta
         self.assertEqual(
-            afwMath.makeStatistics(bkd.getImageF("LINEAR"), afwMath.MEAN).getValue(),
+            afwMath.makeStatistics(bkd.getImageF(), afwMath.MEAN).getValue(),
             sky + delta)
         bkd -= delta
-        self.assertEqual(afwMath.makeStatistics(bkd.getImageF("LINEAR"), afwMath.MEAN).getValue(),
+        self.assertEqual(afwMath.makeStatistics(bkd.getImageF(), afwMath.MEAN).getValue(),
                          sky)
 
     def testNaNFromMaskedImage(self):
@@ -710,9 +737,10 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
         interpStyle = afwMath.Interpolate.AKIMA_SPLINE
         undersampleStyle = afwMath.REDUCE_INTERP_ORDER
         bgCtrl = afwMath.BackgroundControl(6, 6)
+        bgCtrl.setInterpStyle(interpStyle)
         bgCtrl.setUndersampleStyle(undersampleStyle)
         bkgd = afwMath.makeBackground(img, bgCtrl)
-        interpImage = bkgd.getImageF(interpStyle)
+        interpImage = bkgd.getImageF()
 
         with lsst.utils.tests.getTempFilePath("_bgi.fits") as bgiFile, \
                 lsst.utils.tests.getTempFilePath("_bga.fits") as bgaFile:
@@ -726,7 +754,7 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
             approxOrder = 2
             actrl = afwMath.ApproximateControl(approxStyle, approxOrder)
             bkgd.getBackgroundControl().setApproximateControl(actrl)
-            approxImage = bkgd.getImageF(interpStyle)
+            approxImage = bkgd.getImageF()
             bglApprox = afwMath.BackgroundList()
             bglApprox.append((bkgd, interpStyle, undersampleStyle,
                               approxStyle, approxOrder, approxOrder, True))

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -99,7 +99,8 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
         bgCtrl.getStatisticsControl().setNumSigmaClip(3)
         back = afwMath.makeBackground(self.image, bgCtrl)
 
-        self.assertEqual(back.getPixel(xcen, ycen), self.val)
+        with self.assertWarns(FutureWarning):
+            self.assertEqual(back.getPixel(xcen, ycen), self.val)
 
     @unittest.skipIf(AfwdataDir is None, "afwdata not setup")
     def testBackgroundTestImages(self):
@@ -128,18 +129,12 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
             bctrl.setNxSample(5)
             bctrl.setNySample(5)
 
-            # run the background constructor and call the getPixel() and
-            # getImage() functions.
+            # run the background constructor and call the getImage() function.
             backobj = afwMath.makeBackground(img, bctrl)
 
             pixPerSubimage = img.getWidth()*img.getHeight() / \
                 (bctrl.getNxSample()*bctrl.getNySample())
             stdevInterp = reqStdev/math.sqrt(pixPerSubimage)
-
-            # test getPixel()
-            testval = backobj.getPixel(naxis1//2, naxis2//2)
-            self.assertAlmostEqual(testval/centerValue, 1, places=7)
-            self.assertLess(abs(testval - reqMean), 2*stdevInterp)
 
             # test getImage() by checking the center pixel
             bimg = backobj.getImageF()
@@ -196,7 +191,7 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
         ypixels = [0, ny//2, ny - 1]
         for xpix in xpixels:
             for ypix in ypixels:
-                testval = backobj.getPixel(xpix, ypix)
+                testval = backobj.getImageF()[xpix, ypix, afwImage.LOCAL]
                 self.assertAlmostEqual(testval/rampimg[xpix, ypix, afwImage.LOCAL], 1, 6)
 
         # Test pickle
@@ -278,7 +273,7 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
         ypixels = [segmentCenter, ny//2, ny - segmentCenter]
         for xpix in xpixels:
             for ypix in ypixels:
-                testval = backobj.getPixel(bctrl.getInterpStyle(), xpix, ypix)
+                testval = backobj.getImageF(bctrl.getInterpStyle())[xpix, ypix, afwImage.LOCAL]
                 realval = parabimg[xpix, ypix, afwImage.LOCAL]
                 # quadratic terms skew the averages of the subimages and the clipped mean for
                 # a subimage != value of center pixel.  1/20 counts on a 10000 count sky
@@ -461,7 +456,7 @@ class BackgroundTestCase(lsst.utils.tests.TestCase):
         ypixels = [0, ny//2, ny - 1]
         for xpix in xpixels:
             for ypix in ypixels:
-                testval = backobj.getPixel(bctrl.getInterpStyle(), xpix, ypix)
+                testval = backobj.getImageF(bctrl.getInterpStyle())[xpix, ypix]
                 self.assertAlmostEqual(testval/mean, 1)
 
     def testAdjustLevel(self):


### PR DESCRIPTION
The PR reverts the portions of #505 that relate to `Background`, then removes all mention of deprecation from the corresponding documentation.