### PR TITLE
DM-49695 (v29): Allow hasattr to work for table for dunder properties if non-contiguous

### DIFF
--- a/python/lsst/afw/table/_base.py
+++ b/python/lsst/afw/table/_base.py
@@ -338,7 +338,17 @@ class Catalog(metaclass=TemplateMeta):
         try:
             return getattr(self.table, name)
         except AttributeError:
-            return getattr(self.columns, name)
+            # Special case __ properties as they are never going to be column
+            # names.
+            if name.startswith("__"):
+                raise
+        # This can fail if the table is non-contiguous
+        try:
+            attr = getattr(self.columns, name)
+        except Exception as e:
+            e.add_note(f"Error retrieving column attribute '{name}' from {type(self)}")
+            raise
+        return attr
 
     def __str__(self):
         if self.isContiguous():

--- a/tests/test_simpleTable.py
+++ b/tests/test_simpleTable.py
@@ -817,6 +817,11 @@ class SimpleTableTestCase(lsst.utils.tests.TestCase):
         self.assertFloatsEqual(catalog[key], np.array([3.0, 4.0, 5.0]))
         self.assertFalse(catalog[key].flags.writeable)
 
+        # Test that non-contiugous catalog can support hasattr of missing
+        # attributes.
+        self.assertFalse(hasattr(catalog, "__qualname__"))
+        self.assertTrue(hasattr(type(catalog), "__qualname__"))
+
     def testArrayColumnArrayAccess(self):
         """Test column-array access to Array columns on both contiguous and
         non-contiguous arrays.


### PR DESCRIPTION
Other property requests will fail.