### PR TITLE
DM-29303: Declare astshim dependency in pybind11 code that uses it.

### DIFF
--- a/python/lsst/afw/geom/_skyWcs.cc
+++ b/python/lsst/afw/geom/_skyWcs.cc
@@ -165,6 +165,7 @@ void declareSkyWcs(lsst::utils::python::WrapperCollection &wrappers) {
 void wrapSkyWcs(lsst::utils::python::WrapperCollection &wrappers) {
     wrappers.addInheritanceDependency("lsst.afw.table.io");
     wrappers.addInheritanceDependency("lsst.afw.typehandling");
+    wrappers.addSignatureDependency("astshim");
     declareSkyWcs(wrappers);
 }
 }  // namespace geom

--- a/python/lsst/afw/geom/_transform.cc
+++ b/python/lsst/afw/geom/_transform.cc
@@ -128,6 +128,7 @@ void declareTransform(lsst::utils::python::WrapperCollection &wrappers) {
 }  // namespace
 void wrapTransform(lsst::utils::python::WrapperCollection &wrappers) {
     wrappers.addSignatureDependency("lsst.afw.table.io");
+    wrappers.addSignatureDependency("astshim");
     declareTransform<GenericEndpoint, GenericEndpoint>(wrappers);
     declareTransform<GenericEndpoint, Point2Endpoint>(wrappers);
     declareTransform<GenericEndpoint, SpherePointEndpoint>(wrappers);

--- a/python/lsst/afw/geom/_transformFactory.cc
+++ b/python/lsst/afw/geom/_transformFactory.cc
@@ -65,6 +65,7 @@ void declareTransformFactory(lsst::utils::python::WrapperCollection &wrappers) {
 }  // namespace
 void wrapTransformFactory(lsst::utils::python::WrapperCollection &wrappers) {
     declareTransformFactory(wrappers);
+    wrappers.addSignatureDependency("astshim");
 }
 }  // namespace geom
 }  // namespace afw


### PR DESCRIPTION
Failing to do this could lead to it not being imported and some wrappers not working.  This problem probably existed prior to the recent refactor, but was masked by higher-level code that happened to import `astshim` in at the right points.