### PR TITLE
DM-43416: Fix warning in bbox_contains_sky_coords

### DIFF
--- a/doc/lsst.afw.cameraGeom/index.rst
+++ b/doc/lsst.afw.cameraGeom/index.rst
@@ -24,7 +24,7 @@ Contributing
 ============
 
 ``lsst.afw.cameraGeom`` is developed at https://github.com/lsst/afw.
-You can find Jira issues for this module under the `afw <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.
+You can find Jira issues for this module under the `afw <https://rubinobs.atlassian.net/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.
 
 .. _lsst.afw.cameraGeom-pyapi:
 

--- a/doc/lsst.afw.coord/index.rst
+++ b/doc/lsst.afw.coord/index.rst
@@ -14,7 +14,7 @@ Contributing
 ============
 
 ``lsst.afw.coord`` is developed at https://github.com/lsst/afw.
-You can find Jira issues for this module under the `afw <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.
+You can find Jira issues for this module under the `afw <https://rubinobs.atlassian.net/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.
 
 Python API reference
 ====================

--- a/doc/lsst.afw.detection/index.rst
+++ b/doc/lsst.afw.detection/index.rst
@@ -24,7 +24,7 @@ Contributing
 ============
 
 ``lsst.afw.detection`` is developed at https://github.com/lsst/afw.
-You can find Jira issues for this module under the `afw <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.
+You can find Jira issues for this module under the `afw <https://rubinobs.atlassian.net/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.
 
 .. _lsst.afw.detection-pyapi:
 

--- a/doc/lsst.afw.display/index.rst
+++ b/doc/lsst.afw.display/index.rst
@@ -14,7 +14,7 @@ Contributing
 ============
 
 ``lsst.afw.display`` is developed at https://github.com/lsst/afw.
-You can find Jira issues for this module under the `afw <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.
+You can find Jira issues for this module under the `afw <https://rubinobs.atlassian.net/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.
 
 .. _lsst.afw.display-pyapi:
 

--- a/doc/lsst.afw.fits/index.rst
+++ b/doc/lsst.afw.fits/index.rst
@@ -14,7 +14,7 @@ Contributing
 ============
 
 ``lsst.afw.fits`` is developed at https://github.com/lsst/afw.
-You can find Jira issues for this module under the `afw <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.
+You can find Jira issues for this module under the `afw <https://rubinobs.atlassian.net/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.
 
 .. _lsst.afw.fits-pyapi:
 

--- a/doc/lsst.afw.formatters/index.rst
+++ b/doc/lsst.afw.formatters/index.rst
@@ -14,7 +14,7 @@ Contributing
 ============
 
 ``lsst.afw.formatters`` is developed at https://github.com/lsst/afw.
-You can find Jira issues for this module under the `afw <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.
+You can find Jira issues for this module under the `afw <https://rubinobs.atlassian.net/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.
 
 .. _lsst.afw.formatters-pyapi:
 

--- a/doc/lsst.afw.geom/index.rst
+++ b/doc/lsst.afw.geom/index.rst
@@ -24,7 +24,7 @@ Contributing
 ============
 
 ``lsst.afw.geom`` is developed at https://github.com/lsst/afw.
-You can find Jira issues for this module under the `afw <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.
+You can find Jira issues for this module under the `afw <https://rubinobs.atlassian.net/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.
 
 .. _lsst.afw.geom-pyapi:
 

--- a/doc/lsst.afw.image/index.rst
+++ b/doc/lsst.afw.image/index.rst
@@ -25,4 +25,4 @@ Contributing
 ============
 
 ``lsst.afw.image`` is developed at https://github.com/lsst/afw.
-You can find Jira issues for this module under the `afw <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.
+You can find Jira issues for this module under the `afw <https://rubinobs.atlassian.net/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.

--- a/doc/lsst.afw.math/index.rst
+++ b/doc/lsst.afw.math/index.rst
@@ -37,7 +37,7 @@ Contributing
 ============
 
 ``lsst.afw.math`` is developed at https://github.com/lsst/afw.
-You can find Jira issues for this module under the `afw <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.
+You can find Jira issues for this module under the `afw <https://rubinobs.atlassian.net/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.
 
 .. If there are topics related to developing this module (rather than using it), link to this from a toctree placed here.
 

--- a/doc/lsst.afw.multiband/index.rst
+++ b/doc/lsst.afw.multiband/index.rst
@@ -26,4 +26,4 @@ Contributing
 ============
 
 ``lsst.afw.multiband`` is developed at https://github.com/lsst/afw.
-You can find Jira issues for this module under the `afw <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.
+You can find Jira issues for this module under the `afw <https://rubinobs.atlassian.net/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.

--- a/doc/lsst.afw.table/index.rst
+++ b/doc/lsst.afw.table/index.rst
@@ -21,7 +21,7 @@ Contributing
 ============
 
 ``lsst.afw.table`` is developed at https://github.com/lsst/afw.
-You can find Jira issues for this module under the `afw <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.
+You can find Jira issues for this module under the `afw <https://rubinobs.atlassian.net/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.
 
 .. _lsst.afw.table-pyapi:
 

--- a/doc/lsst.afw.typehandling/index.rst
+++ b/doc/lsst.afw.typehandling/index.rst
@@ -15,7 +15,7 @@ Contributing
 ============
 
 ``lsst.afw.typehandling`` is developed at https://github.com/lsst/afw.
-You can find Jira issues for this module under the `afw <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.
+You can find Jira issues for this module under the `afw <https://rubinobs.atlassian.net/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20afw>`_ component.
 
 .. If there are topics related to developing this module (rather than using it), link to this from a toctree placed here.
 

--- a/python/lsst/afw/image/exposure/exposureUtils.py
+++ b/python/lsst/afw/image/exposure/exposureUtils.py
@@ -96,6 +96,9 @@ def bbox_contains_sky_coords(bbox, wcs, ra, dec, padding=10):
 
     x_in, y_in = wcs.skyToPixelArray(_ra, _dec, degrees=False)
 
-    xy_contained = bbox.contains(x_in, y_in)
+    # Assume any non-finite point is far outside the box
+    xy_contained = np.zeros_like(x_in, dtype=bool)
+    finite = np.isfinite(x_in) & np.isfinite(y_in)
+    xy_contained[finite] = bbox.contains(x_in[finite], y_in[finite])
 
     return radec_contained & xy_contained

--- a/python/lsst/afw/image/exposure/exposureUtils.py
+++ b/python/lsst/afw/image/exposure/exposureUtils.py
@@ -94,11 +94,11 @@ def bbox_contains_sky_coords(bbox, wcs, ra, dec, padding=10):
 
     radec_contained = poly.contains(_ra, _dec)
 
-    x_in, y_in = wcs.skyToPixelArray(_ra, _dec, degrees=False)
+    contained = np.zeros_like(radec_contained, dtype=bool)
 
-    # Assume any non-finite point is far outside the box
-    xy_contained = np.zeros_like(x_in, dtype=bool)
-    finite = np.isfinite(x_in) & np.isfinite(y_in)
-    xy_contained[finite] = bbox.contains(x_in[finite], y_in[finite])
+    x_in, y_in = wcs.skyToPixelArray(_ra[radec_contained], _dec[radec_contained], degrees=False)
+    xy_contained = bbox.contains(x_in, y_in)
 
-    return radec_contained & xy_contained
+    # contained[not radec_contained] is already false
+    contained[radec_contained] = xy_contained
+    return contained

--- a/tests/test_exposure.py
+++ b/tests/test_exposure.py
@@ -866,8 +866,11 @@ class ExposureTestCase(lsst.utils.tests.TestCase):
         ra = np.concatenate(([300.0], ra, [180.]))
         dec = np.concatenate(([50.0], dec, [50.0]))
 
-        contains = self.exposureMiWcs.containsSkyCoords(ra*units.degree,
-                                                        dec*units.degree)
+        # Bad NaN handling appears as a warning, not an error
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", category=RuntimeWarning)
+            contains = self.exposureMiWcs.containsSkyCoords(ra*units.degree,
+                                                            dec*units.degree)
         compare = np.ones(len(contains), dtype=bool)
         compare[0] = False
         compare[-1] = False


### PR DESCRIPTION
This PR fixes a bug in coordinate checks that attempted to convert NaN or infinite values to integers. The bug was exposed by unit tests, but went unnoticed because it only caused a warning instead of an error.