### PR TITLE
DM-13943: Deprecate VisitInfo.getExposureId()

### DIFF
--- a/doc/lsst.afw.image/exposure-fits-metadata.rst
+++ b/doc/lsst.afw.image/exposure-fits-metadata.rst
@@ -37,7 +37,7 @@ HDU 0
    * - ``EXPID``
      - long int
      -
-     - `VisitInfo.getExposureId`
+     - `ExposureInfo.getId`
 
        Exposure ID.
 

--- a/include/lsst/afw/coord/Observatory.h
+++ b/include/lsst/afw/coord/Observatory.h
@@ -85,10 +85,17 @@ public:
     std::string toString() const;
 
     bool operator==(Observatory const& rhs) const noexcept {
-        auto deltaLongitude = (_latitude - rhs.getLatitude()).wrapCtr();
-        auto deltaLatitude = (_longitude - rhs.getLongitude()).wrapCtr();
+        // Observatory may be initialized to NaN values as a placeholder, or to indicate "unknown".
+        auto deltaLongitude = std::isnan(_latitude.asRadians()) && std::isnan(rhs._latitude.asRadians())
+                                      ? 0.0 * lsst::geom::degrees
+                                      : (_latitude - rhs._latitude).wrapCtr();
+        auto deltaLatitude = std::isnan(_longitude.asRadians()) && std::isnan(rhs._longitude.asRadians())
+                                     ? 0.0 * lsst::geom::degrees
+                                     : (_longitude - rhs._longitude).wrapCtr();
         return (deltaLongitude == 0.0 * lsst::geom::degrees) &&
-               (deltaLatitude == 0.0 * lsst::geom::degrees) && ((_elevation - rhs._elevation) == 0.0);
+               (deltaLatitude == 0.0 * lsst::geom::degrees) &&
+               ((std::isnan(_elevation) && std::isnan(rhs._elevation)) ||
+                (_elevation - rhs._elevation) == 0.0);
     }
     bool operator!=(Observatory const& rhs) const noexcept { return !(*this == rhs); }
 

--- a/include/lsst/afw/image/VisitInfo.h
+++ b/include/lsst/afw/image/VisitInfo.h
@@ -88,6 +88,7 @@ public:
      * @param[in] instrumentLabel  The short name of the instrument that took this data (e.g. "HSC")
      * @param[in] id  The identifier of this full focal plane data.
      */
+    // TODO: remove exposureId on DM-32138
     explicit VisitInfo(table::RecordId exposureId, double exposureTime, double darkTime,
                        daf::base::DateTime const &date, double ut1, lsst::geom::Angle const &era,
                        lsst::geom::SpherePoint const &boresightRaDec,
@@ -127,7 +128,14 @@ public:
     std::size_t hash_value() const noexcept override;
 
     /// get exposure ID
-    table::RecordId getExposureId() const { return _exposureId; }
+    // TODO: remove on DM-32138
+    [[deprecated(
+            "Replaced by VisitInfo::getId() for full focal plane identifiers and by "
+            "ExposureInfo::getId() for detector-level identifiers. Will be removed after v25.")]] table::
+            RecordId
+            getExposureId() const {
+        return _exposureId;
+    }
 
     /// get exposure duration (shutter open time); (sec)
     double getExposureTime() const { return _exposureTime; }
@@ -215,7 +223,7 @@ protected:
     void write(OutputArchiveHandle &handle) const override;
 
 private:
-    table::RecordId _exposureId;
+    table::RecordId _exposureId;  // TODO: remove on DM-32138
     double _exposureTime;
     double _darkTime;
     daf::base::DateTime _date;

--- a/python/lsst/afw/image/_visitInfo.cc
+++ b/python/lsst/afw/image/_visitInfo.cc
@@ -127,7 +127,7 @@ void declareVisitInfo(lsst::utils::python::WrapperCollection &wrappers) {
                 cls.def_property_readonly("instrumentLabel", &VisitInfo::getInstrumentLabel);
                 cls.def_property_readonly("id", &VisitInfo::getId);
 
-                utils::python::addOutputOp(cls, "__str__");
+                utils::python::addOutputOp(cls, "__repr__");
             });
 }
 void declareRotType(lsst::utils::python::WrapperCollection &wrappers) {

--- a/python/lsst/afw/image/_visitInfo.py
+++ b/python/lsst/afw/image/_visitInfo.py
@@ -18,17 +18,18 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-from ._imageLib import *
-from . import pixel
-from .image import *
-from .apCorrMap import *
-from .maskedImage import *
-from ._filter import *  # just here to support deprecation
-from ._visitInfo import *  # just here to support deprecation
-from .exposure import *
-from ._exposureInfoContinued import *
-from ._exposureSummaryStats import *
-from .basicUtils import *
-from .testUtils import *
+"""This file only exists to deprecate the Filter and FilterProperty classes.
+"""
 
-from ._exposureFitsReaderContinued import *  # just here to support deprecation
+from lsst.utils.deprecated import deprecate_pybind11
+from ._imageLib import VisitInfo
+
+
+__all__ = []
+
+
+VisitInfo.getExposureId = deprecate_pybind11(
+    VisitInfo.getExposureId,
+    reason="Replaced by VisitInfo.id for full focal plane identifiers and by ExposureInfo.id for "
+           "detector-level identifiers. Will be removed after v25.",
+    version="v24.0")

--- a/src/coord/Weather.cc
+++ b/src/coord/Weather.cc
@@ -22,6 +22,7 @@
  * see <http://www.lsstcorp.org/LegalNotices/>.
  */
 
+#include <cmath>
 #include <sstream>
 
 #include "lsst/utils/hashCombine.h"
@@ -38,8 +39,14 @@ Weather::Weather(double airTemperature, double airPressure, double humidity)
 }
 
 bool Weather::operator==(Weather const& other) const noexcept {
-    return (_airTemperature == other.getAirTemperature() && _airPressure == other.getAirPressure() &&
-            _humidity == other.getHumidity());
+    // Weather may be initialized to NaN values as a placeholder, or to indicate "unknown".
+    bool tempMatch = (std::isnan(_airTemperature) && std::isnan(other.getAirTemperature())) ||
+                     _airTemperature == other.getAirTemperature();
+    bool presMatch = (std::isnan(_airPressure) && std::isnan(other.getAirPressure())) ||
+                     _airPressure == other.getAirPressure();
+    bool humiMatch =
+            (std::isnan(_humidity) && std::isnan(other.getHumidity())) || _humidity == other.getHumidity();
+    return (tempMatch && presMatch && humiMatch);
 }
 
 std::size_t Weather::hash_value() const noexcept {

--- a/src/image/VisitInfo.cc
+++ b/src/image/VisitInfo.cc
@@ -472,12 +472,32 @@ VisitInfo::VisitInfo(daf::base::PropertySet const& metadata)
     }
 }
 
+/**
+ * Test whether two numbers are exactly equal or both NaN.
+ *
+ * This function is exactly equivalent to `operator==(double, double)`, except
+ * that NaNs compare equal (NaNs of different values also compare equal).
+ */
+bool _eqOrNan(double lhs, double rhs) noexcept { return (std::isnan(lhs) && std::isnan(rhs)) || lhs == rhs; }
+
+/**
+ * Test whether two SpherePoints are exactly equal or invalid.
+ *
+ * This function is needed because SpherePoint::operation== is specifically
+ * designed to be ill-behaved when NaN values are involved.
+ */
+bool _eqOrNonFinite(lsst::geom::SpherePoint const& lhs, lsst::geom::SpherePoint const& rhs) noexcept {
+    return (!lhs.isFinite() && !rhs.isFinite()) || lhs == rhs;
+}
+
 bool VisitInfo::operator==(VisitInfo const& other) const {
-    return _exposureId == other.getExposureId() && _exposureTime == other.getExposureTime() &&
-           _darkTime == other.getDarkTime() && _date == other.getDate() && _ut1 == other.getUt1() &&
-           _era == other.getEra() && _boresightRaDec == other.getBoresightRaDec() &&
-           _boresightAzAlt == other.getBoresightAzAlt() && _boresightAirmass == other.getBoresightAirmass() &&
-           _boresightRotAngle == other.getBoresightRotAngle() && _rotType == other.getRotType() &&
+    return _exposureId == other.getExposureId() && _eqOrNan(_exposureTime, other.getExposureTime()) &&
+           _eqOrNan(_darkTime, other.getDarkTime()) && _date == other.getDate() &&
+           _eqOrNan(_ut1, other.getUt1()) && _eqOrNan(_era, other.getEra()) &&
+           _eqOrNonFinite(_boresightRaDec, other.getBoresightRaDec()) &&
+           _eqOrNonFinite(_boresightAzAlt, other.getBoresightAzAlt()) &&
+           _eqOrNan(_boresightAirmass, other.getBoresightAirmass()) &&
+           _eqOrNan(_boresightRotAngle, other.getBoresightRotAngle()) && _rotType == other.getRotType() &&
            _observatory == other.getObservatory() && _weather == other.getWeather() &&
            _instrumentLabel == other.getInstrumentLabel() && _id == other.getId();
 }

--- a/src/image/VisitInfo.cc
+++ b/src/image/VisitInfo.cc
@@ -554,7 +554,8 @@ std::string VisitInfo::toString() const {
     buffer << "exposureId=" << getExposureId() << ", ";
     buffer << "exposureTime=" << getExposureTime() << ", ";
     buffer << "darkTime=" << getDarkTime() << ", ";
-    buffer << "date=" << getDate().toString(daf::base::DateTime::TAI) << ", ";
+    buffer << "date=" << (getDate().isValid() ? getDate().toString(daf::base::DateTime::TAI) : "<invalid>")
+           << ", ";
     buffer << "UT1=" << getUt1() << ", ";
     buffer << "ERA=" << getEra() << ", ";
     buffer << "boresightRaDec=" << getBoresightRaDec() << ", ";

--- a/tests/test_exposure.py
+++ b/tests/test_exposure.py
@@ -928,7 +928,8 @@ class ExposureInfoTestCase(lsst.utils.tests.TestCase):
 
         self.assertFalse(self.exposureInfo.hasId())
         self.assertIsNone(self.exposureInfo.getId())
-        self.assertEqual(self.exposureInfo.getVisitInfo().getExposureId(), 0)
+        with self.assertWarns(FutureWarning):
+            self.assertEqual(self.exposureInfo.getVisitInfo().getExposureId(), 0)
         self.assertIsNone(self.exposureInfo.id)
 
         self.exposureInfo.setId(self.exposureId)
@@ -936,7 +937,8 @@ class ExposureInfoTestCase(lsst.utils.tests.TestCase):
         self.assertIsNotNone(self.exposureInfo.getId())
         self.assertIsNotNone(self.exposureInfo.id)
         self.assertEqual(self.exposureInfo.getId(), self.exposureId)
-        self.assertEqual(self.exposureInfo.getVisitInfo().getExposureId(), self.exposureId)
+        with self.assertWarns(FutureWarning):
+            self.assertEqual(self.exposureInfo.getVisitInfo().getExposureId(), self.exposureId)
         self.assertEqual(self.exposureInfo.id, self.exposureId)
 
         self.exposureInfo.id = 99899
@@ -1002,7 +1004,8 @@ class ExposureNoAfwdataTestCase(lsst.utils.tests.TestCase):
         self.assertMaskedImagesEqual(exposure.maskedImage, self.maskedImage)
 
         self.assertEqual(exposure.info.id, self.exposureId)
-        self.assertEqual(exposure.info.getVisitInfo().getExposureId(), self.exposureId)
+        with self.assertWarns(FutureWarning):
+            self.assertEqual(exposure.info.getVisitInfo().getExposureId(), self.exposureId)
         self.assertEqual(exposure.getPhotoCalib(), self.v0PhotoCalib)
         self.assertEqual(exposure.getFilterLabel(), self.v1FilterLabel)
 
@@ -1017,7 +1020,8 @@ class ExposureNoAfwdataTestCase(lsst.utils.tests.TestCase):
         self.assertMaskedImagesEqual(exposure.maskedImage, self.maskedImage)
 
         self.assertEqual(exposure.info.id, self.exposureId)
-        self.assertEqual(exposure.info.getVisitInfo().getExposureId(), self.exposureId)
+        with self.assertWarns(FutureWarning):
+            self.assertEqual(exposure.info.getVisitInfo().getExposureId(), self.exposureId)
         self.assertEqual(exposure.getPhotoCalib(), self.v0PhotoCalib)
         self.assertEqual(exposure.getFilterLabel(), self.v1FilterLabel)
 
@@ -1036,7 +1040,8 @@ class ExposureNoAfwdataTestCase(lsst.utils.tests.TestCase):
         self.assertMaskedImagesEqual(exposure.maskedImage, self.maskedImage)
 
         self.assertEqual(exposure.info.id, self.exposureId)
-        self.assertEqual(exposure.info.getVisitInfo().getExposureId(), self.exposureId)
+        with self.assertWarns(FutureWarning):
+            self.assertEqual(exposure.info.getVisitInfo().getExposureId(), self.exposureId)
         self.assertEqual(exposure.getPhotoCalib(), self.v1PhotoCalib)
         self.assertEqual(exposure.getFilterLabel(), self.v1FilterLabel)
 
@@ -1055,7 +1060,8 @@ class ExposureNoAfwdataTestCase(lsst.utils.tests.TestCase):
         self.assertMaskedImagesEqual(exposure.maskedImage, self.maskedImage)
 
         self.assertEqual(exposure.info.id, self.exposureId)
-        self.assertEqual(exposure.info.getVisitInfo().getExposureId(), self.exposureId)
+        with self.assertWarns(FutureWarning):
+            self.assertEqual(exposure.info.getVisitInfo().getExposureId(), self.exposureId)
         self.assertEqual(exposure.getPhotoCalib(), self.v1PhotoCalib)
         self.assertEqual(exposure.getFilterLabel(), self.v2FilterLabel)
 

--- a/tests/test_visitInfo.py
+++ b/tests/test_visitInfo.py
@@ -143,7 +143,8 @@ class VisitInfoTestCase(lsst.utils.tests.TestCase):
 
     def _testValueConstructor(self, data, localEra, hourAngle):
         visitInfo = makeVisitInfo(data)
-        self.assertEqual(visitInfo.getExposureId(), data.exposureId)
+        with self.assertWarns(FutureWarning):
+            self.assertEqual(visitInfo.getExposureId(), data.exposureId)
         self.assertEqual(visitInfo.getExposureTime(), data.exposureTime)
         self.assertEqual(visitInfo.getDarkTime(), data.darkTime)
         self.assertEqual(visitInfo.getDate(), data.date)
@@ -219,7 +220,8 @@ class VisitInfoTestCase(lsst.utils.tests.TestCase):
         visitInfo = afwImage.VisitInfo.readFits(filePath)
 
         if version >= 0:
-            self.assertEqual(visitInfo.getExposureId(), data.exposureId)
+            with self.assertWarns(FutureWarning):
+                self.assertEqual(visitInfo.getExposureId(), data.exposureId)
             self.assertEqual(visitInfo.getExposureTime(), data.exposureTime)
             self.assertEqual(visitInfo.getDarkTime(), data.darkTime)
             self.assertEqual(visitInfo.getDate(), data.date)
@@ -321,7 +323,8 @@ class VisitInfoTestCase(lsst.utils.tests.TestCase):
     def _testIsEmpty(self, visitInfo):
         """Test that visitInfo is all NaN, 0, or empty string, as appropriate.
         """
-        self.assertEqual(visitInfo.getExposureId(), 0)
+        with self.assertWarns(FutureWarning):
+            self.assertEqual(visitInfo.getExposureId(), 0)
         self.assertTrue(math.isnan(visitInfo.getExposureTime()))
         self.assertTrue(math.isnan(visitInfo.getDarkTime()))
         self.assertEqual(visitInfo.getDate(), DateTime())
@@ -361,7 +364,8 @@ class VisitInfoTestCase(lsst.utils.tests.TestCase):
 
         metadata = propertySetFromDict({"EXPID": data.exposureId})
         visitInfo = afwImage.VisitInfo(metadata)
-        self.assertEqual(visitInfo.getExposureId(), data.exposureId)
+        with self.assertWarns(FutureWarning):
+            self.assertEqual(visitInfo.getExposureId(), data.exposureId)
         self.assertTrue(math.isnan(visitInfo.getExposureTime()))
 
         metadata = propertySetFromDict({"EXPTIME": data.exposureTime})
@@ -492,7 +496,8 @@ class VisitInfoTestCase(lsst.utils.tests.TestCase):
         self._testIsEmpty(visitInfo)
 
         visitInfo = afwImage.VisitInfo(exposureId=data.exposureId)
-        self.assertEqual(visitInfo.getExposureId(), data.exposureId)
+        with self.assertWarns(FutureWarning):
+            self.assertEqual(visitInfo.getExposureId(), data.exposureId)
         self.assertTrue(math.isnan(visitInfo.getExposureTime()))
 
         visitInfo = afwImage.VisitInfo(exposureTime=data.exposureTime)

--- a/tests/test_visitInfo.py
+++ b/tests/test_visitInfo.py
@@ -351,6 +351,25 @@ class VisitInfoTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(visitInfo.getInstrumentLabel(), "")
         self.assertEqual(visitInfo.getId(), 0)
 
+    def testEquals(self):
+        """Test that identical VisitInfo objects compare equal, even if some fields are NaN.
+        """
+        # objects with "equal state" should be equal
+        self.assertEqual(makeVisitInfo(self.data1), makeVisitInfo(self.data1))
+        self.assertEqual(makeVisitInfo(self.data2), makeVisitInfo(self.data2))
+        self.assertNotEqual(makeVisitInfo(self.data1), makeVisitInfo(self.data2))
+        self.assertEqual(afwImage.VisitInfo(), afwImage.VisitInfo())
+
+        # equality must be reflexive
+        info = makeVisitInfo(self.data1)
+        self.assertEqual(info, info)
+        info = makeVisitInfo(self.data2)
+        self.assertEqual(info, info)
+        info = afwImage.VisitInfo()
+        self.assertEqual(info, info)
+
+        # commutativity and transitivity difficult to test with this setup
+
     def testMetadataConstructor(self):
         """Test the metadata constructor
 

--- a/tests/test_visitInfo.py
+++ b/tests/test_visitInfo.py
@@ -575,6 +575,9 @@ class VisitInfoTestCase(lsst.utils.tests.TestCase):
         self.assertIn("darkTime=11.02", string)
         self.assertIn("rotType=1", string)
 
+        # Check that it at least doesn't throw
+        str(afwImage.VisitInfo())
+
     def testParallacticAngle(self):
         """Check that we get the same precomputed values for parallactic angle."""
         parallacticAngle = [141.39684140703142*degrees, 76.99982166973487*degrees]

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -24,6 +24,8 @@ Tests for lsst.afw.image.Weather
 """
 import unittest
 
+import numpy as np
+
 import lsst.utils.tests
 import lsst.pex.exceptions
 from lsst.afw.coord import Weather
@@ -60,6 +62,22 @@ class WeatherTestCase(unittest.TestCase):
         for humidity in (-1, -0.0001):
             with self.assertRaises(lsst.pex.exceptions.InvalidParameterError):
                 Weather(1.1, 2.2, humidity)
+
+    def testEquals(self):
+        weather1 = Weather(1.1, 100.1, 10.1)
+        weather2 = Weather(2.2, 200.2, 0.0)
+        weather3 = Weather(np.nan, np.nan, np.nan)
+
+        # objects with "same" values should be equal
+        self.assertEqual(Weather(1.1, 100.1, 10.1), Weather(1.1, 100.1, 10.1))
+        self.assertEqual(Weather(np.nan, np.nan, np.nan), Weather(np.nan, np.nan, np.nan))
+        self.assertNotEqual(weather1, weather2)
+        self.assertNotEqual(weather3, weather2)
+
+        # equality must be reflexive
+        self.assertEqual(weather1, weather1)
+        self.assertEqual(weather2, weather2)
+        self.assertEqual(weather3, weather3)
 
 
 def setup_module(module):


### PR DESCRIPTION
This PR adds C++ and Python deprecation warnings to `VisitInfo.getExposureId`, removes internal use of that method aside from tests of `VisitInfo` itself, and fixes some bugs in `VisitInfo` (in particular, a broken implementation of `operator==`; as in lsst/geom#35, simply banning NaN values is not an option) that were interfering with lsst/obs_base#396.