### PR TITLE
DM-22823: Remove accidental Doxygen comments for namespaces

### DIFF
--- a/include/lsst/afw/image/Defect.h
+++ b/include/lsst/afw/image/Defect.h
@@ -24,9 +24,7 @@
 
 #if !defined(LSST_AFW_IMAGE_DEFECT_H)
 #define LSST_AFW_IMAGE_DEFECT_H
-/**
- * A base class for image defects
- */
+
 #include <limits>
 #include <vector>
 #include "lsst/geom.h"

--- a/include/lsst/afw/math/IntGKPData10.h
+++ b/include/lsst/afw/math/IntGKPData10.h
@@ -25,7 +25,7 @@
 #if !defined(LSST_AFW_MATH_INTGKPDATA10_H)
 #define LSST_AFW_MATH_INTGKPDATA10_H 1
 
-/**
+/*
  *  Numeric constants used by the Integrate.h integrator routines.
  *
  * @note Gauss-Kronrod-Patterson quadrature coefficients for use in

--- a/include/lsst/afw/math/Statistics.h
+++ b/include/lsst/afw/math/Statistics.h
@@ -24,15 +24,6 @@
 
 #if !defined(LSST_AFW_MATH_STATISTICS_H)
 #define LSST_AFW_MATH_STATISTICS_H
-/**
- * Compute Image Statistics
- *
- * @note The Statistics class itself can only handle lsst::afw::image::MaskedImage() types.
- *       The philosophy has been to handle other types by making them look like
- *       lsst::afw::image::MaskedImage() and reusing that code.
- *       Users should have no need to instantiate a Statistics object directly,
- *       but should use the overloaded makeStatistics() factory functions.
- */
 
 #include <algorithm>
 #include <cassert>
@@ -203,6 +194,11 @@ private:
  *      double const meanError = statobj.getError(lsst::afw::math::MEAN);                // just the error
  *
  *
+ * @note The Statistics class itself can only handle lsst::afw::image::MaskedImage() types.
+ *       The philosophy has been to handle other types by making them look like
+ *       lsst::afw::image::MaskedImage() and reusing that code.
+ *       Users should have no need to instantiate a Statistics object directly,
+ *       but should use the overloaded makeStatistics() factory functions.
  * @note Factory function: We used a helper function, `makeStatistics`, rather that the constructor
  *       directly so that the compiler could deduce the types -- cf. `std::make_pair()`
  *

--- a/src/cameraGeom/Detector.cc
+++ b/src/cameraGeom/Detector.cc
@@ -1,4 +1,4 @@
-/// -*- lsst-c++ -*-
+// -*- lsst-c++ -*-
 /*
  * Developed for the LSST Data Management System.
  * This product includes software developed by the LSST Project

--- a/src/image/PhotoCalib.cc
+++ b/src/image/PhotoCalib.cc
@@ -435,7 +435,7 @@ PhotoCalibFactory registration(getPhotoCalibPersistenceName());
 
 }  // namespace
 
-/**
+/*
  * Backwards-compatibility support for depersisting the old Calib (FluxMag0/FluxMag0Err) objects.
  */
 


### PR DESCRIPTION
This PR removes or rearranges Doxygen comments that were intended to be file-level but instead described namespaces.