### PR TITLE
DM-27696: Fix Boost deprecation warning in afw

### DIFF
--- a/include/lsst/afw/image/ImageBase.h
+++ b/include/lsst/afw/image/ImageBase.h
@@ -364,7 +364,7 @@ public:
     //
     /** Return an STL compliant iterator to the start of the %image
      *
-     * Note that this isn't especially efficient; see @link imageIterators@endlink for
+     * Note that this isn't especially efficient; see @link imageIterators Image Iterators @endlink for
      * a discussion
      */
     iterator begin() const;

--- a/ups/afw.cfg
+++ b/ups/afw.cfg
@@ -6,7 +6,7 @@ dependencies = {
     "required": ["utils", "daf_persistence", "daf_base", "pex_exceptions", "geom", "log", "pex_config",
                  "eigen", "fftw", "ndarray", "numpy", "minuit2", "gsl", "cfitsio",
                  "boost_filesystem", "boost_regex", "boost_serialization", "astshim", "sphgeom"],
-    "buildRequired": ["boost_test", "pybind11"],
+    "buildRequired": ["boost_test", "boost_timer", "pybind11"],
 }
 
 config = lsst.sconsUtils.Configuration(


### PR DESCRIPTION
This PR updates all (unit test) references to Boost Timer from the deprecated API to the new one. It also fixes a Doxygen error I discovered while testing.