### PR TITLE
DM-8591: Follow-up pybind11 behavior with numpy.int64s as indices in Python 3

### DIFF
--- a/python/lsst/afw/table/multiMatch.py
+++ b/python/lsst/afw/table/multiMatch.py
@@ -244,8 +244,7 @@ class GroupView(collections.abc.Mapping):
         groups = numpy.zeros(len(ids), dtype=object)
         ends = list(indices[1:]) + [len(catalog)]
         for n, (i1, i2) in enumerate(zip(indices, ends)):
-            # casts are a work-around for DM-8557
-            groups[n] = catalog[int(i1):int(i2)]
+            groups[n] = catalog[i1:i2]
             assert (groups[n].get(groupKey) == ids[n]).all()
         return cls(catalog.schema, ids, groups)
 


### PR DESCRIPTION
This was necessary under SWIG, but not under pybind11.