### PR TITLE
DM-39828: move Flag/bool column access from ColumnView to Catalog

### DIFF
--- a/include/lsst/afw/table/BaseColumnView.h
+++ b/include/lsst/afw/table/BaseColumnView.h
@@ -106,6 +106,9 @@ public:
     ndarray::result_of::vectorize<detail::FlagExtractor, ndarray::Array<Field<Flag>::Element const, 1> >::type
     operator[](Key<Flag> const& key) const;
 
+    /// @brief Return an array column as a double array in radians.
+    ndarray::Array<double, 1> const get_radians_array(Key<Angle> const & key) const;
+
     /**
      *  Return an integer array with the given Flag fields repacked into individual bits.
      *

--- a/include/lsst/afw/table/python/catalog.h
+++ b/include/lsst/afw/table/python/catalog.h
@@ -25,6 +25,7 @@
 
 #include "pybind11/pybind11.h"
 
+#include "ndarray/pybind11.h"
 #include "lsst/utils/python.h"
 #include "lsst/afw/table/BaseColumnView.h"
 #include "lsst/afw/table/Catalog.h"

--- a/include/lsst/afw/table/python/catalog.h
+++ b/include/lsst/afw/table/python/catalog.h
@@ -182,18 +182,6 @@ void declareCatalogOverloads(PyCatalog<Record> &cls) {
 
     cls.def("_getitem_",
             [](Catalog const &self, Key<T> const &key) { return _getArrayFromCatalog(self, key); });
-    cls.def(
-        "_set_flag",
-        [](Catalog &self, Key<Flag> const & key, ndarray::Array<bool const, 1> const & array) {
-            _setFlagColumnToArray(self, key, array);
-        }
-    );
-    cls.def(
-        "_set_flag",
-        [](Catalog &self, Key<Flag> const & key, bool value) {
-            _setFlagColumnToScalar(self, key, value);
-        }
-    );
 }
 
 /**
@@ -340,6 +328,18 @@ PyCatalog<Record> declareCatalog(utils::python::WrapperCollection &wrappers, std
                         [](Catalog const &self, Key<Flag> const &key) -> ndarray::Array<bool const, 1, 0> {
                             return _getArrayFromCatalog(self, key);
                         });
+                cls.def(
+                    "_set_flag",
+                    [](Catalog &self, Key<Flag> const & key, ndarray::Array<bool const, 1> const & array) {
+                        _setFlagColumnToArray(self, key, array);
+                    }
+                );
+                cls.def(
+                    "_set_flag",
+                    [](Catalog &self, Key<Flag> const & key, bool value) {
+                        _setFlagColumnToScalar(self, key, value);
+                    }
+                );
 
             });
 }

--- a/include/lsst/afw/table/python/columnView.h
+++ b/include/lsst/afw/table/python/columnView.h
@@ -25,6 +25,7 @@
 
 #include "pybind11/pybind11.h"
 
+#include "ndarray/pybind11.h"
 #include "lsst/utils/python.h"
 
 #include "lsst/afw/table/BaseColumnView.h"

--- a/python/lsst/afw/table/_base.py
+++ b/python/lsst/afw/table/_base.py
@@ -350,5 +350,96 @@ class Catalog(metaclass=TemplateMeta):
     def __repr__(self):
         return "%s\n%s" % (type(self), self)
 
+    def extract(self, *patterns, **kwds):
+        """Extract a dictionary of {<name>: <column-array>} in which the field
+        names match the given shell-style glob pattern(s).
+
+        Any number of glob patterns may be passed (including none); the result
+        will be the union of all the result of each glob considered separately.
+
+        Note that extract("*", copy=True) provides an easy way to transform a
+        catalog into a set of writeable contiguous NumPy arrays.
+
+        This routines unpacks `Flag` columns into full boolean arrays.  String
+        fields are silently ignored.
+
+        Parameters
+        ----------
+        patterns : Array of `str`
+            List of glob patterns to use to select field names.
+        kwds : `dict`
+            Dictionary of additional keyword arguments.  May contain:
+
+            ``items`` : `list`
+                The result of a call to self.schema.extract(); this will be
+                used instead of doing any new matching, and allows the pattern
+                matching to be reused to extract values from multiple records.
+                This keyword is incompatible with any position arguments and
+                the regex, sub, and ordered keyword arguments.
+            ``where`` : array index expression
+                Any expression that can be passed as indices to a NumPy array,
+                including slices, boolean arrays, and index arrays, that will
+                be used to index each column array.  This is applied before
+                arrays are copied when copy is True, so if the indexing results
+                in an implicit copy no unnecessary second copy is performed.
+            ``copy`` : `bool`
+                If True, the returned arrays will be contiguous copies rather
+                than strided views into the catalog.  This ensures that the
+                lifetime of the catalog is not tied to the lifetime of a
+                particular catalog, and it also may improve the performance if
+                the array is used repeatedly. Default is False.  Copies are
+                always made if the catalog is noncontiguous, but if
+                ``copy=False`` these set as read-only to ensure code does not
+                assume they are views that could modify the original catalog.
+            ``regex`` : `str` or `re` pattern
+                A regular expression to be used in addition to any glob
+                patterns passed as positional arguments.  Note that this will
+                be compared with re.match, not re.search.
+            ``sub`` : `str`
+                A replacement string (see re.MatchObject.expand) used to set
+                the dictionary keys of any fields matched by regex.
+            ``ordered`` : `bool`
+                If True, a collections.OrderedDict will be returned instead of
+                a standard dict, with the order corresponding to the definition
+                order of the Schema. Default is False.
+
+        Returns
+        -------
+        d : `dict`
+            Dictionary of extracted name-column array sets.
+
+        Raises
+        ------
+        ValueError
+            Raised if a list of ``items`` is supplied with additional keywords.
+        """
+        copy = kwds.pop("copy", False)
+        where = kwds.pop("where", None)
+        d = kwds.pop("items", None)
+        # If ``items`` is given as a kwd, an extraction has already been
+        # performed and there shouldn't be any additional keywords. Otherwise
+        # call schema.extract to load the dictionary.
+        if d is None:
+            d = self.schema.extract(*patterns, **kwds).copy()
+        elif kwds:
+            raise ValueError(
+                "kwd 'items' was specified, which is not compatible with additional keywords")
+
+        def processArray(a):
+            if where is not None:
+                a = a[where]
+            if copy:
+                a = a.copy()
+            return a
+
+        # must use list because we might be adding/deleting elements
+        for name, schemaItem in list(d.items()):
+            key = schemaItem.key
+            if key.getTypeString() == "String":
+                del d[name]
+            else:
+                d[name] = processArray(self[schemaItem.key])
+        return d
+
 
 Catalog.register("Base", BaseCatalog)

--- a/python/lsst/afw/table/_baseColumnView.cc
+++ b/python/lsst/afw/table/_baseColumnView.cc
@@ -97,14 +97,7 @@ static void declareBaseColumnView(WrapperCollection &wrappers) {
         // lsst::geom::Angle requires custom wrappers, because ndarray doesn't
         // recognize it natively; we just return a double view
         // (e.g. radians).
-        using AngleArray = ndarray::Array<lsst::geom::Angle, 1>;
-        using DoubleArray = ndarray::Array<double, 1>;
-        cls.def("_basicget", [](BaseColumnView &self, Key<lsst::geom::Angle> const &key) -> DoubleArray {
-            ndarray::Array<lsst::geom::Angle, 1, 0> a = self[key];
-            return ndarray::detail::ArrayAccess<DoubleArray>::construct(
-                    reinterpret_cast<double *>(a.getData()),
-                    ndarray::detail::ArrayAccess<AngleArray>::getCore(a));
-        });
+        cls.def("_basicget", &BaseColumnView::get_radians_array);
     });
 }
 

--- a/python/lsst/afw/table/_baseColumnView.cc
+++ b/python/lsst/afw/table/_baseColumnView.cc
@@ -60,10 +60,17 @@ static void declareBaseColumnViewArrayOverloads(PyClass &cls) {
             typename ndarray::Array<U, 2, 1> const { return self[key]; });
 };
 
+// TODO: remove this method and any calls to it on DM-32980.
 template <typename PyClass>
 static void declareBaseColumnViewFlagOverloads(PyClass &cls) {
     cls.def("_basicget",
             [](BaseColumnView &self, Key<Flag> const &key) -> ndarray::Array<bool const, 1, 1> const {
+                PyErr_WarnEx(
+                    PyExc_FutureWarning,
+                    "Flag/bool access via ColumnView objects is deprecated in favor of more compete support "
+                    "on Catalog.  Will be removed after v27.",
+                    2  // stack level
+                );
                 return ndarray::copy(self[key]);
             });
 };

--- a/python/lsst/afw/table/_baseColumnView.py
+++ b/python/lsst/afw/table/_baseColumnView.py
@@ -113,11 +113,8 @@ class _BaseColumnViewBase:  # noqa: F811
         row-major ColumnView into a possibly more efficient set of contiguous
         NumPy arrays.
 
-        This routines unpacks `Flag` columns into full boolean arrays and
-        covariances into dense (i.e. non-triangular packed) arrays with
-        dimension (N,M,M), where N is the number of records and M is the
-        dimension of the covariance matrix.  String fields are silently
-        ignored.
+        This routines unpacks `Flag` columns into full boolean arrays.  String
+        fields are silently ignored.
 
         Parameters
         ----------

--- a/python/lsst/afw/table/_baseColumnView.py
+++ b/python/lsst/afw/table/_baseColumnView.py
@@ -106,8 +106,7 @@ class _BaseColumnViewBase:  # noqa: F811
         names match the given shell-style glob pattern(s).
 
         Any number of glob patterns may be passed (including none); the result
-        will be the union of all the result of each glob considered
-        separately.
+        will be the union of all the result of each glob considered separately.
 
         Note that extract("*", copy=True) provides an easy way to transform a
         row-major ColumnView into a possibly more efficient set of contiguous
@@ -124,40 +123,34 @@ class _BaseColumnViewBase:  # noqa: F811
             Dictionary of additional keyword arguments.  May contain:
 
             ``items`` : `list`
-                The result of a call to self.schema.extract(); this
-                will be used instead of doing any new matching, and
-                allows the pattern matching to be reused to extract
-                values from multiple records.  This keyword is
-                incompatible with any position arguments and the
-                regex, sub, and ordered keyword arguments.
+                The result of a call to self.schema.extract(); this will be
+                used instead of doing any new matching, and allows the pattern
+                matching to be reused to extract values from multiple records.
+                This keyword is incompatible with any position arguments and
+                the regex, sub, and ordered keyword arguments.
             ``where`` : array index expression
-                Any expression that can be passed as indices to a
-                NumPy array, including slices, boolean arrays, and
-                index arrays, that will be used to index each column
-                array.  This is applied before arrays are copied when
-                copy is True, so if the indexing results in an
-                implicit copy no unnecessary second copy is performed.
+                Any expression that can be passed as indices to a NumPy array,
+                including slices, boolean arrays, and index arrays, that will
+                be used to index each column array.  This is applied before
+                arrays are copied when copy is True, so if the indexing results
+                in an implicit copy no unnecessary second copy is performed.
             ``copy`` : `bool`
-                If True, the returned arrays will be contiguous copies
-                rather than strided views into the catalog.  This
-                ensures that the lifetime of the catalog is not tied
-                to the lifetime of a particular catalog, and it also
-                may improve the performance if the array is used
-                repeatedly. Default is False.
+                If True, the returned arrays will be contiguous copies rather
+                than strided views into the catalog.  This ensures that the
+                lifetime of the catalog is not tied to the lifetime of a
+                particular catalog, and it also may improve the performance if
+                the array is used repeatedly. Default is False.
             ``regex`` : `str` or `re` pattern
-                A regular expression to be used in addition to any
-                glob patterns passed as positional arguments.  Note
-                that this will be compared with re.match, not
-                re.search.
+                A regular expression to be used in addition to any glob
+                patterns passed as positional arguments.  Note that this will
+                be compared with re.match, not re.search.
             ``sub`` : `str`
-                A replacement string (see re.MatchObject.expand) used
-                to set the dictionary keys of any fields matched by
-                regex.
+                A replacement string (see re.MatchObject.expand) used to set
+                the dictionary keys of any fields matched by regex.
             ``ordered`` : `bool`
-                If True, a collections.OrderedDict will be returned
-                instead of a standard dict, with the order
-                corresponding to the definition order of the
-                Schema. Default is False.
+                If True, a collections.OrderedDict will be returned instead of
+                a standard dict, with the order corresponding to the definition
+                order of the Schema. Default is False.
 
         Returns
         -------
@@ -167,15 +160,14 @@ class _BaseColumnViewBase:  # noqa: F811
         Raises
         ------
         ValueError
-            Raised if a list of ``items`` is supplied with additional
-            keywords.
+            Raised if a list of ``items`` is supplied with additional keywords.
         """
         copy = kwds.pop("copy", False)
         where = kwds.pop("where", None)
         d = kwds.pop("items", None)
-        # If ``items`` is given as a kwd, an extraction has already been performed and there shouldn't be
-        # any additional keywords. Otherwise call schema.extract to load the
-        # dictionary.
+        # If ``items`` is given as a kwd, an extraction has already been
+        # performed and there shouldn't be any additional keywords. Otherwise
+        # call schema.extract to load the dictionary.
         if d is None:
             d = self.schema.extract(*patterns, **kwds).copy()
         elif kwds:

--- a/python/lsst/afw/table/_baseColumnView.py
+++ b/python/lsst/afw/table/_baseColumnView.py
@@ -23,6 +23,8 @@ __all__ = []  # importing this module adds methods to BaseColumnView
 
 import numpy as np
 
+from deprecated.sphinx import deprecated
+
 from lsst.utils import continueClass
 from ._table import KeyFlag, _BaseColumnViewBase
 
@@ -78,6 +80,15 @@ class _BaseColumnViewBase:  # noqa: F811
 
     set = __setitem__
 
+    # TODO: remove on DM-32980.
+    @deprecated(
+        reason=(
+            "Catalog.__getitem__ now provides better support for "
+            "accessing Flag/bool columns.  Will be removed after v27."
+        ),
+        version="v26",
+        category=FutureWarning,
+    )
     def get_bool_array(self, key):
         """Get the value of a flag column as a boolean array; key must be a
         key object or the name of a field.
@@ -112,8 +123,9 @@ class _BaseColumnViewBase:  # noqa: F811
         row-major ColumnView into a possibly more efficient set of contiguous
         NumPy arrays.
 
-        This routines unpacks `Flag` columns into full boolean arrays.  String
-        fields are silently ignored.
+        String fields are silently ignored.  Support for `Flag` columns is
+        deprecated; at present they are copied into full boolean arrays, but
+        after v26 they will be silently ignored as well.
 
         Parameters
         ----------

--- a/src/table/BaseColumnView.cc
+++ b/src/table/BaseColumnView.cc
@@ -114,6 +114,16 @@ ndarray::result_of::vectorize<detail::FlagExtractor, ndarray::Array<Field<Flag>:
                                       _impl->manager)));
 }
 
+ndarray::Array<double, 1> const BaseColumnView::get_radians_array(Key<Angle> const & key) const {
+    using DoubleArray = ndarray::Array<double, 1>;
+    using AngleArray = ndarray::Array<lsst::geom::Angle, 1>;
+    AngleArray angle_array = (*this)[key];
+    return ndarray::detail::ArrayAccess<DoubleArray>::construct(
+        reinterpret_cast<double *>(angle_array.getData()),
+        ndarray::detail::ArrayAccess<AngleArray>::getCore(angle_array)
+    );
+}
+
 BitsColumn BaseColumnView::getBits(std::vector<Key<Flag> > const &keys) const {
     BitsColumn result(_impl->recordCount);
     ndarray::ArrayRef<BitsColumn::SizeT, 1, 1> array = result._array.deep();

--- a/tests/test_simpleTable.py
+++ b/tests/test_simpleTable.py
@@ -819,6 +819,40 @@ class SimpleTableTestCase(lsst.utils.tests.TestCase):
         catalog["a"] = v2
         self.assertEqual(list(catalog[key]), list(v2))
 
+    def testAngleColumnArrayAccess(self):
+        """Test column-array access to Angle columns on both contiguous and
+        non-contiguous arrays.
+        """
+        schema = lsst.afw.table.Schema()
+        key = schema.addField("a", type="Angle", doc="doc for a")
+        catalog = lsst.afw.table.BaseCatalog(schema)
+        catalog.resize(2)
+        self.assertTrue(catalog.isContiguous())
+        catalog[key] = np.array([3.0, 4.0])
+        self.assertFloatsEqual(catalog[key], np.array([3.0, 4.0]))
+        record = catalog.addNew()
+        self.assertFalse(catalog.isContiguous())
+        record[key] = 5.0 * lsst.geom.radians
+        self.assertFloatsEqual(catalog[key], np.array([3.0, 4.0, 5.0]))
+        self.assertFalse(catalog[key].flags.writeable)
+
+    def testArrayColumnArrayAccess(self):
+        """Test column-array access to Array columns on both contiguous and
+        non-contiguous arrays.
+        """
+        schema = lsst.afw.table.Schema()
+        key = schema.addField("a", type="ArrayD", doc="doc for a", size=3)
+        catalog = lsst.afw.table.BaseCatalog(schema)
+        catalog.resize(2)
+        self.assertTrue(catalog.isContiguous())
+        catalog[key] = np.array([[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]])
+        self.assertFloatsEqual(catalog[key], np.array([[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]))
+        record = catalog.addNew()
+        self.assertFalse(catalog.isContiguous())
+        record[key] = [[9.0, 10.0, 11.0]]
+        self.assertFloatsEqual(catalog[key], np.array([[3.0, 4.0, 5.0], [6.0, 7.0, 8.0], [9.0, 10.0, 11.0]]))
+        self.assertFalse(catalog[key].flags.writeable)
+
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):
     pass

--- a/tests/test_simpleTable.py
+++ b/tests/test_simpleTable.py
@@ -194,11 +194,8 @@ class SimpleTableTestCase(lsst.utils.tests.TestCase):
         kB = schema.addField("fB", type="B")
         kU = schema.addField("fU", type="U")
         kI = schema.addField("fI", type="I")
-        kFlag1 = schema.addField("fFlag1", type="Flag")
         kF = schema.addField("fF", type="F")
-        kFlag2 = schema.addField("fFlag2", type="Flag")
         kD = schema.addField("fD", type="D")
-        kFlag3 = schema.addField("fFlag3", type="Flag")
         kArrayF = schema.addField("fArrayF", type="ArrayF", size=2)
         kArrayD = schema.addField("fArrayD", type="ArrayD", size=3)
         kAngle = schema.addField("fAngle", type="Angle")
@@ -210,9 +207,6 @@ class SimpleTableTestCase(lsst.utils.tests.TestCase):
         catalog[0].set(kI, 2)
         catalog[0].set(kF, 0.5)
         catalog[0].set(kD, 0.25)
-        catalog[0].set(kFlag1, False)
-        catalog[0].set(kFlag2, True)
-        catalog[0].set(kFlag3, False)
         catalog[0].set(kArrayF, np.array([-0.5, -0.25], dtype=np.float32))
         catalog[0].set(kArrayD, np.array([-1.5, -1.25, 3.375], dtype=np.float64))
         catalog[0].set(kAngle, lsst.geom.Angle(0.25))
@@ -225,9 +219,6 @@ class SimpleTableTestCase(lsst.utils.tests.TestCase):
         catalog[1].set(kI, 3)
         catalog[1].set(kF, 2.5)
         catalog[1].set(kD, 0.75)
-        catalog[1].set(kFlag1, True)
-        catalog[1].set(kFlag2, False)
-        catalog[1].set(kFlag3, True)
         catalog[1].set(kArrayF, np.array([-3.25, -0.75], dtype=np.float32))
         catalog[1].set(kArrayD, np.array([-1.25, -2.75, 0.625], dtype=np.float64))
         catalog[1].set(kAngle, lsst.geom.Angle(0.15))
@@ -235,7 +226,7 @@ class SimpleTableTestCase(lsst.utils.tests.TestCase):
         col1b = catalog[kI]
         self.assertEqual(col1b.shape, (2,))
         columns = catalog.getColumnView()
-        for key in [kB, kU, kI, kF, kD, kFlag1, kFlag2, kFlag3]:
+        for key in [kB, kU, kI, kF, kD]:
             array = columns[key]
             for i in [0, 1]:
                 self.assertEqual(array[i], catalog[i].get(key))
@@ -265,7 +256,7 @@ class SimpleTableTestCase(lsst.utils.tests.TestCase):
 
         # Accessing an invalid key should raise.
         for keyType in ["Angle", "ArrayB", "ArrayD", "ArrayF", "ArrayI",
-                        "ArrayU", "B", "D", "F", "Flag", "I", "L", "U"]:
+                        "ArrayU", "B", "D", "F", "I", "L", "U"]:
             # Default-constructed key is invalid
             invalidKey = getattr(lsst.afw.table, f"Key{keyType}")()
             self.assertFalse(invalidKey.isValid())
@@ -365,8 +356,6 @@ class SimpleTableTestCase(lsst.utils.tests.TestCase):
             d = catalog.extract("*", **kwds)
             np.testing.assert_array_equal(
                 d["a_b_c1"], catalog.get("a_b_c1")[idx])
-            np.testing.assert_array_equal(
-                d["a_b_c2"], catalog.get("a_b_c2")[idx])
             np.testing.assert_array_equal(
                 d["a_d1"], catalog.get("a_d1")[idx])
             np.testing.assert_array_equal(
@@ -849,7 +838,7 @@ class SimpleTableTestCase(lsst.utils.tests.TestCase):
         self.assertFloatsEqual(catalog[key], np.array([[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]))
         record = catalog.addNew()
         self.assertFalse(catalog.isContiguous())
-        record[key] = [[9.0, 10.0, 11.0]]
+        record[key] = np.array([9.0, 10.0, 11.0])
         self.assertFloatsEqual(catalog[key], np.array([[3.0, 4.0, 5.0], [6.0, 7.0, 8.0], [9.0, 10.0, 11.0]]))
         self.assertFalse(catalog[key].flags.writeable)
 

--- a/tests/test_sourceTable.py
+++ b/tests/test_sourceTable.py
@@ -301,16 +301,11 @@ class SourceTableTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(allBits.getMask("c_flag"), 0x4)
         self.assertEqual(someBits.getMask(self.fluxFlagKey), 0x1)
         self.assertEqual(someBits.getMask(self.shapeFlagKey), 0x2)
-        np.testing.assert_array_equal(
-            (allBits.array & 0x1 != 0), self.catalog.columns["a_flag"])
-        np.testing.assert_array_equal(
-            (allBits.array & 0x2 != 0), self.catalog.columns["b_flag"])
-        np.testing.assert_array_equal(
-            (allBits.array & 0x4 != 0), self.catalog.columns["c_flag"])
-        np.testing.assert_array_equal(
-            (someBits.array & 0x1 != 0), self.catalog.columns["a_flag"])
-        np.testing.assert_array_equal(
-            (someBits.array & 0x2 != 0), self.catalog.columns["c_flag"])
+        np.testing.assert_array_equal((allBits.array & 0x1 != 0), self.catalog["a_flag"])
+        np.testing.assert_array_equal((allBits.array & 0x2 != 0), self.catalog["b_flag"])
+        np.testing.assert_array_equal((allBits.array & 0x4 != 0), self.catalog["c_flag"])
+        np.testing.assert_array_equal((someBits.array & 0x1 != 0), self.catalog["a_flag"])
+        np.testing.assert_array_equal((someBits.array & 0x2 != 0), self.catalog["c_flag"])
 
     def testCast(self):
         baseCat = self.catalog.cast(lsst.afw.table.BaseCatalog)


### PR DESCRIPTION
The overall goal here is to deprecate some duplication: ColumnView and Catalog both implement access to Flag/bool columns in different ways, and it's cleanest to just move it all to Catalog, since there's no way to actually _view_ Flag/bool column when they're stored as packed bits.