### PR TITLE
DM-28004: ExposureInfo may persist dummy FilterLabels

### DIFF
--- a/include/lsst/afw/image/Exposure.h
+++ b/include/lsst/afw/image/Exposure.h
@@ -296,7 +296,12 @@ public:
     void setDetector(std::shared_ptr<lsst::afw::cameraGeom::Detector const> detector) {
         _info->setDetector(detector);
     }
-    /// Set the Exposure's filter
+    /**
+     * Set the Exposure's filter
+     *
+     * @param filter The filter to set. If this is the default filter
+     *               ("_unknown_"), it is interpreted as "no filter".
+     */
     // TODO: deprecate in DM-27170, remove in DM-27177
     void setFilter(Filter const& filter) { _info->setFilter(filter); }
     /// Set the Exposure's filter information

--- a/include/lsst/afw/image/ExposureInfo.h
+++ b/include/lsst/afw/image/ExposureInfo.h
@@ -128,7 +128,12 @@ public:
     // TODO: deprecate in DM-27170, remove in DM-27177
     Filter getFilter() const;
 
-    /// Set the exposure's filter
+    /**
+     * Set the exposure's filter
+     *
+     * @param filter The filter to set. If this is the default filter
+     *               ("_unknown_"), it is interpreted as "no filter".
+     */
     // TODO: deprecate in DM-27170, remove in DM-27177
     void setFilter(Filter const& filter);
 

--- a/src/image/ExposureFitsReader.cc
+++ b/src/image/ExposureFitsReader.cc
@@ -92,6 +92,12 @@ bool _isBand(std::string const& name) {
  * @returns A FilterLabel containing that name.
  */
 std::shared_ptr<FilterLabel> makeFilterLabelDirect(std::string const& name) {
+    static Filter const DEFAULT;
+    // Avoid turning dummy filters into real FilterLabels.
+    if (name == DEFAULT.getName()) {
+        return nullptr;
+    }
+
     // FilterLabel::from* returns a statically allocated object, so only way
     // to get it into shared_ptr is to copy it.
     if (_isBand(name)) {
@@ -113,6 +119,13 @@ std::shared_ptr<FilterLabel> makeFilterLabelDirect(std::string const& name) {
  */
 // TODO: compatibility code to be removed in DM-27177
 std::shared_ptr<FilterLabel> makeFilterLabel(Filter const& filter) {
+    static Filter const DEFAULT;
+    // Avoid turning dummy filters into real FilterLabels.
+    // Default filter has id=UNKNOWN, but others do too.
+    if (filter.getId() == DEFAULT.getId() && filter.getName() == DEFAULT.getName()) {
+        return nullptr;
+    }
+
     // Filter has no self-consistency guarantees whatsoever, and most methods
     // are unsafe. Program extremely defensively.
     if (filter.getId() == Filter::UNKNOWN) {

--- a/src/image/ExposureInfo.cc
+++ b/src/image/ExposureInfo.cc
@@ -189,13 +189,8 @@ ExposureInfo::ExposureInfo(std::shared_ptr<geom::SkyWcs const> const& wcs,
                              : std::shared_ptr<daf::base::PropertySet>(new daf::base::PropertyList())),
           _visitInfo(visitInfo),
           _components(std::make_unique<MapClass>()) {
-    static Filter const DEFAULT;
-    // Avoid putting dummy filters into the FilterLabel store. getFilter()
-    // will preserve old default behavior.
-    // Default filter has id=UNKNOWN, but others do too.
-    if (filter.getId() != DEFAULT.getId() || filter.getName() != DEFAULT.getName()) {
-        setFilter(filter);
-    }
+    // setFilter guards against default filters
+    setFilter(filter);
     setWcs(wcs);
     setPsf(psf);
     setPhotoCalib(photoCalib);

--- a/tests/test_exposure.py
+++ b/tests/test_exposure.py
@@ -274,6 +274,15 @@ class ExposureTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(exposure.getFilter(), gFilter)
         self.assertEqual(exposure.getFilterLabel(), gFilterLabel)
 
+    def testDefaultFilter(self):
+        """Test that old convention of having a "default" filter replaced with `None`.
+        """
+        exposureInfo = afwImage.ExposureInfo()
+        noFilter = afwImage.Filter()
+        exposureInfo.setFilter(noFilter)
+        self.assertFalse(exposureInfo.hasFilterLabel())
+        self.assertIsNone(exposureInfo.getFilterLabel())
+
     def testVisitInfoFitsPersistence(self):
         """Test saving an exposure to FITS and reading it back in preserves (some) VisitInfo fields"""
         exposureId = 5


### PR DESCRIPTION
This PR enforces the convention that `ExposureInfo::getFilter() == Filter()` corresponds to `ExposureInfo::getFilterLabel() == nullptr` at the translator level rather than the `ExposureInfo` constructor level. This prevents spurious "\_unknown\_" `FilterLabels` from getting persisted as part of new `Exposures`.