### PR TITLE
DM-27301: Fix iterator boundaries and special-case 0x0 images

### DIFF
--- a/include/lsst/afw/image/ImageBase.h
+++ b/include/lsst/afw/image/ImageBase.h
@@ -472,7 +472,14 @@ void swap(ImageBase<PixelT>& a, ImageBase<PixelT>& b);
 
 template <typename PixelT>
 typename ImageBase<PixelT>::Array ImageBase<PixelT>::getArray() {
-    int rowStride = reinterpret_cast<PixelT*>(row_begin(1)) - reinterpret_cast<PixelT*>(row_begin(0));
+    int rowStride;
+    if (getHeight() == 1) {
+        rowStride = 1;
+    } else if (getHeight() == 0) {
+        rowStride = 0;
+    } else {
+        rowStride = reinterpret_cast<PixelT*>(row_begin(1)) - reinterpret_cast<PixelT*>(row_begin(0));
+    }
     return ndarray::external(reinterpret_cast<PixelT*>(row_begin(0)),
                              ndarray::makeVector(getHeight(), getWidth()), ndarray::makeVector(rowStride, 1),
                              this->_manager);
@@ -480,7 +487,14 @@ typename ImageBase<PixelT>::Array ImageBase<PixelT>::getArray() {
 
 template <typename PixelT>
 typename ImageBase<PixelT>::ConstArray ImageBase<PixelT>::getArray() const {
-    int rowStride = reinterpret_cast<PixelT*>(row_begin(1)) - reinterpret_cast<PixelT*>(row_begin(0));
+    int rowStride;
+    if (getHeight() == 1) {
+        rowStride = 1;
+    } else if (getHeight() == 0) {
+        rowStride = 0;
+    } else {
+        rowStride = reinterpret_cast<PixelT*>(row_begin(1)) - reinterpret_cast<PixelT*>(row_begin(0));
+    }
     return ndarray::external(reinterpret_cast<PixelT*>(row_begin(0)),
                              ndarray::makeVector(getHeight(), getWidth()), ndarray::makeVector(rowStride, 1),
                              this->_manager);

--- a/include/lsst/afw/image/ImageBase.h
+++ b/include/lsst/afw/image/ImageBase.h
@@ -294,6 +294,8 @@ public:
     int getWidth() const { return _gilView.width(); }
     /// Return the number of rows in the %image
     int getHeight() const { return _gilView.height(); }
+    /// Return the area of the %image
+    int getArea() const { return getWidth()*getHeight(); }
     /**
      * Return the %image's column-origin
      *
@@ -472,30 +474,30 @@ void swap(ImageBase<PixelT>& a, ImageBase<PixelT>& b);
 
 template <typename PixelT>
 typename ImageBase<PixelT>::Array ImageBase<PixelT>::getArray() {
-    int rowStride;
-    if (getHeight() == 1) {
-        rowStride = 1;
-    } else if (getHeight() == 0) {
-        rowStride = 0;
-    } else {
+    int rowStride = 1;
+    PixelT * data = nullptr;
+    if (getArea() > 0) {
+        data = reinterpret_cast<PixelT*>(row_begin(0));
+    }
+    if (getHeight() > 1) {
         rowStride = reinterpret_cast<PixelT*>(row_begin(1)) - reinterpret_cast<PixelT*>(row_begin(0));
     }
-    return ndarray::external(reinterpret_cast<PixelT*>(row_begin(0)),
+    return ndarray::external(data,
                              ndarray::makeVector(getHeight(), getWidth()), ndarray::makeVector(rowStride, 1),
                              this->_manager);
 }
 
 template <typename PixelT>
 typename ImageBase<PixelT>::ConstArray ImageBase<PixelT>::getArray() const {
-    int rowStride;
-    if (getHeight() == 1) {
-        rowStride = 1;
-    } else if (getHeight() == 0) {
-        rowStride = 0;
-    } else {
+    int rowStride = 1;
+    PixelT * data = nullptr;
+    if (getArea() > 0) {
+        data = reinterpret_cast<PixelT*>(row_begin(0));
+    }
+    if (getHeight() > 1) {
         rowStride = reinterpret_cast<PixelT*>(row_begin(1)) - reinterpret_cast<PixelT*>(row_begin(0));
     }
-    return ndarray::external(reinterpret_cast<PixelT*>(row_begin(0)),
+    return ndarray::external(data,
                              ndarray::makeVector(getHeight(), getWidth()), ndarray::makeVector(rowStride, 1),
                              this->_manager);
 }

--- a/include/lsst/afw/image/lsstGil.h
+++ b/include/lsst/afw/image/lsstGil.h
@@ -55,6 +55,13 @@
 #include "boost/gil.hpp"
 #endif
 
+#ifndef BOOST_GIL_DEFINE_BASE_TYPEDEFS
+// Boost >=1.72 redefines GIL_ -> BOOST_GIL
+// Add these for compatibility
+#define BOOST_GIL_DEFINE_BASE_TYPEDEFS GIL_DEFINE_BASE_TYPEDEFS
+#define BOOST_GIL_DEFINE_ALL_TYPEDEFS_INTERNAL GIL_DEFINE_ALL_TYPEDEFS_INTERNAL
+#endif
+
 #if defined(__ICC)
 #pragma warning(pop)
 #endif
@@ -121,18 +128,18 @@ memory_based_2d_locator<T>& operator-=(memory_based_2d_locator<T>& loc, std::pai
 typedef uint64_t bits64;
 typedef int64_t bits64s;
 
-GIL_DEFINE_BASE_TYPEDEFS(64, bits64, gray)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(64, bits64, dev2n, devicen_t<2>, devicen_layout_t<2>)
-GIL_DEFINE_BASE_TYPEDEFS(64s, bits64s, gray)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(64s, bits64s, dev2n, devicen_t<2>, devicen_layout_t<2>)
+BOOST_GIL_DEFINE_BASE_TYPEDEFS(64, bits64, gray)
+BOOST_GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(64, bits64, dev2n, devicen_t<2>, devicen_layout_t<2>)
+BOOST_GIL_DEFINE_BASE_TYPEDEFS(64s, bits64s, gray)
+BOOST_GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(64s, bits64s, dev2n, devicen_t<2>, devicen_layout_t<2>)
 
 /*
  * Define a type that's a pure float, without scaling into [0, 1]
  */
 typedef float bits32f_noscale;
 
-GIL_DEFINE_BASE_TYPEDEFS(32f_noscale, bits32f_noscale, gray)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32f_noscale, bits32f_noscale, dev2n, devicen_t<2>, devicen_layout_t<2>)
+BOOST_GIL_DEFINE_BASE_TYPEDEFS(32f_noscale, bits32f_noscale, gray)
+BOOST_GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(32f_noscale, bits32f_noscale, dev2n, devicen_t<2>, devicen_layout_t<2>)
 
 template <>
 struct channel_multiplier<bits32f_noscale>
@@ -145,8 +152,8 @@ struct channel_multiplier<bits32f_noscale>
  */
 typedef double bits64f_noscale;
 
-GIL_DEFINE_BASE_TYPEDEFS(64f_noscale, bits64f_noscale, gray)
-GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(64f_noscale, bits64f_noscale, dev2n, devicen_t<2>, devicen_layout_t<2>)
+BOOST_GIL_DEFINE_BASE_TYPEDEFS(64f_noscale, bits64f_noscale, gray)
+BOOST_GIL_DEFINE_ALL_TYPEDEFS_INTERNAL(64f_noscale, bits64f_noscale, dev2n, devicen_t<2>, devicen_layout_t<2>)
 
 //
 // Conversions that don't scale

--- a/python/lsst/afw/image/filterLabel.cc
+++ b/python/lsst/afw/image/filterLabel.cc
@@ -103,6 +103,7 @@ void wrapFilterLabel(lsst::utils::python::WrapperCollection &wrappers) {
             _DELEGATE_EXCEPTION(label.getPhysicalLabel(), pex::exceptions::LogicError, std::runtime_error);
         });
         cls.def("__eq__", &FilterLabel::operator==, py::is_operator());
+        utils::python::addHash(cls);
         cls.def("__ne__", &FilterLabel::operator!=, py::is_operator());
 
         cls.def("__repr__", &FilterLabel::toString);

--- a/python/lsst/afw/table/_schema.cc
+++ b/python/lsst/afw/table/_schema.cc
@@ -355,6 +355,7 @@ void declareSchemaType(WrapperCollection &wrappers) {
         cls.def(py::init<>());
         cls.def("__eq__", [](Key<T> const &self, Key<T> const &other) -> bool { return self == other; },
                 py::is_operator());
+        utils::python::addHash(cls);
         cls.def("__ne__", [](Key<T> const &self, Key<T> const &other) -> bool { return self != other; },
                 py::is_operator());
         cls.def("isValid", &Key<T>::isValid);

--- a/src/image/Image.cc
+++ b/src/image/Image.cc
@@ -698,6 +698,12 @@ lsst::geom::Box2I bboxFromMetadata(daf::base::PropertySet& metadata) {
 
 template <typename T1, typename T2>
 bool imagesOverlap(ImageBase<T1> const& image1, ImageBase<T2> const& image2) {
+
+    if (image1.getArea() == 0 || image2.getArea() == 0) {
+        // zero-area images cannot overlap.
+        return false;
+    }
+
     auto arr1 = image1.getArray();
     // get the address of the first and one-past-the-last element of arr1 using ndarray iterators;
     // this works because the iterators for contiguous 1-d ndarray Arrays are just pointers

--- a/src/image/Image.cc
+++ b/src/image/Image.cc
@@ -88,8 +88,14 @@ typename ImageBase<PixelT>::_view_t ImageBase<PixelT>::_makeSubView(lsst::geom::
                  view.height())
                         .str());
     }
-    return boost::gil::subimage_view(view, offset.getX(), offset.getY(), dimensions.getX(),
-                                     dimensions.getY());
+    if (dimensions.getX() == 0 && dimensions.getY() == 0
+        && view.width() == 0 && view.height() == 0) {
+        // Getting a zero-extent subview of a zero-extent view returns itself
+        return view;
+    } else {
+        return boost::gil::subimage_view(view, offset.getX(), offset.getY(), dimensions.getX(),
+                                         dimensions.getY());
+    }
 }
 
 template <typename PixelT>

--- a/src/image/MaskedImage.cc
+++ b/src/image/MaskedImage.cc
@@ -33,6 +33,7 @@
 #pragma clang diagnostic pop
 #include "boost/regex.hpp"
 #include "boost/filesystem/path.hpp"
+#include "boost/format.hpp"
 #include "lsst/log/Log.h"
 #include "lsst/pex/exceptions.h"
 
@@ -306,6 +307,11 @@ template <typename ImagePixelT, typename MaskPixelT, typename VariancePixelT>
 MaskedImage<ImagePixelT, MaskPixelT, VariancePixelT>& MaskedImage<ImagePixelT, MaskPixelT, VariancePixelT>::
 operator*=(MaskedImage const& rhs) {
     // Must do variance before we modify the image values
+    if (_image->getDimensions() != rhs._image->getDimensions()) {
+        throw LSST_EXCEPT(pexExcept::LengthError,
+                          boost::str(boost::format("Images are of different size, %dx%d v %dx%d") %
+                                     _image->getWidth() % _image->getHeight() % rhs._image->getWidth() % rhs._image->getHeight()));
+    }
     transform_pixels(_image->_getRawView(),         // lhs
                      rhs._image->_getRawView(),     // rhs,
                      _variance->_getRawView(),      // Var(lhs),
@@ -322,6 +328,11 @@ template <typename ImagePixelT, typename MaskPixelT, typename VariancePixelT>
 void MaskedImage<ImagePixelT, MaskPixelT, VariancePixelT>::scaledMultiplies(double const c,
                                                                             MaskedImage const& rhs) {
     // Must do variance before we modify the image values
+    if (_image->getDimensions() != rhs._image->getDimensions()) {
+        throw LSST_EXCEPT(pexExcept::LengthError,
+                          boost::str(boost::format("Images are of different size, %dx%d v %dx%d") %
+                                     _image->getWidth() % _image->getHeight() % rhs._image->getWidth() % rhs._image->getHeight()));
+    }
     transform_pixels(_image->_getRawView(),         // lhs
                      rhs._image->_getRawView(),     // rhs,
                      _variance->_getRawView(),      // Var(lhs),
@@ -367,6 +378,11 @@ template <typename ImagePixelT, typename MaskPixelT, typename VariancePixelT>
 MaskedImage<ImagePixelT, MaskPixelT, VariancePixelT>& MaskedImage<ImagePixelT, MaskPixelT, VariancePixelT>::
 operator/=(MaskedImage const& rhs) {
     // Must do variance before we modify the image values
+    if (_image->getDimensions() != rhs._image->getDimensions()) {
+        throw LSST_EXCEPT(pexExcept::LengthError,
+                          boost::str(boost::format("Images are of different size, %dx%d v %dx%d") %
+                                     _image->getWidth() % _image->getHeight() % rhs._image->getWidth() % rhs._image->getHeight()));
+    }
     transform_pixels(_image->_getRawView(),         // lhs
                      rhs._image->_getRawView(),     // rhs,
                      _variance->_getRawView(),      // Var(lhs),
@@ -383,6 +399,11 @@ template <typename ImagePixelT, typename MaskPixelT, typename VariancePixelT>
 void MaskedImage<ImagePixelT, MaskPixelT, VariancePixelT>::scaledDivides(double const c,
                                                                          MaskedImage const& rhs) {
     // Must do variance before we modify the image values
+    if (_image->getDimensions() != rhs._image->getDimensions()) {
+        throw LSST_EXCEPT(pexExcept::LengthError,
+                          str(boost::format("Images are of different size, %dx%d v %dx%d") %
+                              _image->getWidth() % _image->getHeight() % rhs._image->getWidth() % rhs._image->getHeight()));
+    }
     transform_pixels(_image->_getRawView(),         // lhs
                      rhs._image->_getRawView(),     // rhs,
                      _variance->_getRawView(),      // Var(lhs),

--- a/tests/test_filterLabel.py
+++ b/tests/test_filterLabel.py
@@ -89,6 +89,12 @@ class FilterLabelTestCase(lsst.utils.tests.TestCase):
         self.assertNotEqual(FilterLabel(band=self.band),
                             FilterLabel(band=self.band, physical=self.physicalName))
 
+    def testEqualsHash(self):
+        self.assertEqual(hash(FilterLabel(band=self.band)),
+                         hash(FilterLabel(band=self.band)))
+        self.assertEqual(hash(FilterLabel(physical=self.physicalName)),
+                         hash(FilterLabel(physical=self.physicalName)))
+
     def testRepr(self):
         for label in self._labelVariants():
             try:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -65,6 +65,7 @@ class SchemaTestCase(unittest.TestCase):
         def testKey(name, key):
             col = schema.find(name)
             self.assertEqual(col.key, key)
+            self.assertEqual(hash(col.key), hash(key))
             self.assertEqual(col.field.getName(), name)
 
         schema = lsst.afw.table.Schema()
@@ -81,8 +82,10 @@ class SchemaTestCase(unittest.TestCase):
 
         # Extra tests for special types
         self.assertEqual(ab_k.getRa(), schema["a_b_ra"].asKey())
+        self.assertEqual(hash(ab_k.getRa()), hash(schema["a_b_ra"].asKey()))
         abpx_si = schema.find("a_b_p_x")
         self.assertEqual(abp_k.getX(), abpx_si.key)
+        self.assertEqual(hash(abp_k.getX()), hash(abpx_si.key))
         self.assertEqual(abpx_si.field.getName(), "a_b_p_x")
         self.assertEqual(abpx_si.field.getDoc(), "point")
         self.assertEqual(abp_k.getX(), schema["a_b_p_x"].asKey())


### PR DESCRIPTION
With these fixes our use of `boost::gil` is compatible with both `boost=1.70` and `boost=1.74` which has some very aggressive boundary checks requiring slightly different iterators.