### PR TITLE
DM-36207: Reset the Fits object status to 0 if we are throwing an error

### DIFF
--- a/include/lsst/afw/fits.h
+++ b/include/lsst/afw/fits.h
@@ -108,8 +108,12 @@ std::string makeLimitedFitsHeader(lsst::daf::base::PropertySet const& metadata,
 /**
  *  Throw a FitsError exception if the status of the given Fits object is nonzero.
  */
-#define LSST_FITS_CHECK_STATUS(fitsObj, ...) \
-    if ((fitsObj).status != 0) throw LSST_FITS_EXCEPT(lsst::afw::fits::FitsError, fitsObj, __VA_ARGS__)
+#define LSST_FITS_CHECK_STATUS(fitsObj, ...)                                              \
+    if ((fitsObj).status != 0) {                                                          \
+        auto except = LSST_FITS_EXCEPT(lsst::afw::fits::FitsError, fitsObj, __VA_ARGS__); \
+        (fitsObj).status = 0;                                                             \
+        throw except;                                                                     \
+    }
 
 /// Return the cfitsio integer BITPIX code for the given data type.
 template <typename T>

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -128,6 +128,20 @@ class FitsTestCase(lsst.utils.tests.TestCase):
         metadata = self.writeAndRead(header)
         self.assertEqual(metadata.getArray("FOO"), [None, None])
 
+    def test_ticket_dm_36207(self):
+        # test whether moving to invalid HDU and then moving back throws or not
+        testfile = os.path.join(testPath, "data", "parent.fits")
+        fts = lsst.afw.fits.Fits(testfile, "r")
+
+        # parent.fits has 2 HDUs.
+        with self.assertRaises(lsst.afw.fits.FitsError):
+            fts.setHdu(5)
+
+        # check that we can move back to primary HDU and pull out a header
+        fts.setHdu(0)
+        mdattest = fts.readMetadata()["COMMENT"]
+        self.assertIn("and Astrophysics', volume 376, page 359;", mdattest)
+
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):
     pass


### PR DESCRIPTION
Fix and test case added for https://jira.lsstcorp.org/browse/DM-36207. 

