### PR TITLE
DM-27168: Phase out use of FilterProperty

### DIFF
--- a/python/lsst/afw/image/utils.py
+++ b/python/lsst/afw/image/utils.py
@@ -56,8 +56,12 @@ def resetFilters():
     FilterProperty.reset()
 
 
-def defineFilter(name, lambdaEff, lambdaMin=np.nan, lambdaMax=np.nan, alias=[], force=False):
+def defineFilter(name, lambdaEff, lambdaMin=np.nan, lambdaMax=np.nan, alias=[], force=False,
+                 transmissionCurve=None):
     """Define a filter and its properties in the filter registry"""
+    if transmissionCurve:
+        (lambdaMin, lambdaMax) = transmissionCurve.getWavelengthBounds()
+        lambdaEff = 0.5 * (lambdaMax + lambdaMin)
     prop = FilterProperty(name, lambdaEff, lambdaMin, lambdaMax, force)
     Filter.define(prop)
     if isinstance(alias, str):

--- a/tests/test_exposure.py
+++ b/tests/test_exposure.py
@@ -33,7 +33,6 @@ import lsst.utils
 import lsst.utils.tests
 import lsst.geom
 import lsst.afw.image as afwImage
-from lsst.afw.image.utils import defineFilter
 from lsst.afw.coord import Weather
 import lsst.afw.geom as afwGeom
 import lsst.afw.table as afwTable
@@ -87,11 +86,6 @@ class ExposureTestCase(lsst.utils.tests.TestCase):
         self.exposureCrWcs = afwImage.ExposureF(100, 100, self.wcs)
         # test with ExtentI(100, 100) too
         self.exposureCrOnly = afwImage.ExposureF(lsst.geom.ExtentI(100, 100))
-
-        afwImage.Filter.reset()
-        afwImage.FilterProperty.reset()
-
-        defineFilter("g", 470.0)
 
     def tearDown(self):
         del self.smallExposure
@@ -805,10 +799,6 @@ class ExposureTestCase(lsst.utils.tests.TestCase):
 class ExposureInfoTestCase(lsst.utils.tests.TestCase):
     def setUp(self):
         super().setUp()
-
-        afwImage.Filter.reset()
-        afwImage.FilterProperty.reset()
-        defineFilter("g", 470.0)
 
         self.wcs = afwGeom.makeSkyWcs(lsst.geom.Point2D(0.0, 0.0),
                                       lsst.geom.SpherePoint(2.0, 34.0, lsst.geom.degrees),


### PR DESCRIPTION
Stop usage of FilterProperty, as stated in RFC-730.

Allow filter bounds to be defined from a tranmsission curve.