### PR TITLE
DM-30229: Add convenience methods to get PSF shape quantities

### DIFF
--- a/python/lsst/afw/cameraGeom/_camera.py
+++ b/python/lsst/afw/cameraGeom/_camera.py
@@ -26,7 +26,7 @@ from lsst.utils import continueClass, doImport
 from ._cameraGeom import Camera, FOCAL_PLANE
 
 
-@continueClass  # noqa: F811 (FIXME: remove for py 3.8+)
+@continueClass
 class Camera:  # noqa: F811
 
     def getPupilFactory(self, visitInfo, pupilSize, npix, **kwargs):

--- a/python/lsst/afw/cameraGeom/_detector.py
+++ b/python/lsst/afw/cameraGeom/_detector.py
@@ -35,7 +35,7 @@ DetectorTypeNameValDict = {val: key for key, val in
                            DetectorTypeValNameDict.items()}
 
 
-@continueClass  # noqa: F811 (FIXME: remove for py 3.8+)
+@continueClass
 class DetectorBase:  # noqa: F811
     def __iter__(self):
         return (self[i] for i in range(len(self)))

--- a/python/lsst/afw/detection/_footprintMerge.py
+++ b/python/lsst/afw/detection/_footprintMerge.py
@@ -25,7 +25,7 @@ from lsst.utils import continueClass
 from ._detection import FootprintMergeList
 
 
-@continueClass  # noqa: F811 (FIXME: remove for py 3.8+)
+@continueClass
 class FootprintMergeList:  # noqa: F811
     def getMergedSourceCatalog(self, catalogs, filters,
                                peakDist, schema, idFactory, samePeakDist):

--- a/python/lsst/afw/fits/_fitsContinued.py
+++ b/python/lsst/afw/fits/_fitsContinued.py
@@ -26,7 +26,7 @@ from ._fits import (Fits, ImageWriteOptions, ImageCompressionOptions, ImageScali
                     compressionAlgorithmToString, scalingAlgorithmToString)
 
 
-@continueClass  # noqa: F811 (FIXME: remove for py 3.8+)
+@continueClass
 class Fits:  # noqa: F811
     def __enter__(self):
         return self
@@ -35,20 +35,20 @@ class Fits:  # noqa: F811
         self.closeFile()
 
 
-@continueClass  # noqa: F811 (FIXME: remove for py 3.8+)
+@continueClass
 class ImageWriteOptions:  # noqa: F811
     def __repr__(self):
         return f"{self.__class__.__name__}(compression={self.compression!r}, scaling={self.scaling!r})"
 
 
-@continueClass  # noqa: F811 (FIXME: remove for py 3.8+)
+@continueClass
 class ImageCompressionOptions:  # noqa: F811
     def __repr__(self):
         return (f"{self.__class__.__name__}(algorithm={compressionAlgorithmToString(self.algorithm)!r}, "
                 f"tiles={self.tiles.tolist()!r}, quantizeLevel={self.quantizeLevel:f})")
 
 
-@continueClass  # noqa: F811 (FIXME: remove for py 3.8+)
+@continueClass
 class ImageScalingOptions:  # noqa: F811
     def __repr__(self):
         return (f"{self.__class__.__name__}(algorithm={scalingAlgorithmToString(self.algorithm)!r}, "

--- a/python/lsst/afw/geom/ellipses/_axes.py
+++ b/python/lsst/afw/geom/ellipses/_axes.py
@@ -4,7 +4,7 @@ from lsst.utils import continueClass
 from ._ellipses import Axes
 
 
-@continueClass  # noqa: F811 (FIXME: remove for py 3.8+)
+@continueClass
 class Axes:  # noqa: F811
     def __repr__(self):
         return f"Axes(a={self.getA()!r}, b={self.getB()!r}, theta={self.getTheta()!r})"

--- a/python/lsst/afw/geom/ellipses/_ellipse.py
+++ b/python/lsst/afw/geom/ellipses/_ellipse.py
@@ -4,7 +4,7 @@ from lsst.utils import continueClass
 from ._ellipses import Ellipse
 
 
-@continueClass  # noqa: F811 (FIXME: remove for py 3.8+)
+@continueClass
 class Ellipse:  # noqa: F811
     def __repr__(self):
         return f"Ellipse({self.getCore()!r}, {self.getCenter()!r})"

--- a/python/lsst/afw/geom/ellipses/_quadrupole.py
+++ b/python/lsst/afw/geom/ellipses/_quadrupole.py
@@ -4,7 +4,7 @@ from lsst.utils import continueClass
 from ._ellipses import Quadrupole
 
 
-@continueClass  # noqa: F811 (FIXME: remove for py 3.8+)
+@continueClass
 class Quadrupole:  # noqa: F811
     def __repr__(self):
         return f"Quadrupole(ixx={self.getIxx()!r}, iyy={self.getIyy()!r}, ixy={self.getIxy()!r})"

--- a/python/lsst/afw/geom/polygon.py
+++ b/python/lsst/afw/geom/polygon.py
@@ -25,7 +25,7 @@ from lsst.utils import continueClass
 from ._geom import Polygon
 
 
-@continueClass  # noqa: F811 (FIXME: remove for py 3.8+)
+@continueClass
 class Polygon:  # noqa: F811
     def __repr__(self):
         return f"{self.__class__.__name__}({[p for p in self.getVertices()]})"

--- a/python/lsst/afw/image/apCorrMap/_apCorrMapContinued.py
+++ b/python/lsst/afw/image/apCorrMap/_apCorrMapContinued.py
@@ -24,7 +24,7 @@ from ._apCorrMap import ApCorrMap
 __all__ = ['ApCorrMap']
 
 
-@continueClass  # noqa: F811 (FIXME: remove for py 3.8+)
+@continueClass
 class ApCorrMap:  # noqa: F811
 
     def keys(self):

--- a/python/lsst/afw/math/_background.py
+++ b/python/lsst/afw/math/_background.py
@@ -25,7 +25,7 @@ from ._math import Background
 __all__ = []  # import this module only for its side effects
 
 
-@continueClass  # noqa: F811 (FIXME: remove for py 3.8+)
+@continueClass
 class Background:  # noqa: F811
     def __reduce__(self):
         """Pickling"""

--- a/python/lsst/afw/math/_chebyshevBoundedField.py
+++ b/python/lsst/afw/math/_chebyshevBoundedField.py
@@ -27,7 +27,7 @@ from ._math import ChebyshevBoundedField, ChebyshevBoundedFieldControl
 __all__ = []  # import this module only for its side effects
 
 
-@continueClass  # noqa: F811 (FIXME: remove for py 3.8+)
+@continueClass
 class ChebyshevBoundedField:  # noqa: F811
     @classmethod
     def approximate(cls, boundedField,

--- a/python/lsst/afw/table/_aliasMap.py
+++ b/python/lsst/afw/table/_aliasMap.py
@@ -25,7 +25,7 @@ from lsst.utils import continueClass
 from ._table import AliasMap
 
 
-@continueClass  # noqa: F811 (FIXME: remove for py 3.8+)
+@continueClass
 class AliasMap:  # noqa: F811
 
     def keys(self):

--- a/python/lsst/afw/table/_base.py
+++ b/python/lsst/afw/table/_base.py
@@ -28,7 +28,7 @@ from ._schema import Key
 __all__ = ["Catalog"]
 
 
-@continueClass  # noqa: F811 (FIXME: remove for py 3.8+)
+@continueClass
 class BaseRecord:  # noqa: F811
 
     def extract(self, *patterns, **kwargs):

--- a/python/lsst/afw/table/_baseColumnView.py
+++ b/python/lsst/afw/table/_baseColumnView.py
@@ -31,7 +31,7 @@ from ._table import KeyFlag, _BaseColumnViewBase
 # base class, so we use the same naming convention we use for those.
 
 
-@continueClass  # noqa: F811 (FIXME: remove for py 3.8+)
+@continueClass
 class _BaseColumnViewBase:  # noqa: F811
 
     def getBits(self, keys=None):

--- a/python/lsst/afw/table/_schema.py
+++ b/python/lsst/afw/table/_schema.py
@@ -87,7 +87,7 @@ Field.alias(float, _Field["D"])
 SchemaItem.alias(float, _SchemaItem["D"])
 
 
-@continueClass  # noqa: F811 (FIXME: remove for py 3.8+)
+@continueClass
 class Schema:  # noqa: F811
 
     def getOrderedNames(self):

--- a/python/lsst/afw/table/_schemaMapper.py
+++ b/python/lsst/afw/table/_schemaMapper.py
@@ -28,7 +28,7 @@ from ._schema import Field, Schema
 from ._table import SchemaMapper
 
 
-@continueClass  # noqa: F811 (FIXME: remove for py 3.8+)
+@continueClass
 class SchemaMapper:  # noqa: F811
 
     def addOutputField(self, field, type=None, doc=None, units="", size=None,

--- a/python/lsst/afw/typehandling/_SimpleGenericMap.py
+++ b/python/lsst/afw/typehandling/_SimpleGenericMap.py
@@ -67,7 +67,7 @@ SimpleGenericMap.register(str, SimpleGenericMapS)
 _oldInit = SimpleGenericMapS.__init__
 
 
-@continueClass  # noqa: F811 (FIXME: remove for py 3.8+)
+@continueClass
 class SimpleGenericMapS:  # noqa: F811
     def __init__(self, source=None, **kwargs):
         _oldInit(self)


### PR DESCRIPTION
This ticket implements pure-Python methods to get PSF shapes as a `Quadrupole` object and to get the individual components of the moments and flag. Methods to get PSF shape errors and `isValid` are not implemented.