### PR TITLE
DM-21333: Implement afw.image.Filter replacement(s)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,7 @@ tests/testLib.py
 tests/test_cameraSys
 tests/test_coord
 tests/test_endpoint
+tests/test_filterLabel
 tests/test_functorKeys
 tests/test_genericmapkey
 tests/test_imageHash

--- a/include/lsst/afw/image/FilterLabel.h
+++ b/include/lsst/afw/image/FilterLabel.h
@@ -1,0 +1,95 @@
+/*
+ * This file is part of afw.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef LSST_AFW_IMAGE_FILTERLABEL_H
+#define LSST_AFW_IMAGE_FILTERLABEL_H
+
+#include <memory>
+#include <string>
+
+#include "lsst/afw/table/io/Persistable.h"  // Needed for PersistableFacade
+#include "lsst/afw/typehandling/Storable.h"
+
+namespace lsst {
+namespace afw {
+namespace image {
+
+/**
+ * A group of labels for a filter in an exposure or coadd.
+ *
+ * This class provides only identifiers for filters. Other filter information
+ * can be retrieved from an Exposure object or a Butler repository.
+ *
+ * FilterLabel does not expose a public constructor in C++, except for copy
+ * and move constructors. You can create a FilterLabel by calling one of the
+ * `from*` factory methods, or (in Python) through a keyword-only constructor.
+ */
+class FilterLabel final : public table::io::PersistableFacade<FilterLabel>, public typehandling::Storable {
+public:
+    /**
+     * Construct a FilterLabel from specific inputs.
+     *
+     * @{
+     */
+    static FilterLabel fromBandPhysical(std::string const &band, std::string const &physical);
+    static FilterLabel fromBand(std::string const &band);
+    static FilterLabel fromPhysical(std::string const &physical);
+    /** @} */
+
+    /// Return whether the filter label names a band.
+    bool hasBandLabel() const noexcept;
+
+    /**
+     * Return the band label.
+     *
+     * @returns The band label.
+     * @throws lsst::pex::exceptions::LogicError Thrown if hasBandLabel() is `false`.
+     */
+    std::string getBandLabel() const;
+
+    /// Return whether the filter label names a physical filter.
+    bool hasPhysicalLabel() const noexcept;
+
+    /**
+     * Return the physical filter label.
+     *
+     * @returns The physical filter label.
+     * @throws lsst::pex::exceptions::LogicError Thrown if hasPhysicalLabel() is `false`.
+     */
+    std::string getPhysicalLabel() const;
+
+private:
+    FilterLabel(bool hasBand, std::string const &band, bool hasPhysical, std::string const &physical);
+
+    // A separate boolean leads to easier implementations (at the cost of more
+    // memory) than a unique_ptr<string>.
+    // _band and _physical are part of the object state iff _hasBand and _hasPhysical, respectively
+    bool _hasBand, _hasPhysical;
+    std::string _band, _physical;
+};
+
+}  // namespace image
+}  // namespace afw
+}  // namespace lsst
+
+#endif

--- a/include/lsst/afw/image/FilterLabel.h
+++ b/include/lsst/afw/image/FilterLabel.h
@@ -56,6 +56,12 @@ public:
     static FilterLabel fromPhysical(std::string const &physical);
     /** @} */
 
+    FilterLabel(FilterLabel const &);
+    FilterLabel(FilterLabel &&) noexcept;
+    FilterLabel &operator=(FilterLabel const &);  // Only way to modify a FilterLabel
+    FilterLabel &operator=(FilterLabel &&) noexcept;
+    ~FilterLabel() noexcept;
+
     /// Return whether the filter label names a band.
     bool hasBandLabel() const noexcept;
 

--- a/include/lsst/afw/image/FilterLabel.h
+++ b/include/lsst/afw/image/FilterLabel.h
@@ -146,6 +146,13 @@ private:
     static Factory factory;
 };
 
+/**
+ * Remap special characters, etc. to "_" for database fields.
+ *
+ * @return The filter label in database-sanitized format.
+ */
+std::string getDatabaseFilterLabel(std::string const &filterLabel);
+
 }  // namespace image
 }  // namespace afw
 }  // namespace lsst

--- a/include/lsst/afw/image/FilterLabel.h
+++ b/include/lsst/afw/image/FilterLabel.h
@@ -115,6 +115,18 @@ public:
     std::shared_ptr<Storable> cloneStorable() const override;
     bool equals(Storable const &other) const noexcept override { return singleClassEquals(*this, other); }
 
+    // Persistable support
+
+    /// All filter labels are always persistable.
+    bool isPersistable() const noexcept override { return true; }
+
+protected:
+    // Persistable support
+
+    std::string getPersistenceName() const noexcept override;
+    std::string getPythonModule() const noexcept override;
+    void write(table::io::OutputArchiveHandle &handle) const override;
+
 private:
     FilterLabel(bool hasBand, std::string const &band, bool hasPhysical, std::string const &physical);
 #ifndef DOXYGEN
@@ -127,6 +139,11 @@ private:
     // _band and _physical are part of the object state iff _hasBand and _hasPhysical, respectively
     bool _hasBand, _hasPhysical;
     std::string _band, _physical;
+
+    // Persistable support
+
+    class Factory;
+    static Factory factory;
 };
 
 }  // namespace image

--- a/include/lsst/afw/image/FilterLabel.h
+++ b/include/lsst/afw/image/FilterLabel.h
@@ -78,6 +78,19 @@ public:
      */
     std::string getPhysicalLabel() const;
 
+    /**
+     * Filter labels compare equal if their components are equal.
+     *
+     * @note This operation does not test whether two *filters* are the same.
+     *       Two FilterLabels corresponding to identically-named filters on
+     *       different instruments will compare equal.
+     *
+     * @{
+     */
+    bool operator==(FilterLabel const &rhs) const noexcept;
+    bool operator!=(FilterLabel const &rhs) const noexcept { return !(*this == rhs); }
+    /** @} */
+
 private:
     FilterLabel(bool hasBand, std::string const &band, bool hasPhysical, std::string const &physical);
 

--- a/include/lsst/afw/image/FilterLabel.h
+++ b/include/lsst/afw/image/FilterLabel.h
@@ -34,6 +34,14 @@ namespace lsst {
 namespace afw {
 namespace image {
 
+#ifndef DOXYGEN
+class FilterLabel;
+namespace impl {
+// Needed for some esoteric tests; do not use elsewhere!
+FilterLabel makeTestFilterLabel(bool, std::string const &, bool, std::string const &);
+}  // namespace impl
+#endif
+
 /**
  * A group of labels for a filter in an exposure or coadd.
  *
@@ -97,8 +105,22 @@ public:
     bool operator!=(FilterLabel const &rhs) const noexcept { return !(*this == rhs); }
     /** @} */
 
+    // Storable support
+
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept override;
+    /// Return a string representation of this object.
+    std::string toString() const override;
+    /// Create a new object that is a copy of this one.
+    std::shared_ptr<Storable> cloneStorable() const override;
+    bool equals(Storable const &other) const noexcept override { return singleClassEquals(*this, other); }
+
 private:
     FilterLabel(bool hasBand, std::string const &band, bool hasPhysical, std::string const &physical);
+#ifndef DOXYGEN
+    // Needed for some esoteric tests; do not use elsewhere!
+    friend FilterLabel impl::makeTestFilterLabel(bool, std::string const &, bool, std::string const &);
+#endif
 
     // A separate boolean leads to easier implementations (at the cost of more
     // memory) than a unique_ptr<string>.
@@ -110,5 +132,14 @@ private:
 }  // namespace image
 }  // namespace afw
 }  // namespace lsst
+
+namespace std {
+template <>
+struct hash<lsst::afw::image::FilterLabel> {
+    using argument_type = lsst::afw::image::FilterLabel;
+    using result_type = size_t;
+    size_t operator()(argument_type const &obj) const noexcept { return obj.hash_value(); }
+};
+}  // namespace std
 
 #endif

--- a/python/lsst/afw/image/SConscript
+++ b/python/lsst/afw/image/SConscript
@@ -7,6 +7,7 @@ scripts.BasicSConscript.pybind11(
      'color',
      'coaddInputs',
      'filter',
+     'filterLabel',
      'photoCalib',
      'exposure/exposure',
      'exposureInfo',

--- a/python/lsst/afw/image/__init__.py
+++ b/python/lsst/afw/image/__init__.py
@@ -28,6 +28,7 @@ from .coaddInputs import *
 from .color import *
 from .defect import *
 from .filter import *
+from .filterLabel import *
 from .image import *
 from .imageSlice import *
 from .maskedImage import *

--- a/python/lsst/afw/image/filterLabel.cc
+++ b/python/lsst/afw/image/filterLabel.cc
@@ -49,7 +49,18 @@ using PyFilterLabel = py::class_<FilterLabel, std::shared_ptr<FilterLabel>, type
         std::throw_with_nested(py_ex(e.what())); \
     }
 
-PyFilterLabel declare(py::module& mod) { return PyFilterLabel(mod, "FilterLabel"); }
+PyFilterLabel declare(py::module& mod) {
+    // Include Python-only constructor in class doc, since it's what people should use
+    auto initDoc = R"delim(
+        Attributes
+        ----------
+        band : str, optional
+            The band associated with this label.
+        physical : str, optional
+            The physical filter associated with this label.
+    )delim";
+    return PyFilterLabel(mod, "FilterLabel", initDoc);
+}
 
 void define(PyFilterLabel& cls) {
     cls.def_static("fromBandPhysical", &FilterLabel::fromBandPhysical, "band"_a, "physical"_a);

--- a/python/lsst/afw/image/filterLabel.cc
+++ b/python/lsst/afw/image/filterLabel.cc
@@ -64,7 +64,7 @@ PyFilterLabel declare(py::module& mod) {
     return PyFilterLabel(mod, "FilterLabel", initDoc);
 }
 
-void define(PyFilterLabel& cls) {
+void define(py::module& mod, PyFilterLabel& cls) {
     table::io::python::addPersistableMethods(cls);
 
     cls.def_static("fromBandPhysical", &FilterLabel::fromBandPhysical, "band"_a, "physical"_a);
@@ -112,6 +112,10 @@ void define(PyFilterLabel& cls) {
     // Neither __copy__ nor __deepcopy__ default to each other
     cls.def("__copy__", [](const FilterLabel& obj) { return obj.cloneStorable(); });
     cls.def("__deepcopy__", [](const FilterLabel& obj, py::dict& memo) { return obj.cloneStorable(); });
+
+    // Free functions
+
+    mod.def("getDatabaseFilterLabel", &getDatabaseFilterLabel, "filterLabel"_a);
 }
 
 PYBIND11_MODULE(filterLabel, mod) {
@@ -122,7 +126,7 @@ PYBIND11_MODULE(filterLabel, mod) {
     // then import dependencies used in method signatures
     // none
     // and now we can safely define methods and other attributes
-    define(cls);
+    define(mod, cls);
 }
 
 }  // namespace

--- a/python/lsst/afw/image/filterLabel.cc
+++ b/python/lsst/afw/image/filterLabel.cc
@@ -64,27 +64,6 @@ PyFilterLabel declare(py::module& mod) {
     return PyFilterLabel(mod, "FilterLabel", initDoc);
 }
 
-// Implemented in C++ because afw::image uses old-style wrappers, and adding a
-// Python extension is not worth it for a single method.
-std::string getRepr(FilterLabel const& label) {
-    std::string buffer("FilterLabel(");
-    bool comma = false;
-
-    if (label.hasBandLabel()) {
-        if (comma) buffer += ", "s;
-        buffer += "band"s + "=\""s + label.getBandLabel() + "\""s;
-        comma = true;
-    }
-    if (label.hasPhysicalLabel()) {
-        if (comma) buffer += ", "s;
-        buffer += "physical"s + "=\""s + label.getPhysicalLabel() + "\""s;
-        comma = true;
-    }
-    buffer += ")"s;
-
-    return buffer;
-}
-
 void define(PyFilterLabel& cls) {
     cls.def_static("fromBandPhysical", &FilterLabel::fromBandPhysical, "band"_a, "physical"_a);
     cls.def_static("fromBand", &FilterLabel::fromBand, "band"_a);
@@ -127,7 +106,10 @@ void define(PyFilterLabel& cls) {
     cls.def("__eq__", &FilterLabel::operator==, py::is_operator());
     cls.def("__ne__", &FilterLabel::operator!=, py::is_operator());
 
-    cls.def("__repr__", &getRepr);
+    cls.def("__repr__", &FilterLabel::toString);
+    // Neither __copy__ nor __deepcopy__ default to each other
+    cls.def("__copy__", [](const FilterLabel& obj) { return obj.cloneStorable(); });
+    cls.def("__deepcopy__", [](const FilterLabel& obj, py::dict& memo) { return obj.cloneStorable(); });
 }
 
 PYBIND11_MODULE(filterLabel, mod) {

--- a/python/lsst/afw/image/filterLabel.cc
+++ b/python/lsst/afw/image/filterLabel.cc
@@ -65,6 +65,8 @@ PyFilterLabel declare(py::module& mod) {
 }
 
 void define(PyFilterLabel& cls) {
+    table::io::python::addPersistableMethods(cls);
+
     cls.def_static("fromBandPhysical", &FilterLabel::fromBandPhysical, "band"_a, "physical"_a);
     cls.def_static("fromBand", &FilterLabel::fromBand, "band"_a);
     cls.def_static("fromPhysical", &FilterLabel::fromPhysical, "physical"_a);

--- a/python/lsst/afw/image/filterLabel.cc
+++ b/python/lsst/afw/image/filterLabel.cc
@@ -1,0 +1,83 @@
+/*
+ * This file is part of afw.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "pybind11/pybind11.h"
+
+#include <exception>
+
+#include "lsst/utils/python.h"
+
+#include "lsst/afw/image/FilterLabel.h"
+#include "lsst/afw/typehandling/Storable.h"
+#include "lsst/afw/table/io/python.h"
+
+namespace py = pybind11;
+using namespace pybind11::literals;
+
+namespace lsst {
+namespace afw {
+namespace image {
+namespace {
+
+using PyFilterLabel = py::class_<FilterLabel, std::shared_ptr<FilterLabel>, typehandling::Storable>;
+
+// Macro to convert an exception without defining a global handler for it
+#define _DELEGATE_EXCEPTION(call, cpp_ex, py_ex) \
+    try {                                        \
+        return call;                             \
+    } catch (cpp_ex const& e) {                  \
+        std::throw_with_nested(py_ex(e.what())); \
+    }
+
+PyFilterLabel declare(py::module& mod) { return PyFilterLabel(mod, "FilterLabel"); }
+
+void define(PyFilterLabel& cls) {
+    cls.def_static("fromBandPhysical", &FilterLabel::fromBandPhysical, "band"_a, "physical"_a);
+    cls.def_static("fromBand", &FilterLabel::fromBand, "band"_a);
+    cls.def_static("fromPhysical", &FilterLabel::fromPhysical, "physical"_a);
+
+    cls.def("hasBandLabel", &FilterLabel::hasBandLabel);
+    cls.def_property_readonly("bandLabel", [](FilterLabel const& label) {
+        _DELEGATE_EXCEPTION(label.getBandLabel(), pex::exceptions::LogicError, std::runtime_error);
+    });
+    cls.def("hasPhysicalLabel", &FilterLabel::hasPhysicalLabel);
+    cls.def_property_readonly("physicalLabel", [](FilterLabel const& label) {
+        _DELEGATE_EXCEPTION(label.getPhysicalLabel(), pex::exceptions::LogicError, std::runtime_error);
+    });
+}
+
+PYBIND11_MODULE(filterLabel, mod) {
+    // import inheritance dependencies
+    py::module::import("lsst.afw.typehandling");
+    // then declare classes
+    auto cls = declare(mod);
+    // then import dependencies used in method signatures
+    // none
+    // and now we can safely define methods and other attributes
+    define(cls);
+}
+
+}  // namespace
+}  // namespace image
+}  // namespace afw
+}  // namespace lsst

--- a/python/lsst/afw/image/filterLabel.cc
+++ b/python/lsst/afw/image/filterLabel.cc
@@ -31,6 +31,8 @@
 #include "lsst/afw/typehandling/Storable.h"
 #include "lsst/afw/table/io/python.h"
 
+using namespace std::string_literals;
+
 namespace py = pybind11;
 using namespace pybind11::literals;
 
@@ -60,6 +62,27 @@ PyFilterLabel declare(py::module& mod) {
             The physical filter associated with this label.
     )delim";
     return PyFilterLabel(mod, "FilterLabel", initDoc);
+}
+
+// Implemented in C++ because afw::image uses old-style wrappers, and adding a
+// Python extension is not worth it for a single method.
+std::string getRepr(FilterLabel const& label) {
+    std::string buffer("FilterLabel(");
+    bool comma = false;
+
+    if (label.hasBandLabel()) {
+        if (comma) buffer += ", "s;
+        buffer += "band"s + "=\""s + label.getBandLabel() + "\""s;
+        comma = true;
+    }
+    if (label.hasPhysicalLabel()) {
+        if (comma) buffer += ", "s;
+        buffer += "physical"s + "=\""s + label.getPhysicalLabel() + "\""s;
+        comma = true;
+    }
+    buffer += ")"s;
+
+    return buffer;
 }
 
 void define(PyFilterLabel& cls) {
@@ -103,6 +126,8 @@ void define(PyFilterLabel& cls) {
     });
     cls.def("__eq__", &FilterLabel::operator==, py::is_operator());
     cls.def("__ne__", &FilterLabel::operator!=, py::is_operator());
+
+    cls.def("__repr__", &getRepr);
 }
 
 PYBIND11_MODULE(filterLabel, mod) {

--- a/src/image/FilterLabel.cc
+++ b/src/image/FilterLabel.cc
@@ -1,0 +1,70 @@
+/*
+ * This file is part of afw.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "lsst/pex/exceptions.h"
+#include "lsst/afw/image/FilterLabel.h"
+
+using namespace std::string_literals;
+
+namespace lsst {
+namespace afw {
+namespace image {
+
+FilterLabel::FilterLabel(bool hasBand, std::string const &band, bool hasPhysical, std::string const &physical)
+        : _hasBand(hasBand), _hasPhysical(hasPhysical), _band(band), _physical(physical) {}
+
+FilterLabel FilterLabel::fromBandPhysical(std::string const &band, std::string const &physical) {
+    return FilterLabel(true, band, true, physical);
+}
+
+FilterLabel FilterLabel::fromBand(std::string const &band) { return FilterLabel(true, band, false, ""s); }
+
+FilterLabel FilterLabel::fromPhysical(std::string const &physical) {
+    return FilterLabel(false, ""s, true, physical);
+}
+
+bool FilterLabel::hasBandLabel() const noexcept { return _hasBand; }
+
+std::string FilterLabel::getBandLabel() const {
+    // In no implementation I can think of will hasBandLabel() be an expensive test.
+    if (hasBandLabel()) {
+        return _band;
+    } else {
+        throw LSST_EXCEPT(pex::exceptions::LogicError, "FilterLabel has no band."s);
+    }
+}
+
+bool FilterLabel::hasPhysicalLabel() const noexcept { return _hasPhysical; }
+
+std::string FilterLabel::getPhysicalLabel() const {
+    // In no implementation I can think of will hasBandLabel() be an expensive test.
+    if (hasPhysicalLabel()) {
+        return _physical;
+    } else {
+        throw LSST_EXCEPT(pex::exceptions::LogicError, "FilterLabel has no physical filter."s);
+    }
+}
+
+}  // namespace image
+}  // namespace afw
+}  // namespace lsst

--- a/src/image/FilterLabel.cc
+++ b/src/image/FilterLabel.cc
@@ -70,7 +70,7 @@ std::string FilterLabel::getBandLabel() const {
     if (hasBandLabel()) {
         return _band;
     } else {
-        throw LSST_EXCEPT(pex::exceptions::LogicError, "FilterLabel has no band."s);
+        throw LSST_EXCEPT(pex::exceptions::LogicError, toString() + " has no band."s);
     }
 }
 
@@ -81,7 +81,7 @@ std::string FilterLabel::getPhysicalLabel() const {
     if (hasPhysicalLabel()) {
         return _physical;
     } else {
-        throw LSST_EXCEPT(pex::exceptions::LogicError, "FilterLabel has no physical filter."s);
+        throw LSST_EXCEPT(pex::exceptions::LogicError, toString() + " has no physical filter."s);
     }
 }
 

--- a/src/image/FilterLabel.cc
+++ b/src/image/FilterLabel.cc
@@ -43,6 +43,13 @@ FilterLabel FilterLabel::fromPhysical(std::string const &physical) {
     return FilterLabel(false, ""s, true, physical);
 }
 
+// defaults give the right behavior with bool-and-string implementation
+FilterLabel::FilterLabel(FilterLabel const &) = default;
+FilterLabel::FilterLabel(FilterLabel &&) noexcept = default;
+FilterLabel &FilterLabel::operator=(FilterLabel const &) = default;
+FilterLabel &FilterLabel::operator=(FilterLabel &&) noexcept = default;
+FilterLabel::~FilterLabel() noexcept = default;
+
 bool FilterLabel::hasBandLabel() const noexcept { return _hasBand; }
 
 std::string FilterLabel::getBandLabel() const {

--- a/src/image/FilterLabel.cc
+++ b/src/image/FilterLabel.cc
@@ -65,6 +65,23 @@ std::string FilterLabel::getPhysicalLabel() const {
     }
 }
 
+bool FilterLabel::operator==(FilterLabel const &rhs) const noexcept {
+    // Do not compare name unless _hasName for both
+    if (_hasBand != rhs._hasBand) {
+        return false;
+    }
+    if (_hasBand && _band != rhs._band) {
+        return false;
+    }
+    if (_hasPhysical != rhs._hasPhysical) {
+        return false;
+    }
+    if (_hasPhysical && _physical != rhs._physical) {
+        return false;
+    }
+    return true;
+}
+
 }  // namespace image
 }  // namespace afw
 }  // namespace lsst

--- a/src/image/FilterLabel.cc
+++ b/src/image/FilterLabel.cc
@@ -22,6 +22,7 @@
  */
 
 #include <memory>
+#include <regex>
 
 #include "lsst/utils/hashCombine.h"
 #include "lsst/pex/exceptions.h"
@@ -40,6 +41,11 @@ using namespace std::string_literals;
 namespace lsst {
 namespace afw {
 namespace image {
+
+std::string getDatabaseFilterLabel(std::string const &filterLabel) {
+    static std::regex const unsafeCharacters("\\W"s);
+    return std::regex_replace(filterLabel, unsafeCharacters, "_"s);
+}
 
 namespace impl {
 // Hack to allow unit tests to test states that, while legal, are

--- a/tests/test_filterLabel.cc
+++ b/tests/test_filterLabel.cc
@@ -1,0 +1,60 @@
+/*
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE FilterLabelCpp
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
+#include "boost/test/unit_test.hpp"
+#pragma clang diagnostic pop
+
+#include <string>
+
+#include "lsst/utils/tests.h"
+
+#include "lsst/afw/image/FilterLabel.h"
+
+namespace lsst {
+namespace afw {
+namespace image {
+
+BOOST_AUTO_TEST_CASE(Hash) {
+    std::string const band = "k";
+    std::string const physical = "MyScope-K";
+
+    utils::assertValidHash<FilterLabel>();
+
+    utils::assertHashesEqual(FilterLabel::fromBand(band), FilterLabel::fromBand(band));
+    utils::assertHashesEqual(FilterLabel::fromPhysical(physical), FilterLabel::fromPhysical(physical));
+    utils::assertHashesEqual(FilterLabel::fromBandPhysical(band, physical),
+                             FilterLabel::fromBandPhysical(band, physical));
+
+    // There are multiple ways to represent a label without a band/filter; these can arise
+    // from e.g. depersistence. Such objects compare equal; ensure they hash equally as well.
+    utils::assertHashesEqual(impl::makeTestFilterLabel(false, "", true, physical),
+                             impl::makeTestFilterLabel(false, "null", true, physical));
+    utils::assertHashesEqual(impl::makeTestFilterLabel(true, band, false, ""),
+                             impl::makeTestFilterLabel(true, band, false, "undefined"));
+}
+
+}  // namespace image
+}  // namespace afw
+}  // namespace lsst

--- a/tests/test_filterLabel.py
+++ b/tests/test_filterLabel.py
@@ -19,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import copy
 import unittest
 
 import lsst.utils.tests
@@ -121,6 +122,14 @@ class FilterLabelTestCase(lsst.utils.tests.TestCase):
     def _checkCopy(self, label1, label2):
         self.assertEqual(label1, label2)
         self.assertIsNot(label1, label2)
+
+    def testCopy(self):
+        for label in self._labelVariants():
+            copy1 = copy.copy(label)
+            self._checkCopy(copy1, label)
+
+            copy2 = copy.deepcopy(label)
+            self._checkCopy(copy2, label)
 
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_filterLabel.py
+++ b/tests/test_filterLabel.py
@@ -1,0 +1,78 @@
+# This file is part of afw.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+
+import lsst.utils.tests
+
+from lsst.afw.image import FilterLabel
+
+
+class FilterLabelTestCase(lsst.utils.tests.TestCase):
+    def setUp(self):
+        self.className = "FilterLabel"
+        self.physicalName = "k-0324"
+        self.band = "k"
+
+    def _labelVariants(self):
+        return iter({FilterLabel(physical=self.physicalName, band=self.band),
+                     FilterLabel.fromBand(self.band),
+                     FilterLabel(physical=self.physicalName),
+                     })
+
+    def _checkProperty(self, label, has, property, value):
+        # For consistency with C++ API, getting a missing label raises instead of returning None
+        if value:
+            self.assertTrue(has(label))
+            self.assertEqual(property.__get__(label), value)
+        else:
+            self.assertFalse(has(label))
+            with self.assertRaises(RuntimeError):
+                property.__get__(label)
+
+    def _checkFactory(self, label, band, physical):
+        self._checkProperty(label, FilterLabel.hasBandLabel, FilterLabel.bandLabel, band)
+        self._checkProperty(label, FilterLabel.hasPhysicalLabel, FilterLabel.physicalLabel, physical)
+
+    def testFactories(self):
+        """This method tests the getters as well as the factories, since their behaviors are linked.
+        """
+        self._checkFactory(FilterLabel.fromBandPhysical(self.band, self.physicalName),
+                           self.band, self.physicalName)
+        self._checkFactory(FilterLabel.fromBand(self.band), self.band, None)
+        self._checkFactory(FilterLabel.fromPhysical(self.physicalName), None, self.physicalName)
+
+    def _checkCopy(self, label1, label2):
+        self.assertEqual(label1, label2)
+        self.assertIsNot(label1, label2)
+
+
+class TestMemory(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_filterLabel.py
+++ b/tests/test_filterLabel.py
@@ -97,6 +97,15 @@ class FilterLabelTestCase(lsst.utils.tests.TestCase):
                 print(f"repr(label) = '{label!r}'")
                 raise
 
+    def testPersistence(self):
+        """Check persistence of a FilterLabel.
+        """
+        for label in self._labelVariants():
+            with lsst.utils.tests.getTempFilePath(".fits") as outFile:
+                label.writeFits(outFile)
+                roundTrip = FilterLabel.readFits(outFile)
+            self.assertEqual(roundTrip, label)
+
     def _checkProperty(self, label, has, property, value):
         # For consistency with C++ API, getting a missing label raises instead of returning None
         if value:

--- a/tests/test_filterLabel.py
+++ b/tests/test_filterLabel.py
@@ -88,6 +88,14 @@ class FilterLabelTestCase(lsst.utils.tests.TestCase):
         self.assertNotEqual(FilterLabel(band=self.band),
                             FilterLabel(band=self.band, physical=self.physicalName))
 
+    def testRepr(self):
+        for label in self._labelVariants():
+            try:
+                self.assertEqual(eval(repr(label)), label)
+            except (SyntaxError, ValueError):
+                print(f"repr(label) = '{label!r}'")
+                raise
+
     def _checkProperty(self, label, has, property, value):
         # For consistency with C++ API, getting a missing label raises instead of returning None
         if value:

--- a/tests/test_filterLabel.py
+++ b/tests/test_filterLabel.py
@@ -24,7 +24,7 @@ import unittest
 
 import lsst.utils.tests
 
-from lsst.afw.image import FilterLabel
+from lsst.afw.image import FilterLabel, getDatabaseFilterLabel
 
 
 class FilterLabelTestCase(lsst.utils.tests.TestCase):
@@ -139,6 +139,13 @@ class FilterLabelTestCase(lsst.utils.tests.TestCase):
 
             copy2 = copy.deepcopy(label)
             self._checkCopy(copy2, label)
+
+    def testDatabaseLabel(self):
+        self.assertEqual(getDatabaseFilterLabel("k"), "k")
+        self.assertEqual(getDatabaseFilterLabel("k-0234"), "k_0234")
+        self.assertEqual(getDatabaseFilterLabel("g decam 0101"), "g_decam_0101")
+        self.assertEqual(getDatabaseFilterLabel("speci@l band"), "speci_l_band")
+        self.assertEqual(getDatabaseFilterLabel("\"hacky, (42);"), "_hacky___42__")
 
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
This PR implements the `FilterLabel` class and unit-tests its functionality. Integration with `Exposure` is not yet supported, and will be added later.