### PR TITLE
DM-47920-v28: Drop unnecessary and broken handling of dotted FITS keys in WCS reads.

### DIFF
--- a/src/geom/detail/frameSetUtils.cc
+++ b/src/geom/detail/frameSetUtils.cc
@@ -375,10 +375,8 @@ ast::FitsChan getFitsChanFromPropertyList(daf::base::PropertySet& metadata,
     }
 
     // Loop over the names and add them to the FitsChan if not excluded
-    for (auto const &fullName : allParamNames) {
-        if (excludeNames.count(fullName) == 0) {
-            std::size_t lastPeriod = fullName.rfind(char('.'));
-            auto name = (lastPeriod == std::string::npos) ? fullName : fullName.substr(lastPeriod + 1);
+    for (auto const &name : allParamNames) {
+        if (excludeNames.count(name) == 0) {
             std::type_info const &type = metadata.typeOf(name);
 
             if (name.size() > 8) {

--- a/tests/test_exposure.py
+++ b/tests/test_exposure.py
@@ -1150,6 +1150,15 @@ class ExposureNoAfwdataTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(reader.readExposureInfo().getPhotoCalib(), self.v1PhotoCalib)
         self.assertEqual(reader.readPhotoCalib(), self.v1PhotoCalib)
 
+    def testReadDottedHeaderKey(self):
+        """Test that we can read a file with a dot-delimited header key."""
+        original = afwImage.ExposureF.readFits(os.path.join(self.dataDir, "exposure-version-2.fits"))
+        original.metadata["x.y.z"] = "three"
+        with lsst.utils.tests.getTempFilePath(".fits") as tmpFile:
+            original.writeFits(tmpFile)
+            roundtripped = afwImage.ExposureF(tmpFile)
+        self.assertMaskedImagesEqual(original.maskedImage, roundtripped.maskedImage)
+
     def testExposureSummaryExtraComponents(self):
         """Test that we can read an exposure summary with extra components.
         """


### PR DESCRIPTION
Writing keys with '.' in them isn't advisable, but HEIRARCH permits it and we definitely don't want it to cause reading everything else to fail.