### PR TITLE
DM-40451: Update MultibandExposure.computePsfImage

### DIFF
--- a/python/lsst/afw/image/_exposure/_multiband.py
+++ b/python/lsst/afw/image/_exposure/_multiband.py
@@ -45,6 +45,12 @@ class IncompleteDataError(Exception):
     partialPsf: `MultibandImage`
         The image of the PSF using only the bands that successfully
         computed a PSF image.
+
+    Parameters
+    ----------
+    bands : `list` of `str`
+        The full list of bands in the `MultibandExposure` generating
+        the PSF.
     """
     def __init__(self, bands, position, partialPsf):
         missingBands = [band for band in bands if band not in partialPsf.filters]
@@ -74,7 +80,7 @@ def computePsfImage(psfModels, position, useKernelImage=True):
 
     Returns
     -------
-    psfs: `np.ndarray`
+    psfs: `lsst.afw.image.MultibandImage`
         The multiband PSF image.
     """
     psfs = {}
@@ -275,7 +281,7 @@ class MultibandExposure(MultibandTripleBase):
 
         Returns
         -------
-        psfs : `list` of `lsst.afw.detection.Psf`
+        psfs : `dict` of `lsst.afw.detection.Psf`
             The PSF in each band
         """
         return {band: self[band].getPsf() for band in self.filters}

--- a/tests/test_multiband.py
+++ b/tests/test_multiband.py
@@ -632,18 +632,18 @@ class MultibandExposureTestCase(lsst.utils.tests.TestCase):
 
     def testPsf(self):
         psfImage = self.exposure.computePsfKernelImage(self.exposure.getBBox().getCenter())
-        self.assertFloatsAlmostEqual(psfImage, self.psfImage)
+        self.assertFloatsAlmostEqual(psfImage.array, self.psfImage)
 
         newPsfs = [GaussianPsf(self.kernelSize, self.kernelSize, 1.0) for f in self.filters]
         newPsfImage = [p.computeImage(p.getAveragePosition()).array for p in newPsfs]
         for psf, exposure in zip(newPsfs, self.exposure.singles):
             exposure.setPsf(psf)
         psfImage = self.exposure.computePsfKernelImage(self.exposure.getBBox().getCenter())
-        self.assertFloatsAlmostEqual(psfImage, newPsfImage)
+        self.assertFloatsAlmostEqual(psfImage.array, newPsfImage)
 
-        psfImage = self.exposure.computePsfImage(self.exposure.getBBox().getCenter())[0]
+        psfImage = self.exposure.computePsfImage(self.exposure.getBBox().getCenter())["G"]
         self.assertFloatsAlmostEqual(
-            psfImage,
+            psfImage.array,
             self.exposure["G"].getPsf().computeImage(
                 self.exposure["G"].getPsf().getAveragePosition()
             ).array


### PR DESCRIPTION
This updates the `MultibandExposure.computePsf<Kernel>Image` methods to return a `MultibandImage`. It also adds the partial PSF to the `IncompleteDataError` so that users who try...except the error can obtain the PSF in all of the bands that were able to construct a PSF image.