### PR TITLE
DM-32414: fix missing wrapper for ExposureFitsReader::readExposureId

### DIFF
--- a/python/lsst/afw/image/_readers.cc
+++ b/python/lsst/afw/image/_readers.cc
@@ -22,6 +22,7 @@
  */
 
 #include "pybind11/pybind11.h"
+#include "pybind11/stl.h"
 #include "lsst/utils/python.h"
 
 #include "ndarray/pybind11.h"
@@ -283,6 +284,7 @@ void declareExposureFitsReader(lsst::utils::python::WrapperCollection &wrappers)
         declareCommonMethods(cls);
         declareMultiPlaneMethods(cls);
         cls.def("readSerializationVersion", &ExposureFitsReader::readSerializationVersion);
+        cls.def("readExposureId", &ExposureFitsReader::readExposureId);
         cls.def("readMetadata", &ExposureFitsReader::readMetadata);
         cls.def("readWcs", &ExposureFitsReader::readWcs);
         cls.def("readFilter", &ExposureFitsReader::readFilter);

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -192,6 +192,7 @@ class FitsReaderTestCase(lsst.utils.tests.TestCase):
         self.assertIn('EXTNAME', reader.readMetadata().toDict(), "EXTNAME is added upon writing")
         reader.readMetadata().remove('EXTNAME')
         self.assertGreaterEqual(reader.readSerializationVersion(), 0)
+        self.assertEqual(exposureIn.info.id, reader.readExposureId())
         self.assertEqual(exposureIn.getMetadata().toDict(), reader.readMetadata().toDict())
         self.assertWcsAlmostEqualOverBBox(exposureIn.getWcs(), reader.readWcs(), self.bbox,
                                           maxDiffPix=0, maxDiffSky=0*degrees)


### PR DESCRIPTION
This PR adds a pybind11 wrapper for the `ExposureFitsReader::readExposureId` method added on #613. This is necessary for correct execution of the tests on lsst/obs_base#398.