### PR TITLE
DM-26826: Fix See Also section in BackgroundList

### DIFF
--- a/python/lsst/afw/math/backgroundList.py
+++ b/python/lsst/afw/math/backgroundList.py
@@ -155,7 +155,7 @@ class BackgroundList:
 
         See Also
         --------
-        getImage()
+        getImage
         """
         if not isinstance(fileName, MemFileManager) and not os.path.exists(fileName):
             raise RuntimeError(f"File not found: {fileName}")


### PR DESCRIPTION
Starting in Sphinx 3 the extra `()` will become a Sphinx build failure.