### PR TITLE
DM-22486: Ensure pointer to a table in a catalog is always initialized

### DIFF
--- a/include/lsst/afw/table/BaseTable.h
+++ b/include/lsst/afw/table/BaseTable.h
@@ -171,6 +171,13 @@ public:
      */
     static std::shared_ptr<BaseTable> make(Schema const& schema);
 
+    /**
+     *  Return a minimal schema for Base tables and records.
+     *
+     *  The returned empty schema can and generally should be modified further.
+     */
+    static Schema makeMinimalSchema();
+
     // Tables are not assignable to prevent type slicing.
     BaseTable& operator=(BaseTable const& other) = delete;
     BaseTable& operator=(BaseTable&& other) = delete;

--- a/include/lsst/afw/table/Catalog.h
+++ b/include/lsst/afw/table/Catalog.h
@@ -120,11 +120,15 @@ public:
     /**
      *  Construct a catalog from a table (or nothing).
      *
-     *  A catalog with no table is considered invalid; a valid table must be assigned to it
-     *  before it can be used.
+     * A table is always initialized with a minimal schema.
      */
     explicit CatalogT(std::shared_ptr<Table> const& table = std::shared_ptr<Table>())
-            : _table(table), _internal() {}
+            : _table(table), _internal() {
+        if(!_table) {
+            auto schema=Table::makeMinimalSchema();
+            _table=Table::make(schema);
+        }
+    }
 
     /// Construct a catalog from a schema, creating a table with Table::make(schema).
     explicit CatalogT(Schema const& schema) : _table(Table::make(schema)), _internal() {}

--- a/src/table/BaseTable.cc
+++ b/src/table/BaseTable.cc
@@ -122,6 +122,10 @@ std::shared_ptr<BaseTable> BaseTable::make(Schema const &schema) {
     return std::shared_ptr<BaseTable>(new BaseTable(schema));
 }
 
+Schema BaseTable::makeMinimalSchema() {
+    return Schema();
+}
+
 std::shared_ptr<BaseRecord> BaseTable::copyRecord(BaseRecord const &input) {
     std::shared_ptr<BaseRecord> output = makeRecord();
     output->assign(input);

--- a/tests/test_ticket22486.py
+++ b/tests/test_ticket22486.py
@@ -1,0 +1,53 @@
+# This file is part of afw.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+
+import lsst.afw.table as afwTable
+import lsst.utils.tests
+
+
+class DefaultCatalogTest(unittest.TestCase):
+
+    def setUp(self):
+        self.cat1 = afwTable.SourceCatalog()
+        self.cat2 = afwTable.SourceCatalog(None)
+
+    def testaddNew(self):
+        self.cat1.addNew()
+        self.cat2.addNew()
+
+    def tearDown(self):
+        del self.cat1
+        del self.cat2
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
Ensure pointer to a table in a catalog is always initialized
and table contains a minimal schema