### PR TITLE
DM-31801: Use lsst prefix for loggers

### DIFF
--- a/include/lsst/afw/table/Catalog.h
+++ b/include/lsst/afw/table/Catalog.h
@@ -774,7 +774,7 @@ typename CatalogT<RecordT>::iterator CatalogT<RecordT>::find(typename Field<T>::
         if (i.base() == end()) {
             return end();
         }
-        LOGL_DEBUG("afw.table.Catalog", "Catalog is not sorted by the key. Finding a record may be slow.");
+        LOGL_DEBUG("lsst.afw.table.Catalog", "Catalog is not sorted by the key. Finding a record may be slow.");
     }
     return i.base();
 }
@@ -795,7 +795,7 @@ typename CatalogT<RecordT>::const_iterator CatalogT<RecordT>::find(typename Fiel
         if (i.base() == end()) {
             return end();
         }
-        LOGL_DEBUG("afw.table.Catalog", "Catalog is not sorted by the key. Finding a record may be slow.");
+        LOGL_DEBUG("lsst.afw.table.Catalog", "Catalog is not sorted by the key. Finding a record may be slow.");
     }
     return i.base();
 }

--- a/python/lsst/afw/cameraGeom/utils.py
+++ b/python/lsst/afw/cameraGeom/utils.py
@@ -487,7 +487,7 @@ class ButlerImage(FakeImageDataSource):
                     # Lost by jupyterlab.
                     print(f"Reading {ccd.getId()}: {err}")
 
-                log.warn(f"Reading {ccd.getId()}: {err}")
+                log.warning(f"Reading {ccd.getId()}: {err}")
 
         if im is None:
             return self._prepareImage(ccd, imageFactory(*bbox.getDimensions()), binSize), ccd

--- a/python/lsst/afw/cameraGeom/utils.py
+++ b/python/lsst/afw/cameraGeom/utils.py
@@ -50,6 +50,8 @@ from lsst.afw.cameraGeom import DetectorType
 import lsst.afw.display as afwDisplay
 import lsst.afw.display.utils as displayUtils
 
+_LOG = lsst.log.Log.getLogger(__name__)
+
 
 def prepareWcsData(wcs, amp, isTrimmed=True):
     """Put Wcs from an Amp image into CCD coordinates
@@ -451,7 +453,7 @@ class ButlerImage(FakeImageDataSource):
     def getCcdImage(self, ccd, imageFactory=afwImage.ImageF, binSize=1, asMaskedImage=False):
         """Return an image of the specified ccd, and also the (possibly updated) ccd"""
 
-        log = lsst.log.Log.getLogger("afw.cameraGeom.utils.ButlerImage")
+        log = _LOG.getChild("ButlerImage")
 
         if self.isTrimmed:
             bbox = ccd.getBBox()
@@ -884,7 +886,7 @@ def makeImageFromCamera(camera, detectorNameList=None, background=numpy.nan, buf
     image : `lsst.afw.image.Image`
         Image of the entire camera.
     """
-    log = lsst.log.Log.getLogger("afw.cameraGeom.utils.makeImageFromCamera")
+    log = _LOG.getChild("makeImageFromCamera")
 
     if detectorNameList is None:
         ccdList = camera

--- a/python/lsst/afw/cameraGeom/utils.py
+++ b/python/lsst/afw/cameraGeom/utils.py
@@ -487,7 +487,7 @@ class ButlerImage(FakeImageDataSource):
                     # Lost by jupyterlab.
                     print(f"Reading {ccd.getId()}: {err}")
 
-                log.warning(f"Reading {ccd.getId()}: {err}")
+                log.warning("Reading %s: %s", ccd.getId(), err)
 
         if im is None:
             return self._prepareImage(ccd, imageFactory(*bbox.getDimensions()), binSize), ccd
@@ -504,7 +504,7 @@ class ButlerImage(FakeImageDataSource):
                 im = self.callback(im, ccd, imageSource=self)
             except Exception as e:
                 if self.verbose:
-                    log.error(f"callback failed: {e}")
+                    log.error("callback failed: %s", e)
                 im = imageFactory(*bbox.getDimensions())
             else:
                 allowRotate = False     # the callback was responsible for any rotations
@@ -921,7 +921,8 @@ def makeImageFromCamera(camera, detectorNameList=None, background=numpy.nan, buf
         try:
             imView[:] = im
         except pexExceptions.LengthError as e:
-            log.error(f"Unable to fit image for detector \"{det.getName()}\" into image of camera: {e}")
+            log.error("Unable to fit image for detector \"%s\" into image of camera: %s",
+                      det.getName(), e)
 
     return camIm
 

--- a/python/lsst/afw/display/interface.py
+++ b/python/lsst/afw/display/interface.py
@@ -36,7 +36,7 @@ import lsst.afw.geom as afwGeom
 import lsst.afw.image as afwImage
 import lsst.log
 
-logger = lsst.log.Log.getLogger("afw.display.interface")
+logger = lsst.log.Log.getLogger(__name__)
 
 #
 # Symbolic names for mask/line colors.  N.b. ds9 supports any X11 color for masks

--- a/src/cameraGeom/TransformMap.cc
+++ b/src/cameraGeom/TransformMap.cc
@@ -38,7 +38,7 @@ namespace {
 // Allows conversions between LSST and AST data formats
 static lsst::afw::geom::Point2Endpoint const POINT2_ENDPOINT;
 
-static auto LOGGER = LOG_GET("afw.cameraGeom.TransformMap");
+static auto LOGGER = LOG_GET("lsst.afw.cameraGeom.TransformMap");
 
 // Make an AST Frame name for a CameraSys.
 std::string makeFrameName(CameraSys const & sys) {

--- a/src/detection/Threshold.cc
+++ b/src/detection/Threshold.cc
@@ -95,7 +95,7 @@ double Threshold::getValue(ImageT const& image) const {
         math::Statistics stats = math::makeStatistics(image, math::STDEVCLIP);
         double const sd = stats.getValue(math::STDEVCLIP);
 
-        LOGL_DEBUG("afw.detection.threshold", "St. Dev = %g", sd);
+        LOGL_DEBUG("lsst.afw.detection.threshold", "St. Dev = %g", sd);
 
         if (_type == VARIANCE) {
             param = sd * sd;

--- a/src/fits.cc
+++ b/src/fits.cc
@@ -72,7 +72,7 @@ std::string makeLimitedFitsHeaderImpl(std::vector<std::string> const &paramNames
                 // use G because FITS wants uppercase E for exponents
                 out += (boost::format("%#20.17G") % value).str();
             } else {
-                LOGLS_WARN("afw.fits",
+                LOGLS_WARN("lsst.afw.fits",
                             boost::format("In %s, found NaN in metadata item '%s'") %
                                           BOOST_CURRENT_FUNCTION % name);
                 // Convert it to FITS undefined
@@ -83,7 +83,7 @@ std::string makeLimitedFitsHeaderImpl(std::vector<std::string> const &paramNames
             if (!std::isnan(value)) {
                 out += (boost::format("%#20.15G") % value).str();
             } else {
-                LOGLS_WARN("afw.fits",
+                LOGLS_WARN("lsst.afw.fits",
                            boost::format("In %s, found NaN in metadata item '%s'") %
                                          BOOST_CURRENT_FUNCTION % name);
                 // Convert it to FITS undefined
@@ -795,7 +795,7 @@ void Fits::forEachKey(HeaderIterationFunctor &functor) {
         std::string upperKey(key);
         boost::to_upper(upperKey);
         if (upperKey.compare(key) != 0){
-            LOGLS_DEBUG("afw.fits",
+            LOGLS_DEBUG("lsst.afw.fits",
                         boost::format("In %s, standardizing key '%s' to uppercase '%s' on read.") %
                         BOOST_CURRENT_FUNCTION % key % upperKey);
         }
@@ -862,7 +862,7 @@ public:
         // previously we have an undefined value we must use set instead.
         if (list) {
             if (list->exists(key) && list->isUndefined(key)) {
-                LOGLS_WARN("afw.fits",
+                LOGLS_WARN("lsst.afw.fits",
                            boost::format("In %s, replacing undefined value for key '%s'.") %
                                          BOOST_CURRENT_FUNCTION % key);
                 list->set(key, value, comment);
@@ -871,7 +871,7 @@ public:
             }
         } else {
             if (set->exists(key) && set->isUndefined(key)) {
-                LOGLS_WARN("afw.fits",
+                LOGLS_WARN("lsst.afw.fits",
                            boost::format("In %s, replacing undefined value for key '%s'.") %
                                          BOOST_CURRENT_FUNCTION % key);
                 set->set(key, value);
@@ -889,7 +889,7 @@ public:
             if (list->exists(key) && !list->isUndefined(key)) {
                 // Do nothing. Assume the previously defined value takes
                 // precedence.
-                LOGLS_WARN("afw.fits",
+                LOGLS_WARN("lsst.afw.fits",
                            boost::format("In %s, dropping undefined value for key '%s'.") %
                                          BOOST_CURRENT_FUNCTION % key);
             } else {
@@ -899,7 +899,7 @@ public:
             if (set->exists(key) && !set->isUndefined(key)) {
                 // Do nothing. Assume the previously defined value takes
                 // precedence.
-                LOGLS_WARN("afw.fits",
+                LOGLS_WARN("lsst.afw.fits",
                            boost::format("In %s, dropping undefined value for key '%s'.") %
                                          BOOST_CURRENT_FUNCTION % key);
             } else {
@@ -982,7 +982,7 @@ void writeKeyFromProperty(Fits &fits, daf::base::PropertySet const &metadata, st
     std::string upperKey(key);
     boost::to_upper(upperKey);
     if (upperKey.compare(key) != 0){
-        LOGLS_WARN("afw.fits",
+        LOGLS_WARN("lsst.afw.fits",
                    boost::format("In %s, key '%s' may be standardized to uppercase '%s' on write.") %
                    BOOST_CURRENT_FUNCTION % key % upperKey);
     }
@@ -1072,7 +1072,7 @@ void writeKeyFromProperty(Fits &fits, daf::base::PropertySet const &metadata, st
         }
     } else {
         // FIXME: inherited this error handling from fitsIo.cc; need a better option.
-        LOGLS_WARN("afw.writeKeyFromProperty",
+        LOGLS_WARN("lsst.afw.fits.writeKeyFromProperty",
                    makeErrorMessage(fits.fptr, fits.status,
                                     boost::format("In %s, unknown type '%s' for key '%s'.") %
                                             BOOST_CURRENT_FUNCTION % valueType.name() % key));
@@ -1279,7 +1279,7 @@ public:
         try {
             fits.setImageCompression(old);
         } catch (...) {
-            LOGLS_WARN("afw.fits",
+            LOGLS_WARN("lsst.afw.fits",
                        makeErrorMessage(fits.fptr, fits.status, "Failed to restore compression settings"));
         }
         std::swap(status, fits.status);

--- a/src/geom/detail/frameSetUtils.cc
+++ b/src/geom/detail/frameSetUtils.cc
@@ -358,7 +358,7 @@ ast::FitsChan getFitsChanFromPropertyList(daf::base::PropertySet& metadata,
                     fc.setFitsF(name, value);
                 } else {
                     // Treat it like an undefined value but warn about it
-                    LOGLS_WARN("afw.geom.frameSetUtils",
+                    LOGLS_WARN("lsst.afw.geom.frameSetUtils",
                                boost::format("Found NaN in metadata item '%s'") % name);
                 }
             } else if (type == typeid(std::string)) {

--- a/src/image/ExposureFitsReader.cc
+++ b/src/image/ExposureFitsReader.cc
@@ -41,7 +41,7 @@ namespace image {
 
 namespace {
 
-LOG_LOGGER _log = LOG_GET("afw.image.fits.ExposureFitsReader");
+LOG_LOGGER _log = LOG_GET("lsst.afw.image.fits.ExposureFitsReader");
 
 template <typename T, std::size_t N>
 bool _contains(std::array<T, N> const& array, T const& value) {

--- a/src/image/ExposureInfo.cc
+++ b/src/image/ExposureInfo.cc
@@ -37,7 +37,7 @@
 using namespace std::string_literals;
 
 namespace {
-LOG_LOGGER _log = LOG_GET("afw.image.ExposureInfo");
+LOG_LOGGER _log = LOG_GET("lsst.afw.image.ExposureInfo");
 
 using MapClass = lsst::afw::image::detail::StorableMap;
 }  // namespace

--- a/src/image/Mask.cc
+++ b/src/image/Mask.cc
@@ -53,7 +53,7 @@ namespace {}  // namespace
 
 template <typename MaskPixelT>
 void Mask<MaskPixelT>::_initializePlanes(MaskPlaneDict const& planeDefs) {
-    LOGL_DEBUG("afw.image.Mask", "Number of mask planes: %d", getNumPlanesMax());
+    LOGL_DEBUG("lsst.afw.image.Mask", "Number of mask planes: %d", getNumPlanesMax());
 
     _maskDict = detail::MaskDict::copyOrGetDefault(planeDefs);
 }

--- a/src/image/MaskedImageFitsReader.cc
+++ b/src/image/MaskedImageFitsReader.cc
@@ -90,7 +90,7 @@ void checkExtType(ImageBaseFitsReader const & reader, std::shared_ptr<daf::base:
         }
         metadata->remove("EXTTYPE");
     } catch (pex::exceptions::NotFoundError const&) {
-        LOGL_WARN("afw.image.MaskedImageFitsReader", "Expected extension type not found: %s",
+        LOGL_WARN("lsst.afw.image.MaskedImageFitsReader", "Expected extension type not found: %s",
                   expected.c_str());
     }
 }

--- a/src/image/MaskedImageFitsReader.cc
+++ b/src/image/MaskedImageFitsReader.cc
@@ -186,7 +186,7 @@ MaskedImage<ImagePixelT, MaskPixelT, VariancePixelT> MaskedImageFitsReader::read
     // If the mask and/or variance is unreadable, we log a warning and return
     // (blank) defaults.
 
-    LOG_LOGGER _log = LOG_GET("afw.image.MaskedImageFitsReader");
+    LOG_LOGGER _log = LOG_GET("lsst.afw.image.MaskedImageFitsReader");
 
     enum class Hdu { Primary = 0, Image, Mask, Variance };
 

--- a/src/math/LeastSquares.cc
+++ b/src/math/LeastSquares.cc
@@ -33,7 +33,7 @@
 #include "lsst/log/Log.h"
 
 namespace {
-LOG_LOGGER _log = LOG_GET("afw.math.LeastSquares");
+LOG_LOGGER _log = LOG_GET("lsst.afw.math.LeastSquares");
 }
 
 namespace lsst {

--- a/src/math/SpatialCell.cc
+++ b/src/math/SpatialCell.cc
@@ -72,7 +72,7 @@ int SpatialCellImageCandidate::_height = 0;
 SpatialCell::SpatialCell(std::string const &label, lsst::geom::Box2I const &bbox,
                          CandidateList const &candidateList)
         : _label(label), _bbox(bbox), _candidateList(candidateList), _ignoreBad(true) {
-    LOGL_DEBUG("afw.math.SpatialCell", "Cell %s : created with %d candidates", this->_label.c_str(),
+    LOGL_DEBUG("lsst.afw.math.SpatialCell", "Cell %s : created with %d candidates", this->_label.c_str(),
                this->_candidateList.size());
     sortCandidates();
 }

--- a/src/math/Stack.cc
+++ b/src/math/Stack.cc
@@ -38,7 +38,7 @@
 namespace pexExcept = lsst::pex::exceptions;
 
 namespace {
-    LOG_LOGGER _log = LOG_GET("afw.math.Stack");
+    LOG_LOGGER _log = LOG_GET("lsst.afw.math.Stack");
 }
 
 namespace lsst {

--- a/src/math/detail/BasicConvolve.cc
+++ b/src/math/detail/BasicConvolve.cc
@@ -144,13 +144,13 @@ void basicConvolve(OutImageT& convolvedImage, InImageT const& inImage, math::Ker
     // dispatch the correct version of basicConvolve. The case that fails is convolving with a kernel
     // obtained from a pointer or reference to a Kernel (base class), e.g. as used in LinearCombinationKernel.
     if (IS_INSTANCE(kernel, math::DeltaFunctionKernel)) {
-        LOGL_DEBUG("TRACE3.afw.math.convolve.basicConvolve",
+        LOGL_DEBUG("TRACE3.lsst.afw.math.convolve.basicConvolve",
                    "generic basicConvolve: dispatch to DeltaFunctionKernel basicConvolve");
         basicConvolve(convolvedImage, inImage, *dynamic_cast<math::DeltaFunctionKernel const*>(&kernel),
                       convolutionControl);
         return;
     } else if (IS_INSTANCE(kernel, math::SeparableKernel)) {
-        LOGL_DEBUG("TRACE3.afw.math.convolve.basicConvolve",
+        LOGL_DEBUG("TRACE3.lsst.afw.math.convolve.basicConvolve",
                    "generic basicConvolve: dispatch to SeparableKernel basicConvolve");
         basicConvolve(convolvedImage, inImage, *dynamic_cast<math::SeparableKernel const*>(&kernel),
                       convolutionControl);
@@ -166,13 +166,13 @@ void basicConvolve(OutImageT& convolvedImage, InImageT const& inImage, math::Ker
     // OK, use general (and slower) form
     if (kernel.isSpatiallyVarying() && (convolutionControl.getMaxInterpolationDistance() > 1)) {
         // use linear interpolation
-        LOGL_DEBUG("TRACE2.afw.math.convolve.basicConvolve",
+        LOGL_DEBUG("TRACE2.lsst.afw.math.convolve.basicConvolve",
                    "generic basicConvolve: using linear interpolation");
         convolveWithInterpolation(convolvedImage, inImage, kernel, convolutionControl);
 
     } else {
         // use brute force
-        LOGL_DEBUG("TRACE2.afw.math.convolve.basicConvolve", "generic basicConvolve: using brute force");
+        LOGL_DEBUG("TRACE2.lsst.afw.math.convolve.basicConvolve", "generic basicConvolve: using brute force");
         convolveWithBruteForce(convolvedImage, inImage, kernel, convolutionControl);
     }
 }
@@ -193,7 +193,7 @@ void basicConvolve(OutImageT& convolvedImage, InImageT const& inImage,
     int const inStartX = kernel.getPixel().getX();
     int const inStartY = kernel.getPixel().getY();
 
-    LOGL_DEBUG("TRACE2.afw.math.convolve.basicConvolve", "DeltaFunctionKernel basicConvolve");
+    LOGL_DEBUG("TRACE2.lsst.afw.math.convolve.basicConvolve", "DeltaFunctionKernel basicConvolve");
 
     for (int i = 0; i < cnvHeight; ++i) {
         typename InImageT::x_iterator inPtr = inImage.x_at(inStartX, i + inStartY);
@@ -211,7 +211,7 @@ void basicConvolve(OutImageT& convolvedImage, InImageT const& inImage,
                    math::ConvolutionControl const& convolutionControl) {
     if (!kernel.isSpatiallyVarying()) {
         // use the standard algorithm for the spatially invariant case
-        LOGL_DEBUG("TRACE2.afw.math.convolve.basicConvolve",
+        LOGL_DEBUG("TRACE2.lsst.afw.math.convolve.basicConvolve",
                    "basicConvolve for LinearCombinationKernel: spatially invariant; using brute force");
         return convolveWithBruteForce(convolvedImage, inImage, kernel, convolutionControl.getDoNormalize());
     } else {
@@ -229,11 +229,11 @@ void basicConvolve(OutImageT& convolvedImage, InImageT const& inImage,
             refKernelPtr = kernel.clone();
         }
         if (convolutionControl.getMaxInterpolationDistance() > 1) {
-            LOGL_DEBUG("TRACE2.afw.math.convolve.basicConvolve",
+            LOGL_DEBUG("TRACE2.lsst.afw.math.convolve.basicConvolve",
                        "basicConvolve for LinearCombinationKernel: using interpolation");
             return convolveWithInterpolation(convolvedImage, inImage, *refKernelPtr, convolutionControl);
         } else {
-            LOGL_DEBUG("TRACE2.afw.math.convolve.basicConvolve",
+            LOGL_DEBUG("TRACE2.lsst.afw.math.convolve.basicConvolve",
                        "basicConvolve for LinearCombinationKernel: maxInterpolationError < 0; using brute "
                        "force");
             return convolveWithBruteForce(convolvedImage, inImage, *refKernelPtr,
@@ -263,7 +263,7 @@ void basicConvolve(OutImageT& convolvedImage, InImageT const& inImage, math::Sep
     KernelVector kernelYVec(kernel.getHeight());
 
     if (kernel.isSpatiallyVarying()) {
-        LOGL_DEBUG("TRACE2.afw.math.convolve.basicConvolve",
+        LOGL_DEBUG("TRACE2.lsst.afw.math.convolve.basicConvolve",
                    "SeparableKernel basicConvolve: kernel is spatially varying");
 
         for (int cnvY = goodBBox.getMinY(); cnvY <= goodBBox.getMaxY(); ++cnvY) {
@@ -295,7 +295,7 @@ void basicConvolve(OutImageT& convolvedImage, InImageT const& inImage, math::Sep
         // This is circular buffer along y (to avoid shifting pixels before setting each new row);
         // so for each new row the kernel y vector is rotated to match the order of the x-convolved data.
 
-        LOGL_DEBUG("TRACE2.afw.math.convolve.basicConvolve",
+        LOGL_DEBUG("TRACE2.lsst.afw.math.convolve.basicConvolve",
                    "SeparableKernel basicConvolve: kernel is spatially invariant");
 
         kernel.computeVectors(kernelXVec, kernelYVec, convolutionControl.getDoNormalize());
@@ -383,7 +383,7 @@ void convolveWithBruteForce(OutImageT& convolvedImage, InImageT const& inImage, 
     KernelXYLocator const kernelLoc = kernelImage.xy_at(0, 0);
 
     if (kernel.isSpatiallyVarying()) {
-        LOGL_DEBUG("TRACE4.afw.math.convolve.convolveWithBruteForce",
+        LOGL_DEBUG("TRACE4.lsst.afw.math.convolve.convolveWithBruteForce",
                    "convolveWithBruteForce: kernel is spatially varying");
 
         for (int cnvY = cnvStartY; cnvY != cnvEndY; ++cnvY) {
@@ -402,7 +402,7 @@ void convolveWithBruteForce(OutImageT& convolvedImage, InImageT const& inImage, 
             }
         }
     } else {
-        LOGL_DEBUG("TRACE4.afw.math.convolve.convolveWithBruteForce",
+        LOGL_DEBUG("TRACE4.lsst.afw.math.convolve.convolveWithBruteForce",
                    "convolveWithBruteForce: kernel is spatially invariant");
 
         (void)kernel.computeImage(kernelImage, doNormalize);

--- a/src/math/detail/ConvolveWithInterpolation.cc
+++ b/src/math/detail/ConvolveWithInterpolation.cc
@@ -57,10 +57,10 @@ void convolveWithInterpolation(OutImageT &outImage, InImageT const &inImage, mat
     lsst::geom::Box2I goodBBox = kernel.shrinkBBox(fullBBox);
     KernelImagesForRegion goodRegion(KernelImagesForRegion(kernel.clone(), goodBBox, inImage.getXY0(),
                                                            convolutionControl.getDoNormalize()));
-    LOGL_DEBUG("TRACE5.afw.math.convolve.convolveWithInterpolation",
+    LOGL_DEBUG("TRACE5.lsst.afw.math.convolve.convolveWithInterpolation",
                "convolveWithInterpolation: full bbox minimum=(%d, %d), extent=(%d, %d)", fullBBox.getMinX(),
                fullBBox.getMinY(), fullBBox.getWidth(), fullBBox.getHeight());
-    LOGL_DEBUG("TRACE5.afw.math.convolve.convolveWithInterpolation",
+    LOGL_DEBUG("TRACE5.lsst.afw.math.convolve.convolveWithInterpolation",
                "convolveWithInterpolation: goodRegion bbox minimum=(%d, %d), extent=(%d, %d)",
                goodRegion.getBBox().getMinX(), goodRegion.getBBox().getMinY(),
                goodRegion.getBBox().getWidth(), goodRegion.getBBox().getHeight());
@@ -68,14 +68,14 @@ void convolveWithInterpolation(OutImageT &outImage, InImageT const &inImage, mat
     // divide good region into subregions small enough to interpolate over
     int nx = 1 + (goodBBox.getWidth() / convolutionControl.getMaxInterpolationDistance());
     int ny = 1 + (goodBBox.getHeight() / convolutionControl.getMaxInterpolationDistance());
-    LOGL_DEBUG("TRACE3.afw.math.convolve.convolveWithInterpolation",
+    LOGL_DEBUG("TRACE3.lsst.afw.math.convolve.convolveWithInterpolation",
                "convolveWithInterpolation: divide into %d x %d subregions", nx, ny);
 
     ConvolveWithInterpolationWorkingImages workingImages(kernel.getDimensions());
     RowOfKernelImagesForRegion regionRow(nx, ny);
     while (goodRegion.computeNextRow(regionRow)) {
         for (auto const &rgnIter : regionRow) {
-            LOGL_DEBUG("TRACE5.afw.math.convolve.convolveWithInterpolation",
+            LOGL_DEBUG("TRACE5.lsst.afw.math.convolve.convolveWithInterpolation",
                        "convolveWithInterpolation: bbox minimum=(%d, %d), extent=(%d, %d)",
                        rgnIter->getBBox().getMinX(), rgnIter->getBBox().getMinY(),
                        rgnIter->getBBox().getWidth(), rgnIter->getBBox().getHeight());

--- a/src/math/detail/KernelImagesForRegion.cc
+++ b/src/math/detail/KernelImagesForRegion.cc
@@ -48,7 +48,7 @@ KernelImagesForRegion::KernelImagesForRegion(KernelConstPtr kernelPtr, lsst::geo
     if (!_kernelPtr) {
         throw LSST_EXCEPT(pexExcept::InvalidParameterError, "kernelPtr is null");
     }
-    LOGL_DEBUG("TRACE5.afw.math.convolve.KernelImagesForRegion",
+    LOGL_DEBUG("TRACE5.lsst.afw.math.convolve.KernelImagesForRegion",
                "KernelImagesForRegion(bbox(minimum=(%d, %d), extent=(%d, %d)), xy0=(%d, %d), doNormalize=%d, "
                "images...)",
                _bbox.getMinX(), _bbox.getMinY(), _bbox.getWidth(), _bbox.getHeight(), _xy0[0], _xy0[1],
@@ -67,7 +67,7 @@ KernelImagesForRegion::KernelImagesForRegion(KernelConstPtr const kernelPtr, lss
     _insertImage(BOTTOM_RIGHT, bottomRightImagePtr);
     _insertImage(TOP_LEFT, topLeftImagePtr);
     _insertImage(TOP_RIGHT, topRightImagePtr);
-    LOGL_DEBUG("TRACE5.afw.math.convolve.KernelImagesForRegion",
+    LOGL_DEBUG("TRACE5.lsst.afw.math.convolve.KernelImagesForRegion",
                "KernelImagesForRegion(bbox(minimum=(%d, %d), extent=(%d, %d)), xy0=(%d, %d), doNormalize=%d, "
                "images...)",
                _bbox.getMinX(), _bbox.getMinY(), _bbox.getWidth(), _bbox.getHeight(), _xy0[0], _xy0[1],

--- a/src/math/minimize.cc
+++ b/src/math/minimize.cc
@@ -210,7 +210,7 @@ FitResults minimize(Function1<ReturnT> const &function, std::vector<double> cons
     fitResults.chiSq = min.Fval();
     fitResults.isValid = min.IsValid() && std::isfinite(fitResults.chiSq);
     if (!fitResults.isValid) {
-        LOGL_WARN("afw.math.minimize", "Fit failed to converge");
+        LOGL_WARN("lsst.afw.math.minimize", "Fit failed to converge");
     }
 
     for (unsigned int i = 0; i < nParameters; ++i) {
@@ -267,7 +267,7 @@ FitResults minimize(Function2<ReturnT> const &function, std::vector<double> cons
     fitResults.chiSq = min.Fval();
     fitResults.isValid = min.IsValid() && std::isfinite(fitResults.chiSq);
     if (!fitResults.isValid) {
-        LOGL_WARN("afw.math.minimize", "Fit failed to converge");
+        LOGL_WARN("lsst.afw.math.minimize", "Fit failed to converge");
     }
 
     for (unsigned int i = 0; i < nParameters; ++i) {

--- a/src/math/warpExposure.cc
+++ b/src/math/warpExposure.cc
@@ -485,14 +485,14 @@ int warpImage(DestImageT &destImage, SrcImageT const &srcImage,
     // Get the source MaskedImage and a pixel accessor to it.
     int const srcWidth = srcImage.getWidth();
     int const srcHeight = srcImage.getHeight();
-    LOGL_DEBUG("TRACE2.afw.math.warp", "source image width=%d; height=%d", srcWidth, srcHeight);
+    LOGL_DEBUG("TRACE2.lsst.afw.math.warp", "source image width=%d; height=%d", srcWidth, srcHeight);
 
     int const destWidth = destImage.getWidth();
     int const destHeight = destImage.getHeight();
-    LOGL_DEBUG("TRACE2.afw.math.warp", "remap image width=%d; height=%d", destWidth, destHeight);
+    LOGL_DEBUG("TRACE2.lsst.afw.math.warp", "remap image width=%d; height=%d", destWidth, destHeight);
 
     // Set each pixel of destExposure's MaskedImage
-    LOGL_DEBUG("TRACE3.afw.math.warp", "Remapping masked image");
+    LOGL_DEBUG("TRACE3.lsst.afw.math.warp", "Remapping masked image");
 
     int const maxCol = destWidth - 1;
     int const maxRow = destHeight - 1;

--- a/src/table/Match.cc
+++ b/src/table/Match.cc
@@ -455,7 +455,7 @@ template <typename Cat1, typename Cat2>
 std::vector<Match<typename Cat1::Record, typename Cat2::Record> > unpackMatches(BaseCatalog const &matches,
                                                                                 Cat1 const &first,
                                                                                 Cat2 const &second) {
-    LOG_LOGGER tableLog = LOG_GET("afw.table");
+    LOG_LOGGER tableLog = LOG_GET("lsst.afw.table");
     Key<RecordId> inKey1 = matches.getSchema()["first"];
     Key<RecordId> inKey2 = matches.getSchema()["second"];
     Key<double> keyD = matches.getSchema()["distance"];

--- a/src/table/Match.cc
+++ b/src/table/Match.cc
@@ -90,7 +90,7 @@ size_t makeRecordPositions(Cat const &cat, RecordPos<typename Cat::Record> *posi
     }
     std::sort(positions, positions + n);
     if (n < cat.size()) {
-        LOGLS_WARN("afw.table.matchRaDec", "At least one source had ra or dec equal to NaN");
+        LOGLS_WARN("lsst.afw.table.matchRaDec", "At least one source had ra or dec equal to NaN");
     }
     return n;
 }

--- a/src/table/io/FitsSchemaInputMapper.cc
+++ b/src/table/io/FitsSchemaInputMapper.cc
@@ -840,7 +840,7 @@ Schema FitsSchemaInputMapper::finalize() {
             if (reader) {
                 _impl->readers.push_back(std::move(reader));
             } else {
-                LOGLS_WARN("afw.FitsSchemaInputMapper", "Format " << iter->tform << " for column "
+                LOGLS_WARN("lsst.afw.FitsSchemaInputMapper", "Format " << iter->tform << " for column "
                                                                   << iter->ttype
                                                                   << " not supported; skipping.");
             }

--- a/tests/test_convolve.py
+++ b/tests/test_convolve.py
@@ -44,7 +44,7 @@ from lsst.log import Log
 
 import lsst.afw.display as afwDisplay
 
-Log.getLogger("afw.image.Mask").setLevel(Log.INFO)
+Log.getLogger("lsst.afw.image.Mask").setLevel(Log.INFO)
 afwDisplay.setDefaultMaskTransparency(75)
 
 try:

--- a/tests/test_exposure.py
+++ b/tests/test_exposure.py
@@ -44,7 +44,7 @@ from lsst.afw.cameraGeom.testUtils import DetectorWrapper
 from lsst.log import Log
 from testTableArchivesLib import DummyPsf
 
-Log.getLogger("afw.image.Mask").setLevel(Log.INFO)
+Log.getLogger("lsst.afw.image.Mask").setLevel(Log.INFO)
 
 try:
     dataDir = os.path.join(lsst.utils.getPackageDir("afwdata"), "data")

--- a/tests/test_heavyFootprint.py
+++ b/tests/test_heavyFootprint.py
@@ -41,7 +41,7 @@ import lsst.afw.geom as afwGeom
 import lsst.afw.display as afwDisplay
 from lsst.log import Log
 
-Log.getLogger("afw.image.Mask").setLevel(Log.INFO)
+Log.getLogger("lsst.afw.image.Mask").setLevel(Log.INFO)
 afwDisplay.setDefaultMaskTransparency(75)
 
 try:

--- a/tests/test_kernelImagesForRegion.py
+++ b/tests/test_kernelImagesForRegion.py
@@ -32,7 +32,7 @@ import lsst.afw.math.detail as mathDetail
 from lsst.log import Log
 
 # Change the level to Log.DEBUG to see debug messages
-Log.getLogger("TRACE5.afw.math.convolve").setLevel(Log.INFO)
+Log.getLogger("TRACE5.lsst.afw.math.convolve").setLevel(Log.INFO)
 
 LocNameDict = {
     mathDetail.KernelImagesForRegion.BOTTOM_LEFT: "BOTTOM_LEFT",

--- a/tests/test_kernelIo1.py
+++ b/tests/test_kernelIo1.py
@@ -33,7 +33,7 @@ import lsst.afw.math as afwMath
 from lsst.log import Log
 
 # Change the level to Log.DEBUG to see debug messages
-Log.getLogger("afw.math.KernelFormatter").setLevel(Log.INFO)
+Log.getLogger("lsst.afw.math.KernelFormatter").setLevel(Log.INFO)
 
 
 testPath = os.path.abspath(os.path.dirname(__file__))

--- a/tests/test_leastSquares.py
+++ b/tests/test_leastSquares.py
@@ -40,7 +40,7 @@ import lsst.pex.exceptions
 from lsst.afw.math import LeastSquares
 from lsst.log import Log
 
-Log.getLogger("afw.math.LeastSquares").setLevel(Log.DEBUG)
+Log.getLogger("lsst.afw.math.LeastSquares").setLevel(Log.DEBUG)
 
 
 class LeastSquaresTestCase(lsst.utils.tests.TestCase):

--- a/tests/test_scaledPlus.py
+++ b/tests/test_scaledPlus.py
@@ -28,7 +28,7 @@ import lsst.afw.image as afwImage
 import lsst.afw.math as afwMath
 from lsst.log import Log
 
-Log.getLogger("afw.image.Mask").setLevel(Log.INFO)
+Log.getLogger("lsst.afw.image.Mask").setLevel(Log.INFO)
 
 
 class ScaledPlus(lsst.utils.tests.TestCase):

--- a/tests/test_warpExposure.py
+++ b/tests/test_warpExposure.py
@@ -39,9 +39,9 @@ import lsst.afw.display as afwDisplay
 from lsst.log import Log
 
 # Change the level to Log.DEBUG to see debug messages
-Log.getLogger("afw.image.Mask").setLevel(Log.INFO)
-Log.getLogger("TRACE2.afw.math.warp").setLevel(Log.INFO)
-Log.getLogger("TRACE3.afw.math.warp").setLevel(Log.INFO)
+Log.getLogger("lsst.afw.image.Mask").setLevel(Log.INFO)
+Log.getLogger("TRACE2.lsst.afw.math.warp").setLevel(Log.INFO)
+Log.getLogger("TRACE3.lsst.afw.math.warp").setLevel(Log.INFO)
 
 afwDisplay.setDefaultMaskTransparency(75)
 

--- a/tests/test_warper.py
+++ b/tests/test_warper.py
@@ -33,9 +33,9 @@ import lsst.afw.math as afwMath
 from lsst.log import Log
 
 # Change the level to Log.DEBUG to see debug messages
-Log.getLogger("afw.image.Mask").setLevel(Log.INFO)
-Log.getLogger("TRACE3.afw.math.warp").setLevel(Log.INFO)
-Log.getLogger("TRACE4.afw.math.warp").setLevel(Log.INFO)
+Log.getLogger("lsst.afw.image.Mask").setLevel(Log.INFO)
+Log.getLogger("TRACE3.lsst.afw.math.warp").setLevel(Log.INFO)
+Log.getLogger("TRACE4.lsst.afw.math.warp").setLevel(Log.INFO)
 
 try:
     afwdataDir = lsst.utils.getPackageDir("afwdata")


### PR DESCRIPTION
Still uses `lsst.log`