### PR TITLE
DM-28368: Fix id check so that all components can use readComponent.

### DIFF
--- a/include/lsst/afw/image/TransmissionCurve.h
+++ b/include/lsst/afw/image/TransmissionCurve.h
@@ -55,6 +55,12 @@ namespace image {
  *  at each position it is evaluated at).  Other classes and functions using
  *  TransmissionCurves should of course document the flux units and/or
  *  normalization expected/provided.
+ *
+ * @note TransmissionCurve is an interface to various C++-only implementation
+ * classes. Because these classes are not mapped to Python, some references to
+ * a TransmissionCurve object may appear in Python as a table::io::Persistable
+ * or typehandling::Storable instead. The best way to avoid this at present is
+ * to call functions that, in C++, explicitly return a TransmissionCurve.
  */
 class TransmissionCurve : public table::io::PersistableFacade<TransmissionCurve>,
                           public typehandling::Storable,

--- a/src/image/ExposureFitsReader.cc
+++ b/src/image/ExposureFitsReader.cc
@@ -401,6 +401,10 @@ public:
      *
      * @throws pex::exceptions::NotFoundError Thrown if the component is
      *     registered in the file metadata but could not be found.
+     *
+     * @note When accessing from python, components with derived subclasses, such
+     *       as ``TransmissionCurve``, are not properly type converted and thus
+     *       the specialized reader must be used instead of ``readComponent``.
      */
     // This method takes a string instead of a strongly typed Key because
     // readExtraComponents() gets its keys from the FITS metadata.

--- a/src/image/ExposureFitsReader.cc
+++ b/src/image/ExposureFitsReader.cc
@@ -411,7 +411,7 @@ public:
             return nullptr;
         }
 
-        if (_extraIds.count(c) > 0) {
+        if (_genericIds.count(c) > 0) {
             int archiveId = _genericIds.at(c);
             return _archive.get<T>(archiveId);
         } else {


### PR DESCRIPTION
Note that the TransmissionCurve is special in some way and
does not work with the current implementation.