### PR TITLE
DM-35895: Use band for the dataId not filter

### DIFF
--- a/doc/lsst.afw.multiband/multiband.rst
+++ b/doc/lsst.afw.multiband/multiband.rst
@@ -480,17 +480,14 @@ to load an exposure from a file:
 .. code-block:: python
 
     from lsst.afw.image import MultibandExposure
-    from lsst.daf.persistence import Butler
+    from lsst.daf.butler import Butler
 
-    # This is an example dataset on lsstdev which may be out of date,
-    # replace with a local dataset
-    DATA_DIR = "/datasets/hsc/repo/rerun/RC/w_2018_22/DM-14547"
-    butler = Butler(inputs=DATA_DIR)
+    DATA_DIR = "/repo/main"
+    butler = Butler(DATA_DIR)
 
-    filters = ["G", "R","I"]
-    hscFilters = ["HSC-"+f for f in filters]
-    mExposure = MultibandExposure.fromButler(butler, hscFilters, None, "deepCoadd_calexp",
-                                             patch="1,1", tract=9813)
+    bands = ["g", "r", "i"]
+    mExposure = MultibandExposure.fromButler(butler, bands, None, "deepCoadd_calexp",
+                                             patch=42, tract=9813)
 
 MultibandFootprint
 ==================
@@ -739,7 +736,7 @@ band `HeavyFootprint` objects:
 
     # Output
     # id f_x f_y i_x i_y peakValue
-    #    pix pix pix pix     ct   
+    #    pix pix pix pix     ct
     #--- --- --- --- --- ---------
     # 16 1.0 1.0   1   1       1.0
     # 17 3.0 3.0   3   3       2.0

--- a/python/lsst/afw/image/exposure/_multiband.py
+++ b/python/lsst/afw/image/exposure/_multiband.py
@@ -114,11 +114,11 @@ class MultibandExposure(MultibandTripleBase):
 
         Parameters
         ----------
-        butler: `Butler`
+        butler: `lsst.daf.butler.Butler`
             Butler connection to use to load the single band
             calibrated images
         filters: `list` or `str`
-            List of filter names for each band
+            List of bands.
         filterKwargs: `dict`
             Keyword arguments to pass to the Butler
             that are different for each filter.
@@ -143,7 +143,7 @@ class MultibandExposure(MultibandTripleBase):
             if filterKwargs is not None:
                 for key, value in filterKwargs:
                     kwargs[key] = value[f]
-            exposures.append(butler.get(*args, filter=f, **kwargs))
+            exposures.append(butler.get(*args, band=f, **kwargs))
         return MultibandExposure.fromExposures(filters, exposures)
 
     def computePsfKernelImage(self, position=None):


### PR DESCRIPTION
Gen3 uses band for coadds. If people want to retrieve by
physical filter it would likely need a change in API
or much more cleverness in trying to inspect the dataset type.