### PR TITLE
DM-49263-v29: Shift removal to post-v29 to reflect deprecation in v29 (forward-port).

### DIFF
--- a/include/lsst/afw/image/PhotoCalib.h
+++ b/include/lsst/afw/image/PhotoCalib.h
@@ -345,14 +345,14 @@ public:
      *
      * @param maskedImage The masked image to calibrate.
      * @param includeScaleUncertainty Deprecated and ignored; will be removed
-     *                                after v30.
+     *                                after v29.
      *
      * @return The calibrated masked image.
      */
     MaskedImage<float> calibrateImage(MaskedImage<float> const &maskedImage) const;
     // TODO[DM-49400]: remove the overload below.
     [[deprecated(
-        "The includeScaleUncertainty option is deprecated and does nothing. Will be removed after v30."
+        "The includeScaleUncertainty option is deprecated and does nothing. Will be removed after v29."
     )]]
     MaskedImage<float> calibrateImage(MaskedImage<float> const &maskedImage,
                                       bool includeScaleUncertainty) const;
@@ -367,14 +367,14 @@ public:
      *
      * @param maskedImage The masked image with pixel units of nJy to uncalibrate.
      * @param includeScaleUncertainty Deprecated and ignored; will be removed
-     *                                after v30.
+     *                                after v29.
      *
      * @return The uncalibrated masked image.
      */
     MaskedImage<float> uncalibrateImage(MaskedImage<float> const &maskedImage) const;
     // TODO[DM-49400]: remove the overload below.
     [[deprecated(
-        "The includeScaleUncertainty option is deprecated and does nothing. Will be removed after v30."
+        "The includeScaleUncertainty option is deprecated and does nothing. Will be removed after v29."
     )]]
     MaskedImage<float> uncalibrateImage(MaskedImage<float> const &maskedImage,
                                         bool includeScaleUncertainty) const;

--- a/python/lsst/afw/image/_photoCalibContinued.py
+++ b/python/lsst/afw/image/_photoCalibContinued.py
@@ -121,7 +121,7 @@ class PhotoCalib:  # noqa: F811
         maskedImage : `lsst.afw.image.MaskedImage`
             The masked image to calibrate.
         includeScaleUncertainty : `bool`, optional
-             Deprecated and ignored; will be removed after v30.
+             Deprecated and ignored; will be removed after v29.
 
         Returns
         ------
@@ -131,7 +131,7 @@ class PhotoCalib:  # noqa: F811
         if includeScaleUncertainty is not _UnsetEnum.UNSET:
             warnings.warn(
                 "The 'includeScaleUncertainty' argument to calibrateImage is deprecated and does "
-                "nothing.  It will be removed after v30.",
+                "nothing.  It will be removed after v29.",
                 category=FutureWarning
             )
         return self._calibrateImage(maskedImage)
@@ -149,7 +149,7 @@ class PhotoCalib:  # noqa: F811
         maskedImage : `lsst.afw.image.MaskedImage`
             The masked image with pixel units of nJy to uncalibrate.
         includeScaleUncertainty : `bool`, optional
-            Deprecated and ignored; will be removed after v30.
+            Deprecated and ignored; will be removed after v29.
 
         Returns
         uncalibrated : `lsst.afw.image.MaskedImage`
@@ -158,7 +158,7 @@ class PhotoCalib:  # noqa: F811
         if includeScaleUncertainty is not _UnsetEnum.UNSET:
             warnings.warn(
                 "The 'includeScaleUncertainty' argument to uncalibrateImage is deprecated and does "
-                "nothing.  It will be removed after v30.",
+                "nothing.  It will be removed after v29.",
                 category=FutureWarning
             )
         return self._uncalibrateImage(maskedImage)


### PR DESCRIPTION
With the deprecations from DM-49263 now appearing in v29 due a backport, we also need to adjust the deprecation clock on main.