### PR TITLE
DM-28623: Add hash function and associated tests.

### DIFF
--- a/python/lsst/afw/image/filterLabel.cc
+++ b/python/lsst/afw/image/filterLabel.cc
@@ -106,6 +106,7 @@ void define(py::module& mod, PyFilterLabel& cls) {
         _DELEGATE_EXCEPTION(label.getPhysicalLabel(), pex::exceptions::LogicError, std::runtime_error);
     });
     cls.def("__eq__", &FilterLabel::operator==, py::is_operator());
+    utils::python::addHash(cls);
     cls.def("__ne__", &FilterLabel::operator!=, py::is_operator());
 
     cls.def("__repr__", &FilterLabel::toString);

--- a/python/lsst/afw/table/_schema.cc
+++ b/python/lsst/afw/table/_schema.cc
@@ -357,6 +357,7 @@ void declareSchemaType(WrapperCollection &wrappers) {
                 py::is_operator());
         cls.def("__ne__", [](Key<T> const &self, Key<T> const &other) -> bool { return self != other; },
                 py::is_operator());
+        utils::python::addHash(cls);
         cls.def("isValid", &Key<T>::isValid);
         cls.def("getOffset", &Key<T>::getOffset);
         utils::python::addOutputOp(cls, "__str__");

--- a/tests/test_filterLabel.py
+++ b/tests/test_filterLabel.py
@@ -89,6 +89,12 @@ class FilterLabelTestCase(lsst.utils.tests.TestCase):
         self.assertNotEqual(FilterLabel(band=self.band),
                             FilterLabel(band=self.band, physical=self.physicalName))
 
+    def testEqualsHash(self):
+        self.assertEqual(hash(FilterLabel(band=self.band)),
+                         hash(FilterLabel(band=self.band)))
+        self.assertEqual(hash(FilterLabel(physical=self.physicalName)),
+                         hash(FilterLabel(physical=self.physicalName)))
+
     def testRepr(self):
         for label in self._labelVariants():
             try:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -65,6 +65,7 @@ class SchemaTestCase(unittest.TestCase):
         def testKey(name, key):
             col = schema.find(name)
             self.assertEqual(col.key, key)
+            self.assertEqual(hash(col.key), hash(key))
             self.assertEqual(col.field.getName(), name)
 
         schema = lsst.afw.table.Schema()
@@ -81,8 +82,10 @@ class SchemaTestCase(unittest.TestCase):
 
         # Extra tests for special types
         self.assertEqual(ab_k.getRa(), schema["a_b_ra"].asKey())
+        self.assertEqual(hash(ab_k.getRa()), hash(schema["a_b_ra"].asKey()))
         abpx_si = schema.find("a_b_p_x")
         self.assertEqual(abp_k.getX(), abpx_si.key)
+        self.assertEqual(hash(abp_k.getX()), hash(abpx_si.key))
         self.assertEqual(abpx_si.field.getName(), "a_b_p_x")
         self.assertEqual(abpx_si.field.getDoc(), "point")
         self.assertEqual(abp_k.getX(), schema["a_b_p_x"].asKey())


### PR DESCRIPTION
Adding the explicit `__hash__` function objects allows objects to be properly used within sets and as dict keys.  This is also necessary for pybind11=2.6 compatibility.