### PR TITLE
DM-29775: Fix style issues introduced in DM-29737 and log output for unsorted catalogs

### DIFF
--- a/include/lsst/afw/table/Catalog.h
+++ b/include/lsst/afw/table/Catalog.h
@@ -760,14 +760,15 @@ typename CatalogT<RecordT>::iterator CatalogT<RecordT>::find(typename Field<T>::
     detail::KeyExtractionFunctor<RecordT, T> f = {key};
     // Iterator adaptor that makes a CatalogT iterator work like an iterator over field values.
     typedef boost::transform_iterator<detail::KeyExtractionFunctor<RecordT, T>, iterator> SearchIter;
-    // Try binary search for log n search assuming the table is sorted.
-    // If the search is unsuccessful, try a brute-force search before quitting.
+    /* Try binary search for log n search assuming the table is sorted.
+     * If the search is unsuccessful, try a brute-force search before quitting.
+     */
     SearchIter i = std::lower_bound(SearchIter(begin(), f), SearchIter(end(), f), value);
-    if (i.base() == end() || *i != value)
-    {
+    if (i.base() == end() || *i != value) {
         i = std::find(SearchIter(begin(), f), SearchIter(end(), f), value);
-        if (i.base() == end() || *i != value)
+        if (i.base() == end() || *i != value) {
             return end();
+        }
     }
     return i.base();
 }
@@ -779,14 +780,15 @@ typename CatalogT<RecordT>::const_iterator CatalogT<RecordT>::find(typename Fiel
     detail::KeyExtractionFunctor<RecordT, T> f = {key};
     // Iterator adaptor that makes a CatalogT iterator work like an iterator over field values.
     typedef boost::transform_iterator<detail::KeyExtractionFunctor<RecordT, T>, const_iterator> SearchIter;
-    // Try binary search for log n search assuming the table is sorted.
-    // If the search is unsuccessful, try a brute-force search before quitting.
+    /* Try binary search for log n search assuming the table is sorted.
+     * If the search is unsuccessful, try a brute-force search before quitting.
+     */
     SearchIter i = std::lower_bound(SearchIter(begin(), f), SearchIter(end(), f), value);
-    if (i.base() == end() || *i != value)
-    {
+    if (i.base() == end() || *i != value) {
         i = std::find(SearchIter(begin(), f), SearchIter(end(), f), value);
-        if (i.base() == end() || *i != value)
+        if (i.base() == end() || *i != value) {
             return end();
+        }
     }
     return i.base();
 }

--- a/include/lsst/afw/table/Catalog.h
+++ b/include/lsst/afw/table/Catalog.h
@@ -15,6 +15,7 @@
 #include "lsst/afw/table/io/FitsWriter.h"
 #include "lsst/afw/table/io/FitsReader.h"
 #include "lsst/afw/table/SchemaMapper.h"
+#include "lsst/log/Log.h"
 
 namespace lsst {
 namespace afw {
@@ -769,6 +770,7 @@ typename CatalogT<RecordT>::iterator CatalogT<RecordT>::find(typename Field<T>::
         if (i.base() == end()) {
             return end();
         }
+        LOGL_DEBUG("afw.table.Catalog", "Catalog is not sorted by the key. Finding a record may be slow.");
     }
     return i.base();
 }
@@ -789,6 +791,7 @@ typename CatalogT<RecordT>::const_iterator CatalogT<RecordT>::find(typename Fiel
         if (i.base() == end()) {
             return end();
         }
+        LOGL_DEBUG("afw.table.Catalog", "Catalog is not sorted by the key. Finding a record may be slow.");
     }
     return i.base();
 }

--- a/include/lsst/afw/table/Catalog.h
+++ b/include/lsst/afw/table/Catalog.h
@@ -766,7 +766,7 @@ typename CatalogT<RecordT>::iterator CatalogT<RecordT>::find(typename Field<T>::
     SearchIter i = std::lower_bound(SearchIter(begin(), f), SearchIter(end(), f), value);
     if (i.base() == end() || *i != value) {
         i = std::find(SearchIter(begin(), f), SearchIter(end(), f), value);
-        if (i.base() == end() || *i != value) {
+        if (i.base() == end()) {
             return end();
         }
     }
@@ -786,7 +786,7 @@ typename CatalogT<RecordT>::const_iterator CatalogT<RecordT>::find(typename Fiel
     SearchIter i = std::lower_bound(SearchIter(begin(), f), SearchIter(end(), f), value);
     if (i.base() == end() || *i != value) {
         i = std::find(SearchIter(begin(), f), SearchIter(end(), f), value);
-        if (i.base() == end() || *i != value) {
+        if (i.base() == end()) {
             return end();
         }
     }

--- a/src/image/PhotoCalib.cc
+++ b/src/image/PhotoCalib.cc
@@ -95,7 +95,7 @@ void toNanojanskyVariance(ndarray::Array<float const, 2, 1> const &instFlux,
 }
 
 double toMagnitudeErr(double instFlux, double instFluxErr, double scale, double scaleErr) {
-    return 2.5 / log(10.0) * hypot(instFluxErr / instFlux, scaleErr / scale);
+    return 2.5 / std::log(10.0) * hypot(instFluxErr / instFlux, scaleErr / scale);
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
This PR a) fixes a few style errors introduced in a recent merge DM-29737 and b) create a log message if the catalog is found to be unsorted. The log message is to hint the user of plausible inefficiencies in finding a desired record as a result of having catalog unsorted by the Id.