### PR TITLE
Add two new functions for matching and reindexing catalogs

### DIFF
--- a/python/lsst/afw/table/catalogMatches.py
+++ b/python/lsst/afw/table/catalogMatches.py
@@ -20,7 +20,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 __all__ = ["makeMergedSchema", "copyIntoCatalog",
-           "matchesToCatalog", "matchesFromCatalog", "copyAliasMapWithPrefix"]
+           "matchesToCatalog", "matchesFromCatalog", "copyAliasMapWithPrefix",
+           "reindexCatalog"]
 
 import os.path
 
@@ -254,3 +255,26 @@ def copyAliasMapWithPrefix(inSchema, outSchema, prefix=""):
         outSchema.getAliasMap().set(prefix + k, prefix + v)
 
     return outSchema
+
+
+def reindexCatalog(catalog, indices, deep=True):
+    """Apply a numpy index array to an afw Catalog
+
+    Parameters
+    ----------
+    catalog : `lsst.afw.table.SourceCatalog`
+        Catalog to reindex.
+    indices : `numpy.ndarray` of `int`
+        Index array.
+    deep : `bool`
+        Whether or not to make a deep copy of the original catalog.
+
+    Returns
+    -------
+    new : subclass of `lsst.afw.table.BaseCatalog`
+        Reindexed catalog. Records are shallow copies of those in ``catalog``.
+    """
+    new = SourceCatalog(catalog.table.clone() if deep else catalog.table)
+    records = [catalog[int(ii)] for ii in indices]
+    new.extend(records, deep=deep)
+    return new


### PR DESCRIPTION
This PR adds the function `reIndexCatalog` adopted from code by @PaulPrice to apply a numpy array as an index to rows in an afw Catalog and the `matchCatalogsExact` function to use the unique combination of `(parentId, peakId, patch)` to exactly match two catalogs derived from the same `mergeDet` catalog. The main use case is to test changes in deblending and measurement algorithms on the same exact set of sources.