### PR TITLE
DM-30426: New Psf bbox methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,6 +180,7 @@ tests/data/Dest
 tests/data/kernel*.boost
 ups/*.cfgc
 extensions/
+.vscode/
 
 # Output of tests
 doc/htmlDir

--- a/include/lsst/afw/detection/Psf.h
+++ b/include/lsst/afw/detection/Psf.h
@@ -246,6 +246,20 @@ public:
                                   image::Color color = image::Color()) const;
 
     /**
+     *  Return the bounding box of the image returned by computeImage()
+     */
+    lsst::geom::Box2I computeImageBBox(lsst::geom::Point2D position = makeNullPoint(),
+                                       image::Color color = image::Color()) const;
+
+    /**
+     *  Alias for computeBBox
+     */
+    lsst::geom::Box2I computeKernelBBox(lsst::geom::Point2D position = makeNullPoint(),
+                                        image::Color color = image::Color()) const {
+        return computeBBox(position, color);
+    }
+
+    /**
      * Helper function for Psf::doComputeImage(): converts a kernel image (centered at (0,0) when xy0
      * is taken into account) to an image centered at position when xy0 is taken into account.
      *
@@ -290,13 +304,20 @@ protected:
      */
     explicit Psf(bool isFixed = false, std::size_t capacity = 100);
 
+    //@{
     /**
-     * This virtual member is protected (rather than private) so that python-implemented derived
-     * classes may opt to use the default implementation.  C++ derived classes may override this
-     * method, but should not call it.
+     * These virtual members are protected (rather than private) so that python-implemented derived
+     * classes may opt to use the default implementations.  C++ derived classes may override these
+     * methods, but should not call them.  Derived classes should call the corresponding compute*
+     * member functions instead so as to let the Psf base class handle caching properly.
+     *
+     * Derived classes are responsible for ensuring that returned images sum to one.
      */
     virtual std::shared_ptr<Image> doComputeImage(lsst::geom::Point2D const& position,
                                                   image::Color const& color) const;
+    virtual lsst::geom::Box2I doComputeImageBBox(lsst::geom::Point2D const& position,
+                                                 image::Color const& color) const;
+    //@}
 
 private:
     //@{

--- a/include/lsst/afw/detection/python.h
+++ b/include/lsst/afw/detection/python.h
@@ -91,6 +91,15 @@ public:
         );
     }
 
+    lsst::geom::Box2I doComputeImageBBox(
+        lsst::geom::Point2D const& position,
+        image::Color const& color
+    ) const override {
+        PYBIND11_OVERLOAD_NAME(
+            lsst::geom::Box2I, Base, "_doComputeImageBBox", doComputeImageBBox, position, color
+        );
+    }
+
     std::shared_ptr<Image> doComputeKernelImage(
         lsst::geom::Point2D const& position,
         image::Color const& color

--- a/python/lsst/afw/detection/_psf.cc
+++ b/python/lsst/afw/detection/_psf.cc
@@ -75,6 +75,10 @@ void wrapPsf(utils::python::WrapperCollection& wrappers) {
                         "color"_a = image::Color());
                 cls.def("computeBBox", &Psf::computeBBox, "position"_a = NullPoint,
                         "color"_a = image::Color());
+                cls.def("computeImageBBox", &Psf::computeImageBBox, "position"_a = NullPoint,
+                        "color"_a = image::Color());
+                cls.def("computeKernelBBox", &Psf::computeKernelBBox, "position"_a = NullPoint,
+                        "color"_a = image::Color());
                 cls.def("getLocalKernel", &Psf::getLocalKernel, "position"_a = NullPoint,
                         "color"_a = image::Color());
                 cls.def("getAverageColor", &Psf::getAverageColor);

--- a/src/detection/Psf.cc
+++ b/src/detection/Psf.cc
@@ -131,6 +131,12 @@ lsst::geom::Box2I Psf::computeBBox(lsst::geom::Point2D position, image::Color co
     return doComputeBBox(position, color);
 }
 
+lsst::geom::Box2I Psf::computeImageBBox(lsst::geom::Point2D position, image::Color color) const {
+    if (isPointNull(position)) position = getAveragePosition();
+    if (color.isIndeterminate()) color = getAverageColor();
+    return doComputeImageBBox(position, color);
+}
+
 std::shared_ptr<math::Kernel const> Psf::getLocalKernel(lsst::geom::Point2D position,
                                                         image::Color color) const {
     if (isPointNull(position)) position = getAveragePosition();
@@ -163,6 +169,12 @@ std::shared_ptr<Psf::Image> Psf::doComputeImage(lsst::geom::Point2D const &posit
                                                 image::Color const &color) const {
     std::shared_ptr<Psf::Image> im = computeKernelImage(position, color, COPY);
     return recenterKernelImage(im, position);
+}
+
+lsst::geom::Box2I Psf::doComputeImageBBox(lsst::geom::Point2D const& position,
+                                          image::Color const& color) const {
+    std::shared_ptr<Psf::Image> im = computeImage(position, color, INTERNAL);
+    return im->getBBox();
 }
 
 lsst::geom::Point2D Psf::getAveragePosition() const { return lsst::geom::Point2D(); }

--- a/tests/test_gaussianPsf.py
+++ b/tests/test_gaussianPsf.py
@@ -106,6 +106,9 @@ class GaussianPsfTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(self.psf.computeKernelImage(lsst.geom.Point2D(0.0, 0.0)).getBBox(),
                          self.psf.computeBBox(lsst.geom.Point2D(0.0, 0.0)))
 
+        self.assertEqual(self.psf.computeImage().getBBox(),
+                         self.psf.computeImageBBox())
+
     def testResized(self):
         for pad in [0, -10, 10]:
             newLen = self.kernelSize - pad

--- a/tests/test_psf_trampoline.py
+++ b/tests/test_psf_trampoline.py
@@ -153,6 +153,22 @@ class PsfTrampolineTestSuite(lsst.utils.tests.TestCase):
                 pgp.computeBBox(),
                 gp.computeBBox()
             )
+            self.assertEqual(
+                pgp.computeKernelBBox(),
+                gp.computeKernelBBox(),
+            )
+            self.assertEqual(
+                pgp.computeImageBBox(),
+                gp.computeImageBBox(),
+            )
+            self.assertEqual(
+                pgp.computeImage().getBBox(),
+                pgp.computeImageBBox()
+            )
+            self.assertEqual(
+                pgp.computeKernelImage().getBBox(),
+                pgp.computeKernelBBox()
+            )
 
     def testShape(self):
         for pgp, gp in zip(self.pgps, self.gps):


### PR DESCRIPTION
Adds `computeImageBBox`, which returns `Psf->computeImage()->getBBox()`, but allows Psf subclasses to implement this without requiring the intermediate call to `computeImage()`.

Also adds `computeKernelBBox` for symmetry, though this is equal to `computeBBox`.