### PR TITLE
DM-31721: Fix exception catching for getPackageDir

### DIFF
--- a/examples/convolveLinear.cc
+++ b/examples/convolveLinear.cc
@@ -24,7 +24,7 @@
 #include <sstream>
 #include <string>
 
-#include "lsst/utils/Utils.h"
+#include "lsst/utils/packaging.h"
 #include "lsst/pex/exceptions.h"
 #include "lsst/daf/base.h"
 #include "lsst/log/Log.h"

--- a/examples/decoratedImage.cc
+++ b/examples/decoratedImage.cc
@@ -24,7 +24,7 @@
 #include <string>
 #include <algorithm>
 
-#include "lsst/utils/Utils.h"
+#include "lsst/utils/packaging.h"
 #include "lsst/geom.h"
 #include "lsst/pex/exceptions.h"
 #include "lsst/afw/image/Image.h"

--- a/examples/mask.cc
+++ b/examples/mask.cc
@@ -25,7 +25,7 @@
 #include <algorithm>
 
 #include "lsst/geom.h"
-#include "lsst/utils/Utils.h"
+#include "lsst/utils/packaging.h"
 #include "lsst/pex/exceptions.h"
 #include "lsst/afw/image.h"
 

--- a/examples/maskedImageFitsIo.cc
+++ b/examples/maskedImageFitsIo.cc
@@ -23,7 +23,7 @@
 #include <iostream>
 #include <sstream>
 
-#include "lsst/utils/Utils.h"
+#include "lsst/utils/packaging.h"
 #include "lsst/pex/exceptions.h"
 #include "lsst/afw/image/MaskedImage.h"
 

--- a/examples/simpleConvolve.cc
+++ b/examples/simpleConvolve.cc
@@ -24,7 +24,7 @@
 #include <sstream>
 #include <string>
 
-#include "lsst/utils/Utils.h"
+#include "lsst/utils/packaging.h"
 #include "lsst/pex/exceptions.h"
 #include "lsst/log/Log.h"
 #include "lsst/afw/math.h"

--- a/examples/spatialCellExample.cc
+++ b/examples/spatialCellExample.cc
@@ -27,7 +27,7 @@
  */
 #include <string>
 #include "lsst/geom.h"
-#include "lsst/utils/Utils.h"
+#include "lsst/utils/packaging.h"
 #include "lsst/pex/exceptions.h"
 #include "lsst/daf/base.h"
 #include "lsst/afw/detection.h"

--- a/examples/spatiallyVaryingConvolve.cc
+++ b/examples/spatiallyVaryingConvolve.cc
@@ -23,7 +23,7 @@
 #include <iostream>
 #include <sstream>
 
-#include "lsst/utils/Utils.h"
+#include "lsst/utils/packaging.h"
 #include "lsst/pex/exceptions.h"
 #include "lsst/log/Log.h"
 #include "lsst/afw/math.h"

--- a/examples/timeConvolve.cc
+++ b/examples/timeConvolve.cc
@@ -24,7 +24,7 @@
 #include <sstream>
 #include <ctime>
 
-#include "lsst/utils/Utils.h"
+#include "lsst/utils/packaging.h"
 #include "lsst/pex/exceptions.h"
 #include "lsst/afw/math/FunctionLibrary.h"
 #include "lsst/afw/image/Image.h"

--- a/examples/timeWcs.cc
+++ b/examples/timeWcs.cc
@@ -25,7 +25,7 @@
 #include <ctime>
 #include <cmath>
 
-#include "lsst/utils/Utils.h"
+#include "lsst/utils/packaging.h"
 #include "lsst/geom.h"
 #include "lsst/afw/geom/SkyWcs.h"
 #include "lsst/afw/image.h"

--- a/examples/wcsTest.cc
+++ b/examples/wcsTest.cc
@@ -34,7 +34,7 @@
 #include <memory>
 
 #include "lsst/geom.h"
-#include "lsst/utils/Utils.h"
+#include "lsst/utils/packaging.h"
 #include "lsst/log/Log.h"
 #include "lsst/pex/exceptions.h"
 #include "lsst/afw/geom/SkyWcs.h"

--- a/python/lsst/afw/table/catalogMatches.py
+++ b/python/lsst/afw/table/catalogMatches.py
@@ -27,7 +27,6 @@ import os.path
 
 import numpy as np
 
-import lsst.pex.exceptions as pexExcept
 from ._schema import Schema
 from ._schemaMapper import SchemaMapper
 from ._base import BaseCatalog
@@ -177,7 +176,7 @@ def matchesToCatalog(matches, matchMeta):
     # obtain reference catalog name if one is setup
     try:
         catalogName = os.path.basename(getPackageDir("astrometry_net_data"))
-    except pexExcept.NotFoundError:
+    except LookupError:
         catalogName = "NOT_SET"
     matchMeta.add("REFCAT", catalogName)
     mergedCatalog.getTable().setMetadata(matchMeta)

--- a/tests/background.cc
+++ b/tests/background.cc
@@ -35,7 +35,7 @@
 #pragma clang diagnostic pop
 #include "boost/test/tools/floating_point_comparison.hpp"
 
-#include "lsst/utils/Utils.h"
+#include "lsst/utils/packaging.h"
 #include "lsst/pex/exceptions.h"
 #include "lsst/afw/image/Image.h"
 #include "lsst/afw/math/Interpolate.h"

--- a/tests/maskedImage1.cc
+++ b/tests/maskedImage1.cc
@@ -30,7 +30,7 @@
 #include "lsst/pex/exceptions.h"
 #include "lsst/log/Log.h"
 #include "lsst/afw/image.h"
-#include "lsst/utils/Utils.h"
+#include "lsst/utils/packaging.h"
 
 using namespace std;
 namespace pexEx = lsst::pex::exceptions;

--- a/tests/ramFitsIO.cc
+++ b/tests/ramFitsIO.cc
@@ -25,7 +25,7 @@
 #include "lsst/afw/geom/SkyWcs.h"
 #include "lsst/afw/image.h"
 #include "lsst/afw/image/Image.h"
-#include "lsst/utils/Utils.h"
+#include "lsst/utils/packaging.h"
 #include <fstream>
 #include <iostream>
 #include <memory>

--- a/tests/statistics.cc
+++ b/tests/statistics.cc
@@ -35,7 +35,7 @@
 #pragma clang diagnostic pop
 #include "boost/test/tools/floating_point_comparison.hpp"
 
-#include "lsst/utils/Utils.h"
+#include "lsst/utils/packaging.h"
 #include "lsst/pex/exceptions.h"
 #include "lsst/geom.h"
 #include "lsst/afw/image/Image.h"

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -35,7 +35,6 @@ import lsst.geom
 import lsst.afw.image as afwImage
 import lsst.afw.math as afwMath
 import lsst.afw.display as afwDisplay
-import lsst.pex.exceptions as pexExcept
 
 # Set to True to display debug messages and images
 debugMode = False
@@ -43,7 +42,7 @@ debugMode = False
 afwDisplay.setDefaultMaskTransparency(75)
 try:
     AfwdataDir = lsst.utils.getPackageDir("afwdata")
-except pexExcept.NotFoundError:
+except LookupError:
     AfwdataDir = None
 
 

--- a/tests/test_convolve.py
+++ b/tests/test_convolve.py
@@ -38,7 +38,6 @@ import lsst.geom
 import lsst.afw.image as afwImage
 import lsst.afw.math as afwMath
 import lsst.afw.math.detail as mathDetail
-import lsst.pex.exceptions as pexExcept
 
 from test_kernel import makeDeltaFunctionKernelList, makeGaussianKernelList
 from lsst.log import Log
@@ -55,7 +54,7 @@ except NameError:
 
 try:
     dataDir = os.path.join(lsst.utils.getPackageDir("afwdata"), "data")
-except pexExcept.NotFoundError:
+except LookupError:
     dataDir = None
 else:
     InputMaskedImagePath = os.path.join(dataDir, "medexp.fits")

--- a/tests/test_exposure.py
+++ b/tests/test_exposure.py
@@ -48,7 +48,7 @@ Log.getLogger("afw.image.Mask").setLevel(Log.INFO)
 
 try:
     dataDir = os.path.join(lsst.utils.getPackageDir("afwdata"), "data")
-except pexExcept.NotFoundError:
+except LookupError:
     dataDir = None
 else:
     InputMaskedImageName = "871034p_1_MI.fits"

--- a/tests/test_fitsTables.cc
+++ b/tests/test_fitsTables.cc
@@ -13,7 +13,7 @@
 #include <map>
 #include <filesystem>
 
-#include "lsst/utils/Utils.h"
+#include "lsst/utils/packaging.h"
 #include "lsst/afw/table/Source.h"
 #include "lsst/afw/geom/Span.h"
 #include "lsst/afw/geom/SpanSet.h"

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -45,11 +45,10 @@ import lsst.afw.image as afwImage
 import lsst.afw.math as afwMath
 from lsst.afw.fits import readMetadata
 import lsst.afw.display as afwDisplay
-import lsst.pex.exceptions as pexExcept
 
 try:
     afwdataDir = lsst.utils.getPackageDir("afwdata")
-except pexExcept.NotFoundError:
+except LookupError:
     afwdataDir = None
 
 try:

--- a/tests/test_imageIo1.py
+++ b/tests/test_imageIo1.py
@@ -33,7 +33,6 @@ import lsst.afw.image as afwImage
 import lsst.afw.fits as afwFits
 import lsst.utils.tests
 import lsst.afw.display as afwDisplay
-import lsst.pex.exceptions as pexExcept
 
 try:
     type(display)
@@ -42,7 +41,7 @@ except NameError:
 
 try:
     dataDir = os.path.join(lsst.utils.getPackageDir("afwdata"), "data")
-except pexExcept.NotFoundError:
+except LookupError:
     dataDir = None
 
 

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -48,7 +48,7 @@ except NameError:
 
 try:
     afwdataDir = lsst.utils.getPackageDir("afwdata")
-except pexExcept.NotFoundError:
+except LookupError:
     afwdataDir = None
 
 afwDisplay.setDefaultMaskTransparency(75)

--- a/tests/test_maskedImageIO.py
+++ b/tests/test_maskedImageIO.py
@@ -49,7 +49,7 @@ import lsst.pex.exceptions as pexEx
 
 try:
     dataDir = lsst.utils.getPackageDir("afwdata")
-except pexEx.NotFoundError:
+except LookupError:
     dataDir = None
 
 try:

--- a/tests/test_sourceMatch.py
+++ b/tests/test_sourceMatch.py
@@ -37,11 +37,10 @@ import lsst.geom
 import lsst.afw.table as afwTable
 import lsst.daf.base as dafBase
 import lsst.utils.tests
-import lsst.pex.exceptions as pexExcept
 
 try:
     afwdataDir = lsst.utils.getPackageDir("afwdata")
-except pexExcept.NotFoundError:
+except LookupError:
     afwdataDir = None
 
 

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -40,13 +40,12 @@ import lsst.geom
 import lsst.afw.image as afwImage
 import lsst.afw.math as afwMath
 import lsst.afw.display as afwDisplay
-import lsst.pex.exceptions as pexExcept
 
 afwDisplay.setDefaultMaskTransparency(75)
 
 try:
     afwdataDir = lsst.utils.getPackageDir("afwdata")
-except pexExcept.NotFoundError:
+except LookupError:
     afwdataDir = None
 
 try:

--- a/tests/test_tableArchives.cc
+++ b/tests/test_tableArchives.cc
@@ -16,7 +16,7 @@
 
 #include "Eigen/Core"
 
-#include "lsst/utils/Utils.h"
+#include "lsst/utils/packaging.h"
 #include "lsst/geom.h"
 #include "lsst/afw/detection/Footprint.h"
 #include "lsst/afw/detection/HeavyFootprint.h"

--- a/tests/test_tableMultiMatch.py
+++ b/tests/test_tableMultiMatch.py
@@ -38,14 +38,13 @@ import numpy as np
 
 import lsst.afw.table as afwTable
 import lsst.geom
-import lsst.pex.exceptions as pexExcept
 import lsst.utils
 import lsst.utils.tests
 
 
 try:
     afwdataDir = lsst.utils.getPackageDir("afwdata")
-except pexExcept.NotFoundError:
+except LookupError:
     afwdataDir = None
 
 

--- a/tests/test_warpExposure.py
+++ b/tests/test_warpExposure.py
@@ -54,7 +54,7 @@ SAVE_FAILED_FITS_FILES = True
 
 try:
     afwdataDir = lsst.utils.getPackageDir("afwdata")
-except pexExcept.NotFoundError:
+except LookupError:
     afwdataDir = None
 else:
     dataDir = os.path.join(afwdataDir, "data")

--- a/tests/test_warper.py
+++ b/tests/test_warper.py
@@ -30,7 +30,6 @@ import lsst.geom
 import lsst.afw.geom as afwGeom
 import lsst.afw.image as afwImage
 import lsst.afw.math as afwMath
-import lsst.pex.exceptions as pexExcept
 from lsst.log import Log
 
 # Change the level to Log.DEBUG to see debug messages
@@ -40,7 +39,7 @@ Log.getLogger("TRACE4.afw.math.warp").setLevel(Log.INFO)
 
 try:
     afwdataDir = lsst.utils.getPackageDir("afwdata")
-except pexExcept.NotFoundError:
+except LookupError:
     afwdataDir = None
     dataDir = None
 else:


### PR DESCRIPTION
Should use LookupError since that is compatible with C++ and
Python implementations.

Note that astrometry_net_data will never be found so this code
looks suspect.