### PR TITLE
DM-6981: Implement assignment to Flag columns in the pybind11 layer.

### DIFF
--- a/python/lsst/afw/table/_base.py
+++ b/python/lsst/afw/table/_base.py
@@ -138,8 +138,13 @@ class Catalog(metaclass=TemplateMeta):
         ``value``.
         """
         self._columns = None
-        if isinstance(key, Key) or isinstance(key, str):
-            self.columns[key] = value
+        if isinstance(key, str):
+            key = self.schema[key].asKey()
+        if isinstance(key, Key):
+            if isinstance(key, Key["Flag"]):
+                self._set_flag(key, value)
+            else:
+                self.columns[key] = value
         else:
             return self.set(key, value)
 

--- a/tests/test_simpleTable.py
+++ b/tests/test_simpleTable.py
@@ -799,6 +799,26 @@ class SimpleTableTestCase(lsst.utils.tests.TestCase):
         with self.assertRaises(IndexError):
             del catalog[50]
 
+    def testSetFlagColumn(self):
+        schema = lsst.afw.table.Schema()
+        key = schema.addField("a", type="Flag", doc="doc for 'a'")
+        catalog = lsst.afw.table.BaseCatalog(schema)
+        catalog.resize(5)
+        # Set scalar with key.
+        catalog[key] = True
+        self.assertEqual(list(catalog[key]), [True] * 5)
+        # Set scalar with name.
+        catalog["a"] = False
+        self.assertEqual(list(catalog[key]), [False] * 5)
+        # Set array with key.
+        v1 = np.array([True, False, True, False, True], dtype=bool)
+        catalog[key] = v1
+        self.assertEqual(list(catalog[key]), list(v1))
+        # Set array with name.
+        v2 = np.array([False, True, False, True, False], dtype=bool)
+        catalog["a"] = v2
+        self.assertEqual(list(catalog[key]), list(v2))
+
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):
     pass


### PR DESCRIPTION
This only works when the key is a `str` name or a `Key` instance; because support for slice assignment for all other fields currently delegates so much to NumPy, it's a lot harder to make that work for Flags.