### PR TITLE
DM-38694: Specify explicit __deepcopy__ for Exposure/Image/MaskedImage

### DIFF
--- a/python/lsst/afw/image/_exposure/_exposureContinued.py
+++ b/python/lsst/afw/image/_exposure/_exposureContinued.py
@@ -64,6 +64,9 @@ class Exposure(metaclass=TemplateMeta):
         from lsst.afw.fits import reduceToFits
         return reduceToFits(self)
 
+    def __deepcopy__(self, memo=None):
+        return self.clone()
+
     def convertF(self):
         return ExposureF(self, deep=True)
 

--- a/python/lsst/afw/image/_image/_image.py
+++ b/python/lsst/afw/image/_image/_image.py
@@ -37,6 +37,9 @@ class Image(metaclass=TemplateMeta):
         from lsst.afw.fits import reduceToFits
         return reduceToFits(self)
 
+    def __deepcopy__(self, memo=None):
+        return self.clone()
+
     def __str__(self):
         return "{}, bbox={}".format(self.array, self.getBBox())
 

--- a/python/lsst/afw/image/_maskedImage/_maskedImageContinued.py
+++ b/python/lsst/afw/image/_maskedImage/_maskedImageContinued.py
@@ -97,6 +97,9 @@ class MaskedImage(metaclass=TemplateMeta):
         from lsst.afw.fits import reduceToFits
         return reduceToFits(self)
 
+    def __deepcopy__(self, memo=None):
+        return self.clone()
+
     def __str__(self):
         string = "image={},\nmask={}, maskPlaneDict={}\nvariance={}, bbox={}"
         return string.format(self.image.array,

--- a/python/lsst/afw/image/_visitInfo.py
+++ b/python/lsst/afw/image/_visitInfo.py
@@ -31,6 +31,10 @@ __all__ = []
 
 @continueClass
 class VisitInfo:  # noqa: F811
+
+    def __deepcopy__(self, memo=None):
+        return self
+
     def copyWith(
         self,
         exposureId=None,

--- a/tests/test_visitInfo.py
+++ b/tests/test_visitInfo.py
@@ -19,6 +19,7 @@
 # the GNU General Public License along with this program.  If not,
 # see <http://www.lsstcorp.org/LegalNotices/>.
 #
+import copy
 import math
 import os
 import unittest
@@ -263,6 +264,8 @@ class VisitInfoTestCase(lsst.utils.tests.TestCase):
 
         newVisit1 = visitInfo1.copyWith(**kwargs1)
         newVisit2 = visitInfo1.copyWith(**kwargs2)
+
+        self.assertIs(copy.deepcopy(visitInfo1), visitInfo1)
 
         for field in updateFields1:
             self.assertEqual(getattr(newVisit1, field), getattr(visitInfo2, field))


### PR DESCRIPTION
If this is not done a call to deepcopy goes through pickle which is very very slow.