### PR TITLE
DM-27246: Lots of Doxygen warnings in afw

### DIFF
--- a/doc/imageAlgorithm.dox
+++ b/doc/imageAlgorithm.dox
@@ -39,7 +39,7 @@ is a @c std::function with a virtual @c operator() added.
 
 \subsection afwSecForEachPixelExample Example of using for_each_pixel
 
-This code is in \link forEachPixel.cc\endlink.
+This code is in \link forEachPixel.cc \endlink.
 
 \dontinclude forEachPixel.cc
 

--- a/doc/iteratorsAndLocators.dox
+++ b/doc/iteratorsAndLocators.dox
@@ -4,11 +4,11 @@ namespace lsst { namespace afw { namespace image {
 
 (Return to \ref afwSecImage)
 
-This code is in \link image1.cc\endlink.
-Note that \link maskedImageIterators MaskedImage iterators\endlink work almost identically,
+This code is in \link image1.cc \endlink.
+Note that \link maskedImageIterators MaskedImage iterators \endlink work almost identically,
 the main difference being how pixel values are set.
 
-If you need access to nearby pixels, see the \link imageLocators Image locator\endlink tutorial.
+If you need access to nearby pixels, see the \link imageLocators Image locator \endlink tutorial.
 
 \dontinclude image1.cc
 \skip #include
@@ -24,11 +24,11 @@ If you need access to nearby pixels, see the \link imageLocators Image locator\e
 
 (Return to \ref afwSecImage)
 
-This code is in \link maskedImage2.cc\endlink.
-Note that \link imageIterators Image iterators\endlink work almost identically,
+This code is in \link maskedImage2.cc \endlink.
+Note that \link imageIterators Image iterators \endlink work almost identically,
 the main difference being how pixel values are set.
 
-If you need access to nearby pixels, see the \link maskedImageLocators MaskedImage locator\endlink tutorial.
+If you need access to nearby pixels, see the \link maskedImageLocators MaskedImage locator \endlink tutorial.
 
 \dontinclude maskedImage1.cc
 \skip #include
@@ -47,7 +47,7 @@ namespace lsst { namespace afw { namespace image {
 
 (Return to \ref afwSecImage)
 
-\link imageIterators Iterators\endlink provide access to an %image, %pixel by %pixel.  You
+\link imageIterators Iterators \endlink provide access to an %image, %pixel by %pixel.  You
 often want access to neighbouring pixels (e.g. computing a gradient, or smoothing).
 Let's consider the problem of smoothing with a
 \code
@@ -55,7 +55,7 @@ Let's consider the problem of smoothing with a
 2 4 2
 1 2 1
 \endcode
-kernel (the code's in \link image2.cc\endlink):
+kernel (the code's in \link image2.cc \endlink):
 \dontinclude image2.cc
 
 Start by including Image.h defining a namespace for clarity:
@@ -117,12 +117,12 @@ Finally write some output files and close out \c main():
 (Return to \ref afwSecImage)
 
 (You might be interested to compare this example with the discussion
-of Image \link imageLocators locators\endlink; apart from an include
+of Image \link imageLocators locators \endlink; apart from an include
 file and a typedef, the only difference is the use of
 <tt>ImageT::Pixel(y, 0x1, 10)</tt> as the assigned pixel value instead
 of \c y).
 
-\link imageIterators Iterators\endlink provide access to an %image, %pixel by %pixel.  You
+\link imageIterators Iterators \endlink provide access to an %image, %pixel by %pixel.  You
 often want access to neighbouring pixels (e.g. computing a gradient, or smoothing).
 Let's consider the problem of smoothing with a
 \code
@@ -130,7 +130,7 @@ Let's consider the problem of smoothing with a
 2 4 2
 1 2 1
 \endcode
-kernel (the code's in \link maskedImage2.cc\endlink):
+kernel (the code's in \link maskedImage2.cc \endlink):
 \dontinclude maskedImage2.cc
 
 Start by including MaskedImage.h, defining a namespace for clarity:

--- a/doc/mainpage.dox
+++ b/doc/mainpage.dox
@@ -36,10 +36,10 @@ You can use \ref afwSecDisplay "displaying images" to display Image%s and their 
 %Image Pixels may be accessed via iterators or locators;
 the former are simpler if you want single-pixel access, while the latter provide
 you with access to a pixel's friends and neighbours. The following tutorials are available:
-- \link imageIterators Image iterators\endlink
-- \link imageLocators Image locators\endlink
-- \link maskedImageIterators MaskedImage iterators\endlink
-- \link maskedImageLocators MaskedImage locators\endlink
+- \link imageIterators Image iterators \endlink
+- \link imageLocators Image locators \endlink
+- \link maskedImageIterators MaskedImage iterators \endlink
+- \link maskedImageLocators MaskedImage locators \endlink
 
 See also \ref afwSecPixelAccessReference. LSST %image access is modelled after the boost::gil %image interface; see
    http://www.boost.org/doc/libs/1_48_0/libs/gil/doc/html/giltutorial.html
@@ -63,10 +63,10 @@ There are also some algorithms analogous to the STL's @c \<algorithm\>; see \ref
 %Image Pixels may be accessed via iterators or locators;
 the former are simpler if you want single-pixel access, while the latter provide
 you with access to a pixel's friends and neighbours. There are a set of tutorials:
-- \link imageIterators Image iterators\endlink
-- \link imageLocators Image locators\endlink
-- \link maskedImageIterators MaskedImage iterators\endlink
-- \link maskedImageLocators MaskedImage locators\endlink
+- \link imageIterators Image iterators \endlink
+- \link imageLocators Image locators \endlink
+- \link maskedImageIterators MaskedImage iterators \endlink
+- \link maskedImageLocators MaskedImage locators \endlink
 
 In the case of MaskedImage, the user-visible \c iterator%s and
 locator%s (and \c const variants) are derived from MaskedImageIteratorBase
@@ -225,7 +225,7 @@ Image::Image(fileName, hdu=0, metadata=lsst::daf::base::PropertySet::Ptr(), bbox
 of data in the file.  As a special favour, "0" is intepreted as the first HDU, and if
 it's empty, the next is read instead.
 - The \c metadata is basically the contents of the
-FITS header (n.b. it's read automatically if you call \link Exposure::Exposure\endlink(fileName)).
+FITS header (n.b. it's read automatically if you call \link Exposure::Exposure \endlink(fileName)).
 - If the bounding box \c bbox is supplied, only that part of the file is read (n.b. in this
 case the image's origin is set correctly, cf. Image::getXY0).
 


### PR DESCRIPTION
This PR updates all Doxygen links of the form `\link target \endlink` to have whitespace on both sides of the target; the previous format wasn't properly tokenized by Doxygen 1.8.18.