### PR TITLE
DM-51271: Reduce FitsTol for AST

### DIFF
--- a/src/geom/SkyWcs.cc
+++ b/src/geom/SkyWcs.cc
@@ -58,7 +58,7 @@ int const SERIALIZATION_VERSION = 1;
 // (or the region specified by NAXIS[12], if provided, but we do not pass this to AST as of 2018-01-17).
 // For more information,
 // see FitsTol in the AST manual http://starlink.eao.hawaii.edu/devdocs/sun211.htx/sun211.html
-double const TIGHT_FITS_TOL = 0.0001;
+double const TIGHT_FITS_TOL = 0.001;
 
 class SkyWcsPersistenceHelper {
 public:


### PR DESCRIPTION
This works around the problem that the 2 GBDES polynomials in a frame set are not directly representable in SIP and so AST falls back to linear WCS. This is better than no WCS at all so we relax the tolerance until AST can be modified to handle the frame sets that we generate from GBDES.