### PR TITLE
DM-29351: add missing package exports in afw.cameraGeom causing package-docs to fail

### DIFF
--- a/python/lsst/afw/cameraGeom/_detectorCollection.py
+++ b/python/lsst/afw/cameraGeom/_detectorCollection.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__all__ = ['DetectorCollectionBase', 'DetectorCollectionBuilderBase']
+
 from lsst.utils import TemplateMeta
 from ._cameraGeom import Detector
 from ._cameraGeom import DetectorCollectionDetectorBase, DetectorCollectionBuilderBase


### PR DESCRIPTION
afw.cameraGeom._detectorCollection now exports DetectorCollectionBase, DetectorCollectionBuilderBase
