### PR TITLE
DM-43855: Rework error reporting for assertImagesAlmostEqual

### DIFF
--- a/python/lsst/afw/image/testUtils.py
+++ b/python/lsst/afw/image/testUtils.py
@@ -370,10 +370,23 @@ def imagesDiffer(image0, image1, skipMask=None, rtol=1.0e-05, atol=1e-08):
     if not np.allclose(valFilledArr1, valFilledArr2, rtol=rtol, atol=atol):
         errArr = np.abs(valFilledArr1 - valFilledArr2)
         maxErr = errArr.max()
-        maxPosInd = np.where(errArr == maxErr)
-        maxPosTuple = (maxPosInd[1][0], maxPosInd[0][0])
-        errStr = f"maxDiff={maxErr} at position {maxPosTuple}; " \
-                 f"value={valFilledArr1[maxPosInd][0]} vs. {valFilledArr2[maxPosInd][0]}"
+        maxAbsInd = np.where(errArr == maxErr)
+        maxAbsTuple = (maxAbsInd[1][0], maxAbsInd[0][0])
+        # NOTE: use the second image, because the numpy test is:
+        # |a - b| <= (atol + rtol * |b|)
+        allcloseLimit = rtol*np.abs(valFilledArr2) + atol
+        failing = np.where(errArr >= allcloseLimit)
+        # We want value of the largest absolute error.
+        maxFailing = errArr[failing].max()
+        maxFailingInd = np.where(errArr == maxFailing)
+        maxFailingTuple = (maxFailingInd[0][0], maxFailingInd[1][0])
+        errStr = (f"{len(failing[0])} pixels failing np.allclose(), worst is: "
+                  f"|{valFilledArr1[maxFailingTuple]} - {valFilledArr2[maxFailingTuple]}| = "
+                  f"{maxFailing} > {allcloseLimit[maxFailingTuple]} "
+                  f"(rtol*abs(image2)+atol with rtol={rtol}, atol={atol}) "
+                  f"at position {maxFailingTuple}, and maximum absolute error: "
+                  f"|{valFilledArr1[maxAbsInd][0]} - {valFilledArr2[maxAbsInd][0]}| = {maxErr} "
+                  f"at position {maxAbsTuple}.")
         errStrList.insert(0, errStr)
 
     return "; ".join(errStrList)

--- a/python/lsst/afw/image/testUtils.py
+++ b/python/lsst/afw/image/testUtils.py
@@ -371,7 +371,7 @@ def imagesDiffer(image0, image1, skipMask=None, rtol=1.0e-05, atol=1e-08):
         errArr = np.abs(valFilledArr1 - valFilledArr2)
         maxErr = errArr.max()
         maxAbsInd = np.where(errArr == maxErr)
-        maxAbsTuple = (maxAbsInd[1][0], maxAbsInd[0][0])
+        maxAbsTuple = (maxAbsInd[0][0], maxAbsInd[1][0])
         # NOTE: use the second image, because the numpy test is:
         # |a - b| <= (atol + rtol * |b|)
         allcloseLimit = rtol*np.abs(valFilledArr2) + atol

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -20,7 +20,6 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 #
 import unittest
-import re
 
 import numpy as np
 
@@ -303,9 +302,7 @@ class TestTestUtils(lsst.utils.tests.TestCase):
 
         # arrays differ by a maximum of 2
         errMsg1 = imagesDiffer(image0, image1)
-        match = re.match(r"maxDiff *= *(\d+)", errMsg1, re.IGNORECASE)
-        self.assertIsNotNone(match)
-        self.assertEqual(match.group(1), "2")
+        self.assertIn("maximum absolute error: |0 - 2| = 2 at position (0, 1).", errMsg1)
 
         # arrays are equal to within 5
         self.assertImagesAlmostEqual(image0, image1, atol=5)


### PR DESCRIPTION
Just reporting the maximum absolute difference does not tell you where np.allclose() was failing, because it uses a relative+absolute comparison.