### PR TITLE
DM-31542: Allow writeFitsWithOptions for image/mask to select the options section

### DIFF
--- a/python/lsst/afw/image/image/_fitsIoWithOptions.py
+++ b/python/lsst/afw/image/image/_fitsIoWithOptions.py
@@ -85,24 +85,26 @@ def imageReadFitsWithOptions(cls, source, options):
     return cls(source, bbox=bbox, origin=origin)
 
 
-def imageWriteFitsWithOptions(self, dest, options):
+def imageWriteFitsWithOptions(self, dest, options, item="image"):
     """Write an Image or Mask to FITS, with options
 
     Parameters
     ----------
     dest : `str`
         Fits file path to which to write the image or mask.
-    options : `lsst.daf.base.PropertySet
-        Write options. The item "image" is read. It must contain an
-        `lsst.daf.base.PropertySet` with data for
+    options : `lsst.daf.base.PropertySet`
+        Write options. The item ``item`` is read (which defaults to "image").
+        It must contain an `lsst.daf.base.PropertySet` with data for
         ``lsst.afw.fits.ImageWriteOptions``.
+    item : `str`, optional
+        Item to read from the ``options`` parameter.
     """
     if options is not None:
         try:
-            writeOptions = ImageWriteOptions(options.getPropertySet("image"))
+            writeOptions = ImageWriteOptions(options.getPropertySet(item))
         except Exception as e:
             log = Log.getLogger("lsst.afw.image")
-            log.warn("Could not parse options; writing with defaults: {}".format(e))
+            log.warning("Could not parse item %s from options; writing with defaults: %s", item, e)
         else:
             self.writeFits(dest, writeOptions)
             return
@@ -127,7 +129,7 @@ def exposureWriteFitsWithOptions(self, dest, options):
                                for name in ("image", "mask", "variance")}
         except Exception as e:
             log = Log.getLogger("lsst.afw.image")
-            log.warn("Could not parse options; writing with defaults: {}".format(e))
+            log.warning("Could not parse options; writing with defaults: %s", e)
         else:
             self.writeFits(dest, **writeOptionDict)
             return

--- a/python/lsst/afw/image/image/_mask.py
+++ b/python/lsst/afw/image/image/_mask.py
@@ -48,7 +48,27 @@ class Mask(metaclass=TemplateMeta):
 
     readFitsWithOptions = classmethod(imageReadFitsWithOptions)
 
-    writeFitsWithOptions = imageWriteFitsWithOptions
+    def writeFitsWithOptions(self, dest, options, item=None):
+        """Write an Mask to FITS, with options
+
+        Parameters
+        ----------
+        dest : `str`
+            Fits file path to which to write the mask.
+        options : `lsst.daf.base.PropertySet`
+            Write options. The item ``item`` is read.
+            It must contain an `lsst.daf.base.PropertySet` with data for
+            ``lsst.afw.fits.ImageWriteOptions``.
+        item : `str`, optional
+            Item to read from the ``options`` parameter.
+            If not specified it will default to "mask" if present, else
+            will fallback to the generic "image" options.
+        """
+        if item is None:
+            # Fallback to "image" if "mask" is missing. This allows older
+            # code that assumed "image" to still function.
+            item = "mask" if "mask" in options else "image"
+        return imageWriteFitsWithOptions(self, dest, options, item=item)
 
 
 Mask.register(MaskPixel, MaskX)


### PR DESCRIPTION
Image and Mask previously always used an "image" section of the
compression options. This made it impossible to reuse the compression
settings from an Exposure without copying the relevant section to
image. This change allows the section to be explicitly specified
so that a user can declare that they want the variance settings
to be applied. Mask is changed to always prefer "mask" section
before falling back to "image".