### PR TITLE
Fix SourceCatalog.asAstropy copy to make all columns writeable

### DIFF
--- a/python/lsst/afw/table/_base.py
+++ b/python/lsst/afw/table/_base.py
@@ -287,8 +287,6 @@ class Catalog(metaclass=TemplateMeta):
             elif key.getTypeString() == "Angle":
                 data = self.columns.get(key)
                 unit = "radian"
-                if copy:
-                    data = data.copy()
             elif "Array" in key.getTypeString() and key.isVariableLength():
                 # Can't get columns for variable-length array fields.
                 if unviewable == "raise":
@@ -297,8 +295,6 @@ class Catalog(metaclass=TemplateMeta):
                     continue
             else:
                 data = self.columns.get(key)
-                if copy:
-                    data = data.copy()
             columns.append(
                 astropy.table.Column(
                     data,
@@ -307,7 +303,7 @@ class Catalog(metaclass=TemplateMeta):
                     description=item.field.getDoc()
                 )
             )
-        return cls(columns, meta=meta, copy=False)
+        return cls(columns, meta=meta, copy=copy)
 
     def __dir__(self):
         """

--- a/tests/test_astropyTableViews.py
+++ b/tests/test_astropyTableViews.py
@@ -209,6 +209,17 @@ class AstropyTableViewTestCase(lsst.utils.tests.TestCase):
         self.assertNotIn("array2", v1.columns)
         self.assertIn("arrayOk", v1.columns)
 
+    def testCopy(self):
+        """Test that copying a catalog creates a deep copy."""
+        v1 = self.catalog.asAstropy(copy=True)
+        v1["a1"][0] = 10.0
+        self.assertNotEqual(self.catalog[0]["a1"], 10.0)
+        self.assertEqual(v1["a1"][0], 10.0)
+
+        v1["a4"] = False
+        np.testing.assert_array_equal(v1["a4"], np.zeros((len(v1), ), dtype=bool))
+        self.assertNotEqual(self.catalog[0]["a4"], False)
+
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):
     pass


### PR DESCRIPTION
There is a problem that copying a numpy array does not update wheather or not the column is read only. This commit changes the way that copy is implemented by building the astropy table and then copying the table, which is a true deep copy.