### PR TITLE
DM-44352: Prevent overwriting existing detector mapping

### DIFF
--- a/src/cameraGeom/Camera.cc
+++ b/src/cameraGeom/Camera.cc
@@ -252,13 +252,25 @@ std::shared_ptr<Camera const> Camera::Builder::finish() const {
     // from PIXELS to other things.
     for (auto const & pair : getIdMap()) {
         auto const & detectorBuilder = *pair.second;
-        connections.push_back(
-            TransformMap::Connection{
-                detectorBuilder.getOrientation().makeFpPixelTransform(detectorBuilder.getPixelSize()),
-                getNativeCameraSys(),
-                detectorBuilder.getNativeCoordSys()
-            }
-        );
+        std::vector<TransformMap::Connection> detectorConnections = getDetectorBuilderConnections(detectorBuilder);
+        std::vector<std::vector<CameraSys>> allDetConnections;
+        for (auto const &connection : detectorConnections) {
+            std::vector<CameraSys> tmpConnection = {connection.fromSys, connection.toSys};
+            allDetConnections.push_back(tmpConnection);
+        }
+        std::vector<CameraSys> connection = {detectorBuilder.getNativeCoordSys(), getNativeCameraSys()};
+        std::vector<CameraSys> invConnection = {getNativeCameraSys(), detectorBuilder.getNativeCoordSys()};
+        if ((std::find(allDetConnections.begin(), allDetConnections.end(), connection) == allDetConnections.end()) 
+            && (std::find(allDetConnections.begin(), allDetConnections.end(), invConnection) == allDetConnections.end()) ) {
+        
+            connections.push_back(
+                TransformMap::Connection{
+                    detectorBuilder.getOrientation().makeFpPixelTransform(detectorBuilder.getPixelSize()),
+                    getNativeCameraSys(),
+                    detectorBuilder.getNativeCoordSys()
+                }
+            );
+        }
         connections.insert(connections.end(),
                            getDetectorBuilderConnections(detectorBuilder).begin(),
                            getDetectorBuilderConnections(detectorBuilder).end());

--- a/src/cameraGeom/Detector.cc
+++ b/src/cameraGeom/Detector.cc
@@ -446,7 +446,7 @@ void Detector::InCameraBuilder::setTransformFromPixelsTo(
     CameraSys const & toSys,
     std::shared_ptr<afw::geom::TransformPoint2ToPoint2 const> transform
 ) {
-    if (toSys.getDetectorName() != getName()) {
+    if ((toSys.hasDetectorName()) && (toSys.getDetectorName() != getName())) {
         throw LSST_EXCEPT(
             pex::exceptions::InvalidParameterError,
             (boost::format("Cannot add coordinate system for detector '%s' to detector '%s'.") %


### PR DESCRIPTION
The existing afw code assumes a simple model for the pixels->focal plane mapping and automatically sets that for each detector. This change adds a check to see whether these mappings have already been defined, and if so, skips applying the default simple model.