### PR TITLE
Increase atol and rtol when comparing cdmatrix for wcs

### DIFF
--- a/tests/test_skyWcs.py
+++ b/tests/test_skyWcs.py
@@ -293,7 +293,7 @@ class SimpleSkyWcsTestCase(SkyWcsBaseTestCase):
         crpix = wcs.getPixelOrigin()
         self.assertPairsAlmostEqual(crpix, self.crpix, maxDiff=self.tinyPixels)
 
-        self.assertFloatsAlmostEqual(wcs.getCdMatrix(), cdMatrix)
+        self.assertFloatsAlmostEqual(wcs.getCdMatrix(), cdMatrix, atol=1e-15, rtol=1e-11)
 
         pixelScale = wcs.getPixelScale()
         self.assertAnglesAlmostEqual(self.scale, pixelScale, maxDiff=self.tinyAngle)


### PR DESCRIPTION
This fixes insignificant changes we've seen in ast 9.2.3 in the cd matrix.