### PR TITLE
tickets/DM-36230: Add new polygon contains interface

### DIFF
--- a/include/lsst/afw/geom/polygon/Polygon.h
+++ b/include/lsst/afw/geom/polygon/Polygon.h
@@ -144,6 +144,19 @@ public:
     bool contains(Point const& point) const;
 
     //@{
+    /// Returns whether the polygon contains the vector of points
+    std::vector<bool> contains(std::vector<Point> const &points) const;
+    std::vector<bool> contains(std::vector<lsst::geom::Point2I> const &points) const;
+    //@}
+
+    /// Returns whether the polygon contains the x, y pair
+    template <typename Xtype, typename Ytype>
+    bool contains(Xtype x, Ytype y) const {
+        Point point(x, y);
+        return contains(point);
+    }
+
+    //@{
     /// Returns whether the polygons overlap each other
     ///
     /// Note that there may be no intersection if the polygons
@@ -279,6 +292,11 @@ private:
     Polygon(std::shared_ptr<Impl> impl) : _impl(impl) {}
     //@}
 };
+/// \cond DOXYGEN_IGNORE
+template bool Polygon::contains<double, double>(double, double) const;
+template bool Polygon::contains<float, float>(float, float) const;
+template bool Polygon::contains<int, int>(int, int) const;
+/// \endcond DOXYGEN_IGNORE
 
 /// Stream polygon
 std::ostream& operator<<(std::ostream& os, Polygon const& poly);

--- a/python/lsst/afw/geom/_polygon.cc
+++ b/python/lsst/afw/geom/_polygon.cc
@@ -24,6 +24,7 @@
 #include <memory>
 
 #include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
 #include <lsst/utils/python.h>
 
 #include <pybind11/stl.h>
@@ -74,7 +75,14 @@ void declarePolygon(lsst::utils::python::WrapperCollection &wrappers) {
                 cls.def("calculatePerimeter", &Polygon::calculatePerimeter);
                 cls.def("getVertices", &Polygon::getVertices);
                 cls.def("getEdges", &Polygon::getEdges);
-                cls.def("contains", &Polygon::contains);
+
+                cls.def("contains", (bool (Polygon::*)(Polygon::Point const&) const) &Polygon::contains);
+                cls.def("contains", (std::vector<bool> (Polygon::*)(std::vector<Polygon::Point> const&) const) &Polygon::contains);
+                cls.def("contains", (std::vector<bool> (Polygon::*)(std::vector<lsst::geom::Point2I> const&) const) &Polygon::contains);
+                cls.def("contains", py::vectorize((bool (Polygon::*)(double x, double y) const) &Polygon::contains<double, double>));
+                cls.def("contains", py::vectorize((bool (Polygon::*)(float x, float y) const) &Polygon::contains<float, float>));
+                cls.def("contains", py::vectorize((bool (Polygon::*)(int x, int y) const) &Polygon::contains<int, int>));
+
                 cls.def("overlaps", (bool (Polygon::*)(Polygon const &) const) & Polygon::overlaps);
                 cls.def("overlaps", (bool (Polygon::*)(Polygon::Box const &) const) & Polygon::overlaps);
                 cls.def("intersectionSingle", (std::shared_ptr<Polygon>(Polygon::*)(Polygon const &) const) &

--- a/src/geom/polygon/Polygon.cc
+++ b/src/geom/polygon/Polygon.cc
@@ -355,6 +355,22 @@ std::size_t Polygon::hash_value() const noexcept {
 
 bool Polygon::contains(LsstPoint const& point) const { return boost::geometry::within(point, _impl->poly); }
 
+std::vector<bool> Polygon::contains(std::vector<Point> const &points) const {
+    std::vector<bool> results;
+    for (Point const & p : points) {
+        results.push_back(contains(p));
+    }
+    return results;
+}
+
+std::vector<bool> Polygon::contains(std::vector<lsst::geom::Point2I> const &points) const {
+    std::vector<bool> results;
+    for (lsst::geom::PointI const & p : points) {
+        results.push_back(contains(Point(p)));
+    }
+    return results;
+}
+
 bool Polygon::overlaps(Polygon const& other) const { return _impl->overlaps(other._impl->poly); }
 
 bool Polygon::overlaps(Box const& box) const { return _impl->overlaps(box); }

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -146,6 +146,27 @@ class PolygonTest(lsst.utils.tests.TestCase):
             self.assertTrue(poly.contains(lsst.geom.Point2D(self.x0, self.y0)))
             self.assertFalse(poly.contains(
                 lsst.geom.Point2D(self.x0 + radius, self.y0 + radius)))
+        # validate checking an array
+        poly = self.polygon(50, radius=10)
+        # check for inclusion
+        yind, xind = np.mgrid[-4:5, -4:5]
+        self.assertTrue(np.all(poly.contains(xind, yind)))
+        # check for exclusion
+        yind, xind = np.mgrid[30:35, 30:35]
+        self.assertTrue(np.all(~poly.contains(xind, yind)))
+
+        # check various box types
+        box = lsst.geom.Box2I(lsst.geom.Point2I(-1, -1), lsst.geom.Point2I(1, 1))
+        self.assertTrue(all(poly.contains(box.getCorners())))
+
+        box = lsst.geom.Box2I(lsst.geom.Point2I(-100, -100), lsst.geom.Point2I(100, 100))
+        self.assertFalse(all(poly.contains(box.getCorners())))
+
+        box = lsst.geom.Box2D(lsst.geom.Point2D(-1, -1), lsst.geom.Point2D(1, 1))
+        self.assertTrue(all(poly.contains(box.getCorners())))
+
+        box = lsst.geom.Box2D(lsst.geom.Point2D(-100, -100), lsst.geom.Point2D(100, 100))
+        self.assertFalse(all(poly.contains(box.getCorners())))
 
     def testOverlaps(self):
         """Test Polygon.overlaps"""


### PR DESCRIPTION
Allow checking if a polygon contains various objects like vectors of points, and a point by passing an x, y
pair instead of a Point object. Expose this to python with an auto-vectorized interface to allow passing of numpy arrays of points.