### PR TITLE
DM-30105: Get children sources without repeatedly checking if the afw SourceCatalog is sorted by parent

### DIFF
--- a/python/lsst/afw/table/_source.py
+++ b/python/lsst/afw/table/_source.py
@@ -28,8 +28,8 @@ from ._table import SourceCatalog, SourceTable
 Catalog.register("Source", SourceCatalog)
 
 
-@continueClass  # noqa: F811 (FIXME: remove for py 3.8+)
-class SourceCatalog:  # noqa: F811
+@continueClass
+class SourceCatalog:
 
     def getChildren(self, parent, *args):
         """Return the subset of self for which the parent field equals the

--- a/tests/test_sourceTable.py
+++ b/tests/test_sourceTable.py
@@ -419,9 +419,9 @@ class SourceTableTestCase(lsst.utils.tests.TestCase):
                 child = self.catalog.addNew()
                 self.fillRecord(child)
                 child.set(parentKey, parent.getId())
-        for parent in parents:
-            children, ids = self.catalog.getChildren(
-                parent.getId(), [record.getId() for record in self.catalog])
+        childrenIter = self.catalog.getChildren([parent.getId() for parent in parents],
+                                                [record.getId() for record in self.catalog])
+        for parent, (children, ids) in zip(parents, childrenIter):
             self.assertEqual(len(children), 10)
             self.assertEqual(len(children), len(ids))
             for child, id in zip(children, ids):


### PR DESCRIPTION
This is essentially DM-29936 in all its aspects. The bug that caused the failure in DM-29936 was in the `meas_base` repo, and not `afw` repo. This PR puts back the commits that were reverted earlier.