### PR TITLE
DM-34628: Add a mosaic mode option to Statistics

### DIFF
--- a/python/lsst/afw/math/_statistics.cc
+++ b/python/lsst/afw/math/_statistics.cc
@@ -117,6 +117,7 @@ void declareStatistics(lsst::utils::python::WrapperCollection &wrappers) {
         cls.def("getWeighted", &StatisticsControl::getWeighted);
         cls.def("getWeightedIsSet", &StatisticsControl::getWeightedIsSet);
         cls.def("getCalcErrorFromInputVariance", &StatisticsControl::getCalcErrorFromInputVariance);
+        cls.def("getCalcErrorMosaicMode", &StatisticsControl::getCalcErrorMosaicMode);
         cls.def("setNumSigmaClip", &StatisticsControl::setNumSigmaClip);
         cls.def("setNumIter", &StatisticsControl::setNumIter);
         cls.def("setAndMask", &StatisticsControl::setAndMask);
@@ -124,6 +125,7 @@ void declareStatistics(lsst::utils::python::WrapperCollection &wrappers) {
         cls.def("setNanSafe", &StatisticsControl::setNanSafe);
         cls.def("setWeighted", &StatisticsControl::setWeighted);
         cls.def("setCalcErrorFromInputVariance", &StatisticsControl::setCalcErrorFromInputVariance);
+        cls.def("setCalcErrorMosaicMode", &StatisticsControl::setCalcErrorMosaicMode);
     });
 
     wrappers.wrapType(py::enum_<StatisticsControl::WeightsBoolean>(control, "WeightsBoolean"),


### PR DESCRIPTION
StatisticsStack is also useful for mosaicking coadds. Two neighboring patches will have the same exact input visits and be exact duplicates on the patch boundaries. They are 100% correlated and when stacking, then there's a genuine use case for computing variance plane as the mean of the variances. This should only be used in the very specific scenario of mosaicking coadds.