### PR TITLE
DM-27106: Add array-based operations to simple photoCalib routines.

### DIFF
--- a/include/lsst/afw/image/PhotoCalib.h
+++ b/include/lsst/afw/image/PhotoCalib.h
@@ -418,6 +418,13 @@ public:
     double getCalibrationErr() const { return _calibrationErr; }
 
     /**
+     * Is this photoCalib spatially constant?
+     *
+     * @returns    Is the calibration spatially constant?
+     */
+    bool isConstant() const { return _isConstant; }
+
+    /**
      * Get the magnitude zero point (the instrumental flux corresponding to 0 magnitude).
      *
      * This value is defined such that:

--- a/python/lsst/afw/image/__init__.py
+++ b/python/lsst/afw/image/__init__.py
@@ -30,5 +30,6 @@ from ._exposureInfoContinued import *
 from ._exposureSummaryStats import *
 from .basicUtils import *
 from .testUtils import *
+from ._photoCalibContinued import *
 
 from ._exposureFitsReaderContinued import *  # just here to support deprecation

--- a/python/lsst/afw/image/_photoCalib.cc
+++ b/python/lsst/afw/image/_photoCalib.cc
@@ -162,6 +162,7 @@ void declarePhotoCalib(lsst::utils::python::WrapperCollection &wrappers) {
                 /* utilities */
                 cls.def("getCalibrationMean", &PhotoCalib::getCalibrationMean);
                 cls.def("getCalibrationErr", &PhotoCalib::getCalibrationErr);
+                cls.def_property_readonly("_isConstant", &PhotoCalib::isConstant);
                 cls.def("getInstFluxAtZeroMagnitude", &PhotoCalib::getInstFluxAtZeroMagnitude);
                 cls.def("getLocalCalibration", &PhotoCalib::getLocalCalibration, "point"_a);
 

--- a/python/lsst/afw/image/_photoCalibContinued.py
+++ b/python/lsst/afw/image/_photoCalibContinued.py
@@ -1,0 +1,103 @@
+# This file is part of afw.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = ["PhotoCalib"]
+
+import numpy as np
+from astropy import units
+
+from lsst.utils import continueClass
+
+from ._imageLib import PhotoCalib
+
+
+@continueClass
+class PhotoCalib:  # noqa: F811
+    def getLocalCalibrationArray(self, x, y):
+        """Get the local calibration values (nJy/counts) for numpy arrays (pixels).
+
+        Parameters
+        ----------
+        x : `np.ndarray` (N,)
+            Array of x values (pixels).
+        y : `np.ndarray` (N,)
+            Array of y values (pixels).
+
+        Returns
+        -------
+        localCalibration : `np.ndarray` (N,)
+            Array of local calibration values (nJy/counts).
+        """
+        if self._isConstant:
+            return np.full(len(x), self.getCalibrationMean())
+        else:
+            bf = self.computeScaledCalibration()
+            return self.getCalibrationMean()*bf.evaluate(x, y)
+
+    def instFluxToMagnitudeArray(self, instFluxes, x, y):
+        """Convert instFlux (counts) to magnitudes for numpy arrays (pixels).
+
+        Parameters
+        ----------
+        instFluxes : `np.ndarray` (N,)
+            Array of instFluxes to convert (counts).
+        x : `np.ndarray` (N,)
+            Array of x values (pixels).
+        y : `np.ndarray` (N,)
+            Array of y values (pixels).
+
+        Returns
+        -------
+        magnitudes : `astropy.units.Magnitude` (N,)
+            Array of AB magnitudes.
+        """
+        scale = self.getLocalCalibrationArray(x, y)
+        nanoJansky = (instFluxes*scale)*units.nJy
+
+        return nanoJansky.to(units.ABmag)
+
+    def magnitudeToInstFluxArray(self, magnitudes, x, y):
+        """Convert magnitudes to instFlux (counts) for numpy arrays (pixels).
+
+        Parameters
+        ----------
+        magnitudes : `np.ndarray` or `astropy.units.Magnitude` (N,)
+            Array of AB magnitudes.
+        x : `np.ndarray` (N,)
+            Array of x values (pixels).
+        y : `np.ndarray` (N,)
+            Array of y values (pixels).
+
+        Returns
+        -------
+        instFluxes : `np.ndarray` (N,)
+            Array of instFluxes (counts).
+        """
+        scale = self.getLocalCalibrationArray(x, y)
+
+        if not isinstance(magnitudes, units.Magnitude):
+            _magnitudes = magnitudes*units.ABmag
+        else:
+            _magnitudes = magnitudes
+
+        nanoJansky = _magnitudes.to(units.nJy).value
+
+        return nanoJansky/scale

--- a/tests/test_photoCalib.py
+++ b/tests/test_photoCalib.py
@@ -325,6 +325,9 @@ class PhotoCalibTestCase(lsst.utils.tests.TestCase):
         photoCalib = lsst.afw.image.PhotoCalib(self.calibration)
         self._testPhotoCalibCenter(photoCalib, 0)
 
+        # Test _isConstant
+        self.assertTrue(photoCalib._isConstant)
+
         # test on positions off the center (position should not matter)
         self.assertEqual(self.flux1, photoCalib.instFluxToNanojansky(self.instFlux1, self.pointXShift))
         self.assertEqual(self.mag1, photoCalib.instFluxToMagnitude(self.instFlux1, self.pointXShift))
@@ -354,6 +357,9 @@ class PhotoCalibTestCase(lsst.utils.tests.TestCase):
         # test converting to a photoCalib
         photoCalib = lsst.afw.image.PhotoCalib(self.constantCalibration, self.calibrationErr)
         self._testPhotoCalibCenter(photoCalib, self.calibrationErr)
+
+        # test _isConstant (bounded field is not constant)
+        self.assertFalse(photoCalib._isConstant)
 
     def testLinearXBoundedField(self):
         photoCalib = lsst.afw.image.PhotoCalib(self.linearXCalibration)


### PR DESCRIPTION
This also adds a property to know if the given photoCalib is constant (spatially-varying) or not.