### PR TITLE
DM-37534: Ensure that pex_exceptions is imported for afw.fits

### DIFF
--- a/python/lsst/afw/fits/_fits.cc
+++ b/python/lsst/afw/fits/_fits.cc
@@ -283,7 +283,7 @@ void declareFitsModule(lsst::utils::python::WrapperCollection &wrappers) {
 }  // namespace
 PYBIND11_MODULE(_fits, mod) {
     lsst::utils::python::WrapperCollection wrappers(mod, "lsst.afw.fits");
-    wrappers.addSignatureDependency("lsst.pex.exceptions");
+    wrappers.addInheritanceDependency("lsst.pex.exceptions");
     wrappers.addSignatureDependency("lsst.daf.base");
     // FIXME: after afw.image pybind wrappers are converted
     //wrappers.addSignatureDependency("lsst.afw.image");

--- a/python/lsst/afw/geom/_polygon.cc
+++ b/python/lsst/afw/geom/_polygon.cc
@@ -135,7 +135,7 @@ void declarePolygon(lsst::utils::python::WrapperCollection &wrappers) {
 }
 }  // namespace
 void wrapPolygon(lsst::utils::python::WrapperCollection &wrappers) {
-    wrappers.addSignatureDependency("lsst.pex.exceptions");
+    wrappers.addInheritanceDependency("lsst.pex.exceptions");
     wrappers.addInheritanceDependency("lsst.afw.typehandling");
     wrappers.addSignatureDependency("lsst.afw.table.io");
     wrappers.wrapException<SinglePolygonException, pex::exceptions::RuntimeError>("SinglePolygonException",


### PR DESCRIPTION
Without this it is not possible to "import lsst.afw.fits" because the FitsError is not translated to python. Tests passed in afw because other parts of afw were importing pex_exceptions.