### PR TITLE
DM-51401: Ensure subTest arguments are strings.

### DIFF
--- a/python/lsst/afw/cameraGeom/testUtils.py
+++ b/python/lsst/afw/cameraGeom/testUtils.py
@@ -451,7 +451,7 @@ def assertTransformMapsEqual(self, map1, map2, **kwds):
     self.assertEqual(list(map1), list(map2))  # compares the sets of CameraSys
     for sysFrom in map1:
         for sysTo in map1:
-            with self.subTest(sysFrom=sysFrom, sysTo=sysTo):
+            with self.subTest(sysFrom=repr(sysFrom), sysTo=repr(sysTo)):
                 transform1 = map1.getTransform(sysFrom, sysTo)
                 transform2 = map2.getTransform(sysFrom, sysTo)
                 self.compare2DFunctions(transform1.applyForward, transform2.applyForward, **kwds)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -147,7 +147,7 @@ class ImageTestCase(lsst.utils.tests.TestCase):
 
                 for bboxa, bboxb in itertools.product(bboxes, bboxes):
                     shouldOverlap = bboxa.overlaps(bboxb)
-                    with self.subTest(bboxa=bboxa, bboxb=bboxb):
+                    with self.subTest(bboxa=repr(bboxa), bboxb=repr(bboxb)):
                         subim1a = ImageClass1(image1, bboxa)
                         subim1b = ImageClass1(image1, bboxb)
                         self.assertEqual(afwImage.imagesOverlap(subim1a, subim1b), shouldOverlap)

--- a/tests/test_imageIo1.py
+++ b/tests/test_imageIo1.py
@@ -223,7 +223,7 @@ class ReadFitsTestCase(lsst.utils.tests.TestCase):
                 (afwImage.ImageF, afwImage.ImageD),
                 (None, "LOCAL", "PARENT"),
             ):
-                with self.subTest(ImageClass=str(ImageClass), imageOrigin=imageOrigin):
+                with self.subTest(ImageClass=str(ImageClass), imageOrigin=repr(imageOrigin)):
                     fullImage = ImageClass(filepath)
                     options = dafBase.PropertySet()
                     options.set("llcX", bbox.getMinX())

--- a/tests/test_makeLimitedFitsHeader.py
+++ b/tests/test_makeLimitedFitsHeader.py
@@ -55,7 +55,7 @@ class MakeLimitedFitsHeaderTestCase(lsst.utils.tests.TestCase):
             # Strip trailing whitespace to make the diff clearer
             this = header[start:end].rstrip()
             expected = expectedHeader[start:end].rstrip()
-            with self.subTest(this=this, expected=expected):
+            with self.subTest(this=repr(this), expected=repr(expected)):
                 # For floating point numbers compare as numbers
                 # rather than strings
                 if "'" not in expected and ("." in expected[9:] or "E" in expected[9:]):

--- a/tests/test_maskedImage.py
+++ b/tests/test_maskedImage.py
@@ -160,8 +160,8 @@ class MaskedImageTestCase(lsst.utils.tests.TestCase):
             for image1, mask1, variance1, image2, mask2, variance2 in itertools.product(
                     images, masks, variances, images, masks, variances):
                 with self.subTest(ImageClass1=str(ImageClass1), ImageClass2=str(ImageClass2),
-                                  image1=image1, mask1=mask1, variance1=variance1,
-                                  image2=image2, mask2=mask2, variance2=variance2):
+                                  image1=repr(image1), mask1=repr(mask1), variance1=repr(variance1),
+                                  image2=repr(image2), mask2=repr(mask2), variance2=repr(variance2)):
                     shouldOverlap = (image1 is image2) or (mask1 is mask2) or (variance1 is variance2)
 
                     mi1 = afwImage.makeMaskedImage(image=image1, mask=mask1, variance=variance1)
@@ -170,7 +170,7 @@ class MaskedImageTestCase(lsst.utils.tests.TestCase):
                     self.assertEqual(afwImage.imagesOverlap(mi2, mi1), shouldOverlap)
 
                     for bbox1, bbox2 in itertools.product(bboxes, bboxes):
-                        with self.subTest(bbox1=bbox1, bbox2=bbox2):
+                        with self.subTest(bbox1=repr(bbox1), bbox2=repr(bbox2)):
                             subMi1 = afwImage.makeMaskedImage(image=type(image1)(image1, bbox1),
                                                               mask=afwImage.Mask(mask1, bbox1),
                                                               variance=afwImage.ImageF(variance1, bbox1))

--- a/tests/test_maskedImageIO.py
+++ b/tests/test_maskedImageIO.py
@@ -214,7 +214,7 @@ class MaskedImageTestCase(lsst.utils.tests.TestCase):
                 (afwImage.MaskedImageF, afwImage.MaskedImageD),
                 (None, "LOCAL", "PARENT"),
             ):
-                with self.subTest(ImageClass=str(ImageClass), imageOrigin=imageOrigin):
+                with self.subTest(ImageClass=str(ImageClass), imageOrigin=repr(imageOrigin)):
                     fullImage = ImageClass(filepath)
                     options = dafBase.PropertySet()
                     options.set("llcX", bbox.getMinX())

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -54,7 +54,7 @@ class FitsReaderTestCase(lsst.utils.tests.TestCase):
 
     def testImageFitsReader(self):
         for n, dtypeIn in enumerate(self.dtypes):
-            with self.subTest(dtypeIn=dtypeIn):
+            with self.subTest(dtypeIn=repr(dtypeIn)):
                 imageIn = Image(self.bbox, dtype=dtypeIn)
                 imageIn.array[:, :] = np.random.randint(low=1, high=5, size=imageIn.array.shape)
                 with lsst.utils.tests.getTempFilePath(".fits") as fileName:
@@ -64,7 +64,7 @@ class FitsReaderTestCase(lsst.utils.tests.TestCase):
                     self.assertEqual(reader.readDType(), dtypeIn)
                     self.assertEqual(reader.fileName, fileName)
                     for args in self.args:
-                        with self.subTest(args=args):
+                        with self.subTest(args=repr(args)):
                             array1 = reader.readArray(*args)
                             image1 = reader.read(*args)
                             subIn = imageIn.subset(*args) if args else imageIn
@@ -74,7 +74,7 @@ class FitsReaderTestCase(lsst.utils.tests.TestCase):
                             self.assertImagesEqual(subIn, image1)
                     for dtype2 in self.dtypes[n:]:
                         for args in self.args:
-                            with self.subTest(dtype2=dtype2, args=args):
+                            with self.subTest(dtype2=repr(dtype2), args=repr(args)):
                                 subIn = imageIn.subset(*args) if args else imageIn
                                 array2 = reader.readArray(*args, dtype=dtype2)
                                 image2 = reader.read(*args, dtype=dtype2)
@@ -94,7 +94,7 @@ class FitsReaderTestCase(lsst.utils.tests.TestCase):
             self.assertEqual(reader.readDType(), MaskPixel)
             self.assertEqual(reader.fileName, fileName)
             for args in self.args:
-                with self.subTest(args=args):
+                with self.subTest(args=repr(args)):
                     array = reader.readArray(*args)
                     mask = reader.read(*args)
                     subIn = maskIn.subset(*args) if args else maskIn
@@ -105,7 +105,7 @@ class FitsReaderTestCase(lsst.utils.tests.TestCase):
 
     def testMaskedImageFitsReader(self):
         for n, dtypeIn in enumerate(self.dtypes):
-            with self.subTest(dtypeIn=dtypeIn):
+            with self.subTest(dtypeIn=repr(dtypeIn)):
                 maskedImageIn = MaskedImage(self.bbox, dtype=dtypeIn)
                 maskedImageIn.image.array[:, :] = np.random.randint(low=1, high=5,
                                                                     size=maskedImageIn.image.array.shape
@@ -150,7 +150,7 @@ class FitsReaderTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(reader.readVarianceDType(), VariancePixel)
         self.assertEqual(reader.fileName, fileName)
         for args in self.args:
-            with self.subTest(args=args):
+            with self.subTest(args=repr(args)):
                 object1 = reader.read(*args)
                 subIn = objectIn.subset(*args) if args else objectIn
                 self.assertEqual(object1.image.array.dtype, dtypeIn)
@@ -161,7 +161,7 @@ class FitsReaderTestCase(lsst.utils.tests.TestCase):
                 self.assertImagesEqual(subIn.variance, reader.readVariance(*args))
                 compare(subIn, object1)
                 for dtype2 in dtypesOut:
-                    with self.subTest(dtype2=dtype2, args=args):
+                    with self.subTest(dtype2=repr(dtype2), args=repr(args)):
                         object2 = reader.read(*args, dtype=dtype2)
                         image2 = reader.readImage(*args, dtype=dtype2)
                         self.assertEqual(object2.image.array.dtype, dtype2)
@@ -299,7 +299,7 @@ class FitsReaderTestCase(lsst.utils.tests.TestCase):
         record.setTransmissionCurve(transmissionCurve)
         record.setDetector(detector)
         for n, dtypeIn in enumerate(self.dtypes):
-            with self.subTest(dtypeIn=dtypeIn):
+            with self.subTest(dtypeIn=repr(dtypeIn)):
                 exposureIn = Exposure(self.bbox, dtype=dtypeIn)
                 shape = exposureIn.image.array.shape
                 exposureIn.image.array[:, :] = np.random.randint(low=1, high=5, size=shape)

--- a/tests/test_skyWcs.py
+++ b/tests/test_skyWcs.py
@@ -519,8 +519,9 @@ class SimpleSkyWcsTestCase(SkyWcsBaseTestCase):
                 (lsst.geom.Point3D(0, 0, 0), lsst.geom.Point3D(-100, 500, 1.5)),
                 (0*lsst.geom.degrees, 71*lsst.geom.degrees), (False, True),
                 self.crvalList[0:2], self.orientationList[0:2], (False, True), ("TAN", "STG")):
-            with self.subTest(fpPosition=fpPosition, yaw=yaw, addOpticalDistortion=addOpticalDistortion,
-                              crval=crval, orientation=pixelOrientation):
+            with self.subTest(fpPosition=repr(fpPosition), yaw=repr(yaw),
+                              addOpticalDistortion=repr(addOpticalDistortion),
+                              crval=repr(crval), orientation=repr(pixelOrientation)):
                 pixelsToFocalPlane = cameraGeom.Orientation(
                     fpPosition=fpPosition,
                     yaw=yaw,


### PR DESCRIPTION
pytest-xdist chokes on the error messages otherwise, causing the test to fail.