### PR TITLE
DM-38772: Use pybind11 v3 holder classes

### DIFF
--- a/include/lsst/afw/cameraGeom/Detector.h
+++ b/include/lsst/afw/cameraGeom/Detector.h
@@ -53,7 +53,7 @@ enum class DetectorType {
  * An abstract base class that provides common accessors for Detector and
  * Detector::Builder.
  */
-class DetectorBase {
+class DetectorBase : public typehandling::Storable {
 public:
 
     using CrosstalkMatrix = ndarray::Array<float const, 2>;
@@ -180,8 +180,7 @@ protected:
  */
 class Detector final :
     public DetectorBase,
-    public table::io::PersistableFacade<Detector>,
-    public typehandling::Storable
+    public table::io::PersistableFacade<Detector>
 {
 public:
 

--- a/include/lsst/afw/table/Catalog.h
+++ b/include/lsst/afw/table/Catalog.h
@@ -148,10 +148,11 @@ public:
         insert(end(), first, last, deep);
     }
 
-    /// Shallow copy constructor.
-    CatalogT(CatalogT const& other) : _table(other._table), _internal(other._internal) {}
-    // Delegate to copy constructor for backward compatibility
-    CatalogT(CatalogT&& other) : CatalogT(other) {}
+    //@{
+    /// Shallow copy and constructors.
+    CatalogT(CatalogT const& other) = default;
+    CatalogT(CatalogT&& other) noexcept = default;
+    //@}
 
     ~CatalogT() = default;
 
@@ -181,7 +182,7 @@ public:
      *
      *  The returned array's records are shallow copies, and hence will not in general be contiguous.
      */
-    CatalogT<RecordT> subset(ndarray::Array<bool const, 1> const& mask) const {
+    CatalogT subset(ndarray::Array<bool const, 1> const& mask) const {
         if (size_type(mask.size()) != size()) {
             throw LSST_EXCEPT(
                     pex::exceptions::LengthError,
@@ -202,7 +203,7 @@ public:
      * @brief Returns a shallow copy of a subset of this Catalog.  The arguments
      * correspond to python's slice() syntax.
      */
-    CatalogT<RecordT> subset(std::ptrdiff_t startd, std::ptrdiff_t stopd, std::ptrdiff_t step) const {
+    CatalogT subset(std::ptrdiff_t startd, std::ptrdiff_t stopd, std::ptrdiff_t step) const {
         /* Python's slicing syntax is weird and wonderful.
 
          Both the "start" and "stop" indices can be negative, which means the

--- a/include/lsst/afw/table/Exposure.h
+++ b/include/lsst/afw/table/Exposure.h
@@ -353,7 +353,7 @@ public:
     ExposureCatalogT(ExposureCatalogT<OtherRecordT> const& other) : Base(other) {}
 
     ExposureCatalogT(ExposureCatalogT const&) = default;
-    ExposureCatalogT(ExposureCatalogT&&) = default;
+    ExposureCatalogT(ExposureCatalogT&&) noexcept = default;
     ExposureCatalogT& operator=(ExposureCatalogT const&) = default;
     ExposureCatalogT& operator=(ExposureCatalogT&&) = default;
     ~ExposureCatalogT() = default;

--- a/include/lsst/afw/table/SortedCatalog.h
+++ b/include/lsst/afw/table/SortedCatalog.h
@@ -54,7 +54,7 @@ public:
     using Base::find;
 
     SortedCatalogT(SortedCatalogT const&) = default;
-    SortedCatalogT(SortedCatalogT&&) = default;
+    SortedCatalogT(SortedCatalogT&&) noexcept = default;
     SortedCatalogT& operator=(SortedCatalogT const&) = default;
     SortedCatalogT& operator=(SortedCatalogT&&) = default;
     ~SortedCatalogT() = default;

--- a/include/lsst/afw/table/python/catalog.h
+++ b/include/lsst/afw/table/python/catalog.h
@@ -36,7 +36,7 @@ namespace table {
 namespace python {
 
 template <typename Record>
-using PyCatalog = pybind11::class_<CatalogT<Record>, std::shared_ptr<CatalogT<Record>>>;
+using PyCatalog = pybind11::classh<CatalogT<Record>>;
 
 /// Extract a column from a potentially non-contiguous Catalog
 template <typename T, typename Record>

--- a/include/lsst/afw/table/python/columnView.h
+++ b/include/lsst/afw/table/python/columnView.h
@@ -36,8 +36,7 @@ namespace table {
 namespace python {
 
 template <typename Record>
-using PyColumnView =
-        pybind11::class_<ColumnViewT<Record>, std::shared_ptr<ColumnViewT<Record>>, BaseColumnView>;
+using PyColumnView = pybind11::classh<ColumnViewT<Record>, BaseColumnView>;
 
 /**
  * Declare member and static functions for a given instantiation of lsst::afw::table::ColumnViewT<RecordT>.

--- a/include/lsst/afw/table/python/sortedCatalog.h
+++ b/include/lsst/afw/table/python/sortedCatalog.h
@@ -36,8 +36,7 @@ namespace table {
 namespace python {
 
 template <typename Record>
-using PySortedCatalog =
-        pybind11::class_<SortedCatalogT<Record>, std::shared_ptr<SortedCatalogT<Record>>, CatalogT<Record>>;
+using PySortedCatalog = pybind11::classh<SortedCatalogT<Record>, CatalogT<Record>>;
 
 /**
  * Wrap an instantiation of lsst::afw::table::SortedCatalogT<Record>.

--- a/include/lsst/afw/typehandling/python.h
+++ b/include/lsst/afw/typehandling/python.h
@@ -51,7 +51,7 @@ namespace typehandling {
  * @see [pybind11 documentation](https://pybind11.readthedocs.io/en/stable/advanced/classes.html)
  */
 template <class Base = Storable>
-class StorableHelper : public Base {
+class StorableHelper : public Base, public pybind11::trampoline_self_life_support {
 public:
     using Base::Base;
 

--- a/python/lsst/afw/cameraGeom/_amplifier.cc
+++ b/python/lsst/afw/cameraGeom/_amplifier.cc
@@ -37,8 +37,8 @@ namespace lsst {
 namespace afw {
 namespace cameraGeom {
 
-using PyAmplifier = py::class_<Amplifier, std::shared_ptr<Amplifier>>;
-using PyAmplifierBuilder = py::class_<Amplifier::Builder, Amplifier, std::shared_ptr<Amplifier::Builder>>;
+using PyAmplifier = py::classh<Amplifier>;
+using PyAmplifierBuilder = py::classh<Amplifier::Builder, Amplifier>;
 
 void wrapAmplifier(lsst::cpputils::python::WrapperCollection &wrappers) {
     wrappers.addInheritanceDependency("lsst.afw.table");

--- a/python/lsst/afw/cameraGeom/_camera.cc
+++ b/python/lsst/afw/cameraGeom/_camera.cc
@@ -36,9 +36,8 @@ namespace lsst {
 namespace afw {
 namespace cameraGeom {
 
-using PyCamera = py::class_<Camera, DetectorCollection, std::shared_ptr<Camera>>;
-using PyCameraBuilder = py::class_<Camera::Builder, DetectorCollectionBase<Detector::InCameraBuilder>,
-                                   std::shared_ptr<Camera::Builder>>;
+using PyCamera = py::classh<Camera, DetectorCollection>;
+using PyCameraBuilder = py::classh<Camera::Builder, DetectorCollectionBase<Detector::InCameraBuilder>>;
 
 // Bindings here are ordered to match the order of the declarations in
 // Camera.h to the greatest extent possible; modifications to this file should

--- a/python/lsst/afw/cameraGeom/_cameraSys.cc
+++ b/python/lsst/afw/cameraGeom/_cameraSys.cc
@@ -62,12 +62,12 @@ void declareCommonSysMethods(PyClass &cls) {
 
 void wrapCameraSys(lsst::cpputils::python::WrapperCollection &wrappers) {
     /* Module level */
-    wrappers.wrapType(py::class_<CameraSysPrefix>(wrappers.module, "CameraSysPrefix"),
+    wrappers.wrapType(py::classh<CameraSysPrefix>(wrappers.module, "CameraSysPrefix"),
                       [](auto &mod, auto &cls) {
                           declareCommonSysMethods<CameraSysPrefix>(cls);
                           cls.def(py::init<std::string const &>(), "sysName"_a);
                       });
-    wrappers.wrapType(py::class_<CameraSys>(wrappers.module, "CameraSys"), [](auto &mod, auto &cls) {
+    wrappers.wrapType(py::classh<CameraSys>(wrappers.module, "CameraSys"), [](auto &mod, auto &cls) {
         declareCommonSysMethods<CameraSys>(cls);
         /* Constructors */
         cls.def(py::init<std::string const &>(), "sysName"_a);

--- a/python/lsst/afw/cameraGeom/_detector.cc
+++ b/python/lsst/afw/cameraGeom/_detector.cc
@@ -48,13 +48,11 @@ namespace cameraGeom {
 
 namespace {
 
-using PyDetectorBase = py::class_<DetectorBase, std::shared_ptr<DetectorBase>>;
-using PyDetector = py::class_<Detector, DetectorBase, std::shared_ptr<Detector>, typehandling::Storable>;
-using PyDetectorBuilder = py::class_<Detector::Builder, DetectorBase, std::shared_ptr<Detector::Builder>>;
-using PyDetectorPartialRebuilder = py::class_<Detector::PartialRebuilder, Detector::Builder,
-                                              std::shared_ptr<Detector::PartialRebuilder>>;
-using PyDetectorInCameraBuilder =
-        py::class_<Detector::InCameraBuilder, Detector::Builder, std::shared_ptr<Detector::InCameraBuilder>>;
+using PyDetectorBase = py::classh<DetectorBase, typehandling::Storable>;
+using PyDetector = py::classh<Detector, DetectorBase>;
+using PyDetectorBuilder = py::classh<Detector::Builder, DetectorBase>;
+using PyDetectorPartialRebuilder = py::classh<Detector::PartialRebuilder, Detector::Builder>;
+using PyDetectorInCameraBuilder = py::classh<Detector::InCameraBuilder, Detector::Builder>;
 
 // Declare Detector methods overloaded on one coordinate system class
 template <typename SysT, typename PyClass>

--- a/python/lsst/afw/cameraGeom/_detectorCollection.cc
+++ b/python/lsst/afw/cameraGeom/_detectorCollection.cc
@@ -39,11 +39,9 @@ namespace cameraGeom {
 namespace {
 
 template <typename T>
-using PyDetectorCollectionBase =
-        py::class_<DetectorCollectionBase<T>, std::shared_ptr<DetectorCollectionBase<T>>>;
+using PyDetectorCollectionBase = py::classh<DetectorCollectionBase<T>>;
 
-using PyDetectorCollection = py::class_<DetectorCollection, DetectorCollectionBase<Detector const>,
-                                        std::shared_ptr<DetectorCollection>>;
+using PyDetectorCollection = py::classh<DetectorCollection, DetectorCollectionBase<Detector const>>;
 
 template <typename T>
 void declareDetectorCollectionBase(PyDetectorCollectionBase<T> &cls) {

--- a/python/lsst/afw/cameraGeom/_transformMap.cc
+++ b/python/lsst/afw/cameraGeom/_transformMap.cc
@@ -40,9 +40,8 @@ namespace afw {
 namespace cameraGeom {
 namespace {
 
-using PyTransformMap = py::class_<TransformMap, std::shared_ptr<TransformMap>>;
-using PyTransformMapConnection =
-        py::class_<TransformMap::Connection, std::shared_ptr<TransformMap::Connection>>;
+using PyTransformMap = py::classh<TransformMap>;
+using PyTransformMapConnection = py::classh<TransformMap::Connection>;
 
 void declareTransformMap(lsst::cpputils::python::WrapperCollection &wrappers) {
     auto transformMap = wrappers.wrapType(PyTransformMap(wrappers.module, "TransformMap"), [](auto &mod,

--- a/python/lsst/afw/coord/_observatory.cc
+++ b/python/lsst/afw/coord/_observatory.cc
@@ -35,7 +35,7 @@ namespace coord {
 
 void wrapObservatory(lsst::cpputils::python::WrapperCollection& wrappers) {
     wrappers.wrapType(
-            py::class_<Observatory, std::shared_ptr<Observatory>>(wrappers.module, "Observatory"),
+            py::classh<Observatory>(wrappers.module, "Observatory"),
             [](auto& mod, auto& cls) {
                 /* Constructors */
                 cls.def(py::init<lsst::geom::Angle const, lsst::geom::Angle const, double const>());

--- a/python/lsst/afw/detection/_footprint.cc
+++ b/python/lsst/afw/detection/_footprint.cc
@@ -80,7 +80,7 @@ void wrapFootprint(WrapperCollection &wrappers) {
     wrappers.addSignatureDependency("lsst.afw.table");
 
     wrappers.wrapType(
-            py::class_<Footprint, std::shared_ptr<Footprint>>(wrappers.module, "Footprint"),
+            py::classh<Footprint>(wrappers.module, "Footprint"),
             [](auto &mod, auto &cls) {
                 cls.def(py::init<std::shared_ptr<geom::SpanSet>, lsst::geom::Box2I const &>(), "inputSpans"_a,
                         "region"_a = lsst::geom::Box2I());

--- a/python/lsst/afw/detection/_footprintCtrl.cc
+++ b/python/lsst/afw/detection/_footprintCtrl.cc
@@ -37,7 +37,7 @@ namespace afw {
 namespace detection {
 
 void wrapFootprintCtrl(cpputils::python::WrapperCollection& wrappers) {
-    wrappers.wrapType(py::class_<FootprintControl>(wrappers.module, "FootprintControl"),
+    wrappers.wrapType(py::classh<FootprintControl>(wrappers.module, "FootprintControl"),
                       [](auto& mod, auto& cls) {
                           cls.def(py::init<>());
                           cls.def(py::init<bool, bool>(), "circular"_a, "isotropic"_a = false);

--- a/python/lsst/afw/detection/_footprintMerge.cc
+++ b/python/lsst/afw/detection/_footprintMerge.cc
@@ -39,7 +39,7 @@ void wrapFootprintMerge(cpputils::python::WrapperCollection &wrappers) {
     wrappers.addSignatureDependency("lsst.afw.table");
 
     wrappers.wrapType(
-            py::class_<FootprintMergeList>(wrappers.module, "FootprintMergeList"), [](auto &mod, auto &cls) {
+            py::classh<FootprintMergeList>(wrappers.module, "FootprintMergeList"), [](auto &mod, auto &cls) {
                 cls.def(py::init<afw::table::Schema &, std::vector<std::string> const &,
                                  afw::table::Schema const &>(),
                         "sourceSchema"_a, "filterList"_a, "initialPeakSchema"_a);

--- a/python/lsst/afw/detection/_footprintSet.cc
+++ b/python/lsst/afw/detection/_footprintSet.cc
@@ -88,7 +88,7 @@ void wrapFootprintSet(cpputils::python::WrapperCollection &wrappers) {
     wrappers.addSignatureDependency("lsst.afw.table");
 
     wrappers.wrapType(
-            py::class_<FootprintSet, std::shared_ptr<FootprintSet>>(wrappers.module, "FootprintSet"),
+            py::classh<FootprintSet>(wrappers.module, "FootprintSet"),
             [](auto &mod, auto &cls) {
                 declareTemplatedMembers<std::uint16_t>(cls);
                 declareTemplatedMembers<int>(cls);

--- a/python/lsst/afw/detection/_gaussianPsf.cc
+++ b/python/lsst/afw/detection/_gaussianPsf.cc
@@ -37,7 +37,7 @@ namespace detection {
 
 void wrapGaussianPsf(cpputils::python::WrapperCollection& wrappers) {
     wrappers.wrapType(
-            py::class_<GaussianPsf, std::shared_ptr<GaussianPsf>, Psf>(wrappers.module, "GaussianPsf"),
+            py::classh<GaussianPsf, Psf>(wrappers.module, "GaussianPsf"),
             [](auto& mod, auto& cls) {
                 table::io::python::addPersistableMethods<GaussianPsf>(cls);
 

--- a/python/lsst/afw/detection/_heavyFootprint.cc
+++ b/python/lsst/afw/detection/_heavyFootprint.cc
@@ -47,7 +47,7 @@ template <typename ImagePixelT, typename MaskPixelT = lsst::afw::image::MaskPixe
 void declareHeavyFootprint(WrapperCollection &wrappers, std::string const &suffix) {
     using Class = HeavyFootprint<ImagePixelT>;
     wrappers.wrapType(
-            py::class_<Class, std::shared_ptr<Class>, Footprint>(wrappers.module,
+            py::classh<Class, Footprint>(wrappers.module,
                                                                  ("HeavyFootprint" + suffix).c_str()),
             [](auto &mod, auto &cls) {
                 cls.def(py::init<Footprint const &,

--- a/python/lsst/afw/detection/_peak.cc
+++ b/python/lsst/afw/detection/_peak.cc
@@ -43,8 +43,8 @@ namespace detection {
 
 namespace {
 
-using PyPeakRecord = py::class_<PeakRecord, std::shared_ptr<PeakRecord>, table::BaseRecord>;
-using PyPeakTable = py::class_<PeakTable, std::shared_ptr<PeakTable>, table::BaseTable>;
+using PyPeakRecord = py::classh<PeakRecord, table::BaseRecord>;
+using PyPeakTable = py::classh<PeakTable, table::BaseTable>;
 
 /**
 @internal Declare constructors and member and static functions for a pybind11 PeakRecord

--- a/python/lsst/afw/detection/_psf.cc
+++ b/python/lsst/afw/detection/_psf.cc
@@ -26,7 +26,6 @@
 #include <pybind11/pybind11.h>
 
 #include "lsst/cpputils/python.h"
-#include "lsst/cpputils/python/PySharedPtr.h"
 
 #include "lsst/pex/exceptions/Runtime.h"
 #include "lsst/pex/exceptions/python/Exception.h"
@@ -39,8 +38,6 @@
 
 namespace py = pybind11;
 using namespace pybind11::literals;
-
-using lsst::cpputils::python::PySharedPtr;
 
 namespace lsst {
 namespace afw {
@@ -58,7 +55,7 @@ void wrapPsf(cpputils::python::WrapperCollection& wrappers) {
     cls.def(py::init<std::string const &>());
 
     auto clsPsf = wrappers.wrapType(
-            py::class_<Psf, PySharedPtr<Psf>, typehandling::Storable, PsfTrampoline<>>(
+            py::classh<Psf, typehandling::Storable, PsfTrampoline<>>(
                 wrappers.module, "Psf"
             ),
             [](auto& mod, auto& cls) {

--- a/python/lsst/afw/detection/_threshold.cc
+++ b/python/lsst/afw/detection/_threshold.cc
@@ -40,7 +40,7 @@ namespace detection {
 
 void wrapThreshold(cpputils::python::WrapperCollection& wrappers) {
     auto clsThreshold = wrappers.wrapType(
-            py::class_<Threshold, std::shared_ptr<Threshold>>(wrappers.module, "Threshold"),
+            py::classh<Threshold>(wrappers.module, "Threshold"),
             [](auto& mod, auto& cls) {
                 cls.def(py::init<double const, typename Threshold::ThresholdType const, bool const,
                                  double const>(),

--- a/python/lsst/afw/geom/_endpoint.cc
+++ b/python/lsst/afw/geom/_endpoint.cc
@@ -117,7 +117,7 @@ template <typename Point, typename Array>
 void declareBaseEndpoint(lsst::cpputils::python::WrapperCollection &wrappers, std::string const &suffix) {
     using Class = BaseEndpoint<Point, Array>;
     std::string const pyClassName = "_BaseEndpoint" + suffix;
-    wrappers.wrapType(py::class_<Class, std::shared_ptr<Class>>(wrappers.module, pyClassName.c_str()),
+    wrappers.wrapType(py::classh<Class>(wrappers.module, pyClassName.c_str()),
                       [](auto &mod, auto &cls) {
                           cls.def_property_readonly("nAxes", &Class::getNAxes);
                           addDataConverters(cls);
@@ -137,7 +137,7 @@ void declareBaseVectorEndpoint(lsst::cpputils::python::WrapperCollection &wrappe
     std::string const pyClassName = "_BaseVectorEndpoint" + suffix;
 
     declareBaseEndpoint<Point, Array>(wrappers, suffix);
-    wrappers.wrapType(py::class_<Class, std::shared_ptr<Class>, BaseEndpoint<Point, Array>>(
+    wrappers.wrapType(py::classh<Class, BaseEndpoint<Point, Array>>(
                               wrappers.module, pyClassName.c_str()),
                       [](auto &mod, auto &cls) { addDataConverters(cls); });
 }
@@ -150,7 +150,7 @@ void declareGenericEndpoint(lsst::cpputils::python::WrapperCollection &wrappers)
 
     declareBaseEndpoint<Point, Array>(wrappers, "Generic");
 
-    wrappers.wrapType(py::class_<Class, std::shared_ptr<Class>, BaseEndpoint<Point, Array>>(
+    wrappers.wrapType(py::classh<Class, BaseEndpoint<Point, Array>>(
                               wrappers.module, "GenericEndpoint"),
                       [](auto &mod, auto &cls) {
                           cls.def(py::init<int>(), "nAxes"_a);
@@ -168,7 +168,7 @@ void declarePoint2Endpoint(lsst::cpputils::python::WrapperCollection &wrappers) 
 
     declareBaseVectorEndpoint<Point>(wrappers, pointNumStr);
 
-    wrappers.wrapType(py::class_<Class, std::shared_ptr<Class>, BaseVectorEndpoint<Point>>(
+    wrappers.wrapType(py::classh<Class, BaseVectorEndpoint<Point>>(
                               wrappers.module, pyClassName.c_str()),
                       [](auto &mod, auto &cls) {
                           cls.def(py::init<>());
@@ -186,7 +186,7 @@ void declareSpherePointEndpoint(lsst::cpputils::python::WrapperCollection &wrapp
 
     declareBaseVectorEndpoint<Point>(wrappers, "SpherePoint");
 
-    wrappers.wrapType(py::class_<Class, std::shared_ptr<Class>, BaseVectorEndpoint<Point>>(
+    wrappers.wrapType(py::classh<Class, BaseVectorEndpoint<Point>>(
                               wrappers.module, "SpherePointEndpoint"),
                       [](auto &mod, auto &cls) {
                           cls.def(py::init<>());

--- a/python/lsst/afw/geom/_polygon.cc
+++ b/python/lsst/afw/geom/_polygon.cc
@@ -49,7 +49,7 @@ namespace polygon {
 namespace {
 void declarePolygon(lsst::cpputils::python::WrapperCollection &wrappers) {
     wrappers.wrapType(
-            py::class_<Polygon, std::shared_ptr<Polygon>, typehandling::Storable>(wrappers.module, "Polygon"),
+            py::classh<Polygon, typehandling::Storable>(wrappers.module, "Polygon"),
             [](auto &mod, auto &cls) {
                 /* Constructors */
                 cls.def(py::init<Polygon::Box const &>());

--- a/python/lsst/afw/geom/_sipApproximation.cc
+++ b/python/lsst/afw/geom/_sipApproximation.cc
@@ -38,7 +38,7 @@ namespace afw {
 namespace geom {
 namespace {
 
-using PySipApproximation = py::class_<SipApproximation, std::shared_ptr<SipApproximation>>;
+using PySipApproximation = py::classh<SipApproximation>;
 
 void declareSipApproximation(lsst::cpputils::python::WrapperCollection &wrappers) {
     wrappers.wrapType(PySipApproximation(wrappers.module, "SipApproximation"), [](auto &mod, auto &cls) {

--- a/python/lsst/afw/geom/_skyWcs.cc
+++ b/python/lsst/afw/geom/_skyWcs.cc
@@ -80,7 +80,7 @@ void declareSkyWcs(lsst::cpputils::python::WrapperCollection &wrappers) {
                 "simplify"_a = true);
     });
     wrappers.wrapType(
-            py::class_<SkyWcs, std::shared_ptr<SkyWcs>, typehandling::Storable>(wrappers.module, "SkyWcs"),
+            py::classh<SkyWcs, typehandling::Storable>(wrappers.module, "SkyWcs"),
             [](auto &mod, auto &cls) {
                 cls.def(py::init<daf::base::PropertySet &, bool>(), "metadata"_a, "strip"_a = false);
                 cls.def(py::init<ast::FrameDict const &>(), "frameDict"_a);

--- a/python/lsst/afw/geom/_span.cc
+++ b/python/lsst/afw/geom/_span.cc
@@ -37,7 +37,7 @@ namespace afw {
 namespace geom {
 namespace {
 
-using PySpan = py::class_<Span, std::shared_ptr<Span>>;
+using PySpan = py::classh<Span>;
 
 // A thin wrapper around SpanPixelIterator.
 // Unfortunately we cannot use py::make_iterator here, as we normally
@@ -59,7 +59,7 @@ private:
 };
 
 static void declareSpanIterator(lsst::cpputils::python::WrapperCollection &wrappers) {
-    wrappers.wrapType(py::class_<SpanIterator>(wrappers.module, "SpanIterator"), [](auto &mod, auto &cls) {
+    wrappers.wrapType(py::classh<SpanIterator>(wrappers.module, "SpanIterator"), [](auto &mod, auto &cls) {
         cls.def("__iter__", [](SpanIterator &it) -> SpanIterator & { return it; });
         cls.def("__next__", &SpanIterator::next);
     });

--- a/python/lsst/afw/geom/_spanSet.cc
+++ b/python/lsst/afw/geom/_spanSet.cc
@@ -46,7 +46,7 @@ namespace geom {
 
 namespace {
 
-using PySpanSet = py::class_<SpanSet, std::shared_ptr<SpanSet>>;
+using PySpanSet = py::classh<SpanSet>;
 
 template <typename Pixel, typename PyClass>
 void declareFlattenMethod(PyClass &cls) {

--- a/python/lsst/afw/geom/_transform.cc
+++ b/python/lsst/afw/geom/_transform.cc
@@ -79,7 +79,7 @@ void declareTransform(lsst::cpputils::python::WrapperCollection &wrappers) {
 
     std::string const pyClassName = Class::getShortClassName();
     wrappers.wrapType(
-            py::class_<Class, std::shared_ptr<Class>, table::io::Persistable>(wrappers.module, pyClassName.c_str()),
+            py::classh<Class, table::io::Persistable>(wrappers.module, pyClassName.c_str()),
             [](auto &mod, auto &cls) {
                 std::string const pyClassName = Class::getShortClassName();
                 cls.def(py::init<ast::FrameSet const &, bool>(), "frameSet"_a, "simplify"_a = true);

--- a/python/lsst/afw/geom/ellipses/_axes.cc
+++ b/python/lsst/afw/geom/ellipses/_axes.cc
@@ -36,7 +36,7 @@ namespace geom {
 namespace ellipses {
 void wrapAxes(lsst::cpputils::python::WrapperCollection &wrappers) {
     wrappers.wrapType(
-            py::class_<Axes, std::shared_ptr<Axes>, BaseCore>(wrappers.module, "Axes"),
+            py::classh<Axes, BaseCore>(wrappers.module, "Axes"),
             [](auto &mod, auto &cls) {
                 /* Constructors */
                 cls.def(py::init<double, double, double, bool>(), "a"_a = 1.0, "b"_a = 1.0, "theta"_a = 0.0,

--- a/python/lsst/afw/geom/ellipses/_baseCore.cc
+++ b/python/lsst/afw/geom/ellipses/_baseCore.cc
@@ -38,7 +38,7 @@ namespace afw {
 namespace geom {
 namespace ellipses {
 void wrapBaseCore(lsst::cpputils::python::WrapperCollection &wrappers) {
-    wrappers.wrapType(py::class_<BaseCore, std::shared_ptr<BaseCore>>(wrappers.module, "BaseCore"),
+    wrappers.wrapType(py::classh<BaseCore>(wrappers.module, "BaseCore"),
                       [](auto &mod, auto &cls) {
                           cls.def("__eq__", &BaseCore::operator==, py::is_operator());
                           cls.def("__nq__", &BaseCore::operator!=, py::is_operator());

--- a/python/lsst/afw/geom/ellipses/_ellipse.cc
+++ b/python/lsst/afw/geom/ellipses/_ellipse.cc
@@ -43,7 +43,7 @@ namespace geom {
 namespace ellipses {
 void wrapEllipse(lsst::cpputils::python::WrapperCollection &wrappers) {
     wrappers.wrapType(
-            py::class_<Ellipse, std::shared_ptr<Ellipse>>(wrappers.module, "Ellipse"),
+            py::classh<Ellipse>(wrappers.module, "Ellipse"),
             [](auto &mod, auto &cls) {
                 /* Constructors */
                 cls.def(py::init<BaseCore const &, lsst::geom::Point2D const &>(), "core"_a,

--- a/python/lsst/afw/geom/ellipses/_quadrupole.cc
+++ b/python/lsst/afw/geom/ellipses/_quadrupole.cc
@@ -38,7 +38,7 @@ namespace geom {
 namespace ellipses {
 void wrapQuadrupole(lsst::cpputils::python::WrapperCollection &wrappers) {
     wrappers.wrapType(
-            py::class_<Quadrupole, std::shared_ptr<Quadrupole>, BaseCore>(wrappers.module, "Quadrupole"),
+            py::classh<Quadrupole, BaseCore>(wrappers.module, "Quadrupole"),
             [](auto &mod, auto &cls) {
                 /* Member types and enums */
                 using Matrix = Eigen::Matrix<double, 2, 2, Eigen::DontAlign>;

--- a/python/lsst/afw/geom/ellipses/_separable.cc
+++ b/python/lsst/afw/geom/ellipses/_separable.cc
@@ -43,7 +43,7 @@ template <typename Ellipticity_, typename Radius_>
 void declareSeparable(lsst::cpputils::python::WrapperCollection &wrappers, const std::string &suffix) {
     using Class = Separable<Ellipticity_, Radius_>;
     wrappers.wrapType(
-            py::class_<Class, std::shared_ptr<Class>, BaseCore>(wrappers.module,
+            py::classh<Class, BaseCore>(wrappers.module,
                                                                 ("Separable" + suffix).c_str()),
             [](auto &mod, auto &cls) {
                 cls.def(py::init<double, double, double, bool>(), "e1"_a = 0.0, "e2"_a = 0.0,

--- a/python/lsst/afw/image/_apCorrMap/_apCorrMap.cc
+++ b/python/lsst/afw/image/_apCorrMap/_apCorrMap.cc
@@ -40,7 +40,7 @@ namespace afw {
 namespace image {
 namespace {
 
-using PyApCorrMap = py::class_<ApCorrMap, std::shared_ptr<ApCorrMap>, typehandling::Storable>;
+using PyApCorrMap = py::classh<ApCorrMap, typehandling::Storable>;
 
 void wrapApCorrMap(lsst::cpputils::python::WrapperCollection &wrappers) {
     wrappers.wrapType(PyApCorrMap(wrappers.module, "ApCorrMap"), [](auto &mod, auto &cls) {

--- a/python/lsst/afw/image/_coaddInputs.cc
+++ b/python/lsst/afw/image/_coaddInputs.cc
@@ -37,7 +37,7 @@ namespace lsst {
 namespace afw {
 namespace image {
 
-using PyCoaddInputs = py::class_<CoaddInputs, std::shared_ptr<CoaddInputs>, typehandling::Storable>;
+using PyCoaddInputs = py::classh<CoaddInputs, typehandling::Storable>;
 
 void wrapCoaddInputs(lsst::cpputils::python::WrapperCollection &wrappers) {
     wrappers.addInheritanceDependency("lsst.afw.typehandling");

--- a/python/lsst/afw/image/_color.cc
+++ b/python/lsst/afw/image/_color.cc
@@ -36,7 +36,7 @@ namespace lsst {
 namespace afw {
 namespace image {
 
-using PyColor = py::class_<Color, std::shared_ptr<Color>>;
+using PyColor = py::classh<Color>;
 
 void wrapColor(lsst::cpputils::python::WrapperCollection & wrappers) {
     PyColor cls(wrappers.module, "Color");

--- a/python/lsst/afw/image/_defect.cc
+++ b/python/lsst/afw/image/_defect.cc
@@ -34,7 +34,7 @@ namespace afw {
 namespace image {
 namespace {
 
-using PyDefectBase = py::class_<DefectBase, std::shared_ptr<DefectBase>>;
+using PyDefectBase = py::classh<DefectBase>;
 
 void declareDefects(lsst::cpputils::python::WrapperCollection &wrappers) {
     wrappers.wrapType(PyDefectBase(wrappers.module, "DefectBase"), [](auto &mod, auto &cls) {

--- a/python/lsst/afw/image/_exposure/_exposure.cc
+++ b/python/lsst/afw/image/_exposure/_exposure.cc
@@ -41,7 +41,7 @@ namespace image {
 namespace {
 
 template <typename PixelT>
-using PyExposure = py::class_<Exposure<PixelT>, std::shared_ptr<Exposure<PixelT>>>;
+using PyExposure = py::classh<Exposure<PixelT>>;
 
 /*
 Declare a constructor that takes an Exposure of FromPixelT and returns an Exposure cast to ToPixelT

--- a/python/lsst/afw/image/_exposureInfo.cc
+++ b/python/lsst/afw/image/_exposureInfo.cc
@@ -46,7 +46,7 @@ namespace afw {
 namespace image {
 namespace {
 
-using PyExposureInfo = py::class_<ExposureInfo, std::shared_ptr<ExposureInfo>>;
+using PyExposureInfo = py::classh<ExposureInfo>;
 
 // Template methods where we can use pybind11's overload resolution (T is input)
 template <class T>

--- a/python/lsst/afw/image/_filterLabel.cc
+++ b/python/lsst/afw/image/_filterLabel.cc
@@ -41,7 +41,7 @@ namespace afw {
 namespace image {
 namespace {
 
-using PyFilterLabel = py::class_<FilterLabel, std::shared_ptr<FilterLabel>, typehandling::Storable>;
+using PyFilterLabel = py::classh<FilterLabel, typehandling::Storable>;
 
 // Macro to convert an exception without defining a global handler for it
 #define _DELEGATE_EXCEPTION(call, cpp_ex, py_ex) \

--- a/python/lsst/afw/image/_image/_image.cc
+++ b/python/lsst/afw/image/_image/_image.cc
@@ -42,16 +42,16 @@ namespace image {
 namespace {
 
 template <typename PixelT>
-using PyImageBase = py::class_<ImageBase<PixelT>, std::shared_ptr<ImageBase<PixelT>>>;
+using PyImageBase = py::classh<ImageBase<PixelT>>;
 
 template <typename PixelT>
-using PyImage = py::class_<Image<PixelT>, std::shared_ptr<Image<PixelT>>, ImageBase<PixelT>>;
+using PyImage = py::classh<Image<PixelT>, ImageBase<PixelT>>;
 
 template <typename PixelT>
-using PyDecoratedImage = py::class_<DecoratedImage<PixelT>, std::shared_ptr<DecoratedImage<PixelT>>>;
+using PyDecoratedImage = py::classh<DecoratedImage<PixelT>>;
 
 template <typename MaskPixelT>
-using PyMask = py::class_<Mask<MaskPixelT>, std::shared_ptr<Mask<MaskPixelT>>, ImageBase<MaskPixelT>>;
+using PyMask = py::classh<Mask<MaskPixelT>, ImageBase<MaskPixelT>>;
 
 /**
 @internal Declare a constructor that takes a MaskedImage of FromPixelT and returns a MaskedImage cast to
@@ -395,7 +395,7 @@ static void declareDecoratedImage(lsst::cpputils::python::WrapperCollection &wra
 /* Declare ImageSlice operators separately since they are only instantiated for float double */
 template <typename PixelT>
 static void addImageSliceOperators(
-        py::class_<Image<PixelT>, std::shared_ptr<Image<PixelT>>, ImageBase<PixelT>> &cls) {
+        py::classh<Image<PixelT>, ImageBase<PixelT>> &cls) {
     cls.def(
             "__add__",
             [](Image<PixelT> const &self, ImageSlice<PixelT> const &other) { return self + other; },

--- a/python/lsst/afw/image/_image/_imageSlice.cc
+++ b/python/lsst/afw/image/_image/_imageSlice.cc
@@ -40,7 +40,7 @@ static void declareImageSlice(lsst::cpputils::python::WrapperCollection &wrapper
     using Class = ImageSlice<PixelT>;
 
     wrappers.wrapType(
-            py::class_<Class, std::shared_ptr<Class>, Image<PixelT>>(wrappers.module,
+            py::classh<Class, Image<PixelT>>(wrappers.module,
                                                                      ("ImageSlice" + suffix).c_str()),
             [](auto &mod, auto &cls) {
                 cls.def(py::init<Image<PixelT> const &>(), "img"_a);

--- a/python/lsst/afw/image/_imagePca.cc
+++ b/python/lsst/afw/image/_imagePca.cc
@@ -41,11 +41,8 @@ template <typename ImageT>
 static void declareImagePca(lsst::cpputils::python::WrapperCollection &wrappers, std::string const &suffix) {
     std::string name = "ImagePca" + suffix;
     wrappers.wrapType(
-            py::class_<ImagePca<ImageT>, std::shared_ptr<ImagePca<ImageT>>>(wrappers.module, name.c_str()),
+            py::classh<ImagePca<ImageT>>(wrappers.module, name.c_str()),
             [](auto &mod, auto &cls) {
-                //  py::class_<ImagePca<ImageT>, std::shared_ptr<ImagePca<ImageT>>> cls(mod, ("ImagePca" +
-                //  suffix).c_str());
-
                 cls.def(py::init<bool>(), "constantWeight"_a = true);
 
                 cls.def("addImage", &ImagePca<ImageT>::addImage, "img"_a, "flux"_a = 0.0);

--- a/python/lsst/afw/image/_maskedImage/_maskedImage.cc
+++ b/python/lsst/afw/image/_maskedImage/_maskedImage.cc
@@ -38,7 +38,7 @@ namespace image {
 namespace {
 
 template <typename ImagePixelT>  // only the image type varies; mask and variance are fixed
-using PyMaskedImage = py::class_<MaskedImage<ImagePixelT>, std::shared_ptr<MaskedImage<ImagePixelT>>>;
+using PyMaskedImage = py::classh<MaskedImage<ImagePixelT>>;
 
 /**
 @internal Declare a constructor that takes a MaskedImage of FromPixelT and returns a MaskedImage cast to

--- a/python/lsst/afw/image/_photoCalib.cc
+++ b/python/lsst/afw/image/_photoCalib.cc
@@ -47,7 +47,7 @@ namespace image {
 namespace {
 
 void declareMeasurement(lsst::cpputils::python::WrapperCollection &wrappers) {
-    wrappers.wrapType(py::class_<Measurement, std::shared_ptr<Measurement>>(wrappers.module, "Measurement"),
+    wrappers.wrapType(py::classh<Measurement>(wrappers.module, "Measurement"),
                       [](auto &mod, auto &cls) {
                           cls.def(py::init<double, double>(), "value"_a, "error"_a);
                           cls.def_readonly("value", &Measurement::value);
@@ -64,7 +64,7 @@ void declareMeasurement(lsst::cpputils::python::WrapperCollection &wrappers) {
 
 void declarePhotoCalib(lsst::cpputils::python::WrapperCollection &wrappers) {
     wrappers.wrapType(
-            py::class_<PhotoCalib, std::shared_ptr<PhotoCalib>, typehandling::Storable>(wrappers.module,
+            py::classh<PhotoCalib, typehandling::Storable>(wrappers.module,
                                                                                         "PhotoCalib"),
             [](auto &mod, auto &cls) {
                 /* Constructors */

--- a/python/lsst/afw/image/_readers.cc
+++ b/python/lsst/afw/image/_readers.cc
@@ -54,15 +54,15 @@ namespace {
 // ImageBaseFitsReader is an implementation detail and is not exposed directly
 // to Python, as we have better ways to share wrapper code between classes
 // at the pybind11 level (e.g. declareCommon below).
-using PyImageFitsReader = py::class_<ImageFitsReader, std::shared_ptr<ImageFitsReader>>;
-using PyMaskFitsReader = py::class_<MaskFitsReader, std::shared_ptr<MaskFitsReader>>;
-using PyMaskedImageFitsReader = py::class_<MaskedImageFitsReader, std::shared_ptr<MaskedImageFitsReader>>;
-using PyExposureFitsReader = py::class_<ExposureFitsReader, std::shared_ptr<ExposureFitsReader>>;
+using PyImageFitsReader = py::classh<ImageFitsReader>;
+using PyMaskFitsReader = py::classh<MaskFitsReader>;
+using PyMaskedImageFitsReader = py::classh<MaskedImageFitsReader>;
+using PyExposureFitsReader = py::classh<ExposureFitsReader>;
 
 // Declare attributes common to all FitsReaders.  Excludes constructors
 // because ExposureFitsReader's don't take an HDU argument.
 template <typename Class, typename... Args>
-void declareCommonMethods(py::class_<Class, Args...> &cls) {
+void declareCommonMethods(py::classh<Class, Args...> &cls) {
     cls.def("readBBox", &Class::readBBox, "origin"_a = PARENT);
     cls.def("readXY0", &Class::readXY0, "bbox"_a = lsst::geom::Box2I(), "origin"_a = PARENT);
     cls.def("getFileName", &Class::getFileName);
@@ -71,7 +71,7 @@ void declareCommonMethods(py::class_<Class, Args...> &cls) {
 
 // Declare attributes common to ImageFitsReader and MaskFitsReader
 template <typename Class, typename... Args>
-void declareSinglePlaneMethods(py::class_<Class, Args...> &cls) {
+void declareSinglePlaneMethods(py::classh<Class, Args...> &cls) {
     cls.def(py::init<std::string const &, int>(), "fileName"_a, "hdu"_a = fits::DEFAULT_HDU);
     cls.def(py::init<fits::MemFileManager &, int>(), "manager"_a, "hdu"_a = fits::DEFAULT_HDU);
     cls.def("readMetadata", &Class::readMetadata);
@@ -99,7 +99,7 @@ void declareSinglePlaneMethods(py::class_<Class, Args...> &cls) {
 
 // Declare attributes shared by MaskedImageFitsReader and MaskedImageFitsReader.
 template <typename Class, typename... Args>
-void declareMultiPlaneMethods(py::class_<Class, Args...> &cls) {
+void declareMultiPlaneMethods(py::classh<Class, Args...> &cls) {
     cls.def("readImageDType", [](Class &self) { return py::dtype(self.readImageDType()); });
     cls.def("readMaskDType", [](Class &self) { return py::dtype(self.readMaskDType()); });
     cls.def("readVarianceDType", [](Class &self) { return py::dtype(self.readVarianceDType()); });

--- a/python/lsst/afw/image/_transmissionCurve.cc
+++ b/python/lsst/afw/image/_transmissionCurve.cc
@@ -41,7 +41,7 @@ namespace afw {
 namespace image {
 
 using PyTransmissionCurve =
-        py::class_<TransmissionCurve, std::shared_ptr<TransmissionCurve>, typehandling::Storable>;
+        py::classh<TransmissionCurve, typehandling::Storable>;
 
 void wrapTransmissionCurve(lsst::cpputils::python::WrapperCollection &wrappers) {
     wrappers.addInheritanceDependency("lsst.afw.typehandling");

--- a/python/lsst/afw/image/_visitInfo.cc
+++ b/python/lsst/afw/image/_visitInfo.cc
@@ -56,7 +56,7 @@ static lsst::geom::Angle const nanAngle(nan);
 
 void declareVisitInfo(lsst::cpputils::python::WrapperCollection &wrappers) {
     wrappers.wrapType(
-            py::class_<VisitInfo, std::shared_ptr<VisitInfo>, typehandling::Storable>(wrappers.module,
+            py::classh<VisitInfo, typehandling::Storable>(wrappers.module,
                                                                                       "VisitInfo"),
             [](auto &mod, auto &cls) {
                 /* Constructors */

--- a/python/lsst/afw/math/_approximate.cc
+++ b/python/lsst/afw/math/_approximate.cc
@@ -41,7 +41,7 @@ void declareApproximate(lsst::cpputils::python::WrapperCollection &wrappers, std
     using Class = Approximate<PixelT>;
 
     wrappers.wrapType(
-            py::class_<Class, std::shared_ptr<Class>>(wrappers.module, ("Approximate" + suffix).c_str()),
+            py::classh<Class>(wrappers.module, ("Approximate" + suffix).c_str()),
             [](auto &mod, auto &cls) {
                 cls.def("getImage", &Class::getImage, "orderX"_a = -1, "orderY"_a = -1);
                 cls.def("getMaskedImage", &Class::getMaskedImage, "orderX"_a = -1, "orderY"_a = -1);
@@ -56,7 +56,7 @@ void declareApproximate(lsst::cpputils::python::WrapperCollection &wrappers, std
 }
 void declareApproximate(lsst::cpputils::python::WrapperCollection &wrappers) {
     auto control =
-            wrappers.wrapType(py::class_<ApproximateControl, std::shared_ptr<ApproximateControl>>(
+            wrappers.wrapType(py::classh<ApproximateControl>(
                                       wrappers.module, "ApproximateControl"),
                               [](auto &mod, auto &cls) {
                                   cls.def(py::init<ApproximateControl::Style, int, int, bool>(), "style"_a,

--- a/python/lsst/afw/math/_background.cc
+++ b/python/lsst/afw/math/_background.cc
@@ -82,7 +82,7 @@ void declareBackground(lsst::cpputils::python::WrapperCollection &wrappers) {
                           enm.export_values();
                       });
 
-    using PyBackgroundControl = py::class_<BackgroundControl, std::shared_ptr<BackgroundControl>>;
+    using PyBackgroundControl = py::classh<BackgroundControl>;
     wrappers.wrapType(PyBackgroundControl(wrappers.module, "BackgroundControl"), [](auto &mod, auto &cls) {
         /* Constructors */
         cls.def(py::init<int const, int const, StatisticsControl const, Property const,
@@ -130,7 +130,7 @@ void declareBackground(lsst::cpputils::python::WrapperCollection &wrappers) {
         cls.def("getApproximateControl", (std::shared_ptr<ApproximateControl>(BackgroundControl::*)()) &
                                                  BackgroundControl::getApproximateControl);
     });
-    using PyBackground = py::class_<Background, std::shared_ptr<Background>>;
+    using PyBackground = py::classh<Background>;
     wrappers.wrapType(PyBackground(wrappers.module, "Background"), [](auto &mod, auto &cls) {
         /* Members */
         declareGetImage<float>(cls, "F");
@@ -143,7 +143,7 @@ void declareBackground(lsst::cpputils::python::WrapperCollection &wrappers) {
                 (std::shared_ptr<BackgroundControl>(Background::*)()) & Background::getBackgroundControl);
     });
 
-    using PyBackgroundMI = py::class_<BackgroundMI, std::shared_ptr<BackgroundMI>, Background>;
+    using PyBackgroundMI = py::classh<BackgroundMI, Background>;
     wrappers.wrapType(PyBackgroundMI(wrappers.module, "BackgroundMI"), [](auto &mod, auto &cls) {
         /* Constructors */
         cls.def(py::init<lsst::geom::Box2I const,

--- a/python/lsst/afw/math/_boundedField.cc
+++ b/python/lsst/afw/math/_boundedField.cc
@@ -43,7 +43,7 @@ namespace afw {
 namespace math {
 namespace {
 
-using PyClass = py::class_<BoundedField, std::shared_ptr<BoundedField>>;
+using PyClass = py::classh<BoundedField>;
 
 template <typename PixelT>
 void declareTemplates(PyClass &cls) {

--- a/python/lsst/afw/math/_chebyshevBoundedField.cc
+++ b/python/lsst/afw/math/_chebyshevBoundedField.cc
@@ -40,7 +40,7 @@ namespace lsst {
 namespace afw {
 namespace math {
 namespace {
-using ClsField = py::class_<ChebyshevBoundedField, std::shared_ptr<ChebyshevBoundedField>, BoundedField>;
+using ClsField = py::classh<ChebyshevBoundedField, BoundedField>;
 
 template <typename PixelT>
 void declareTemplates(ClsField &cls) {
@@ -52,7 +52,7 @@ void declareChebyshevBoundedField(lsst::cpputils::python::WrapperCollection &wra
     /* Module level */
 
     wrappers.wrapType(
-            py::class_<ChebyshevBoundedFieldControl>(wrappers.module, "ChebyshevBoundedFieldControl"),
+            py::classh<ChebyshevBoundedFieldControl>(wrappers.module, "ChebyshevBoundedFieldControl"),
             [](auto &mod, auto &cls) {
                 cls.def(py::init<>());
                 LSST_DECLARE_CONTROL_FIELD(cls, ChebyshevBoundedFieldControl, orderX);

--- a/python/lsst/afw/math/_convolveImage.cc
+++ b/python/lsst/afw/math/_convolveImage.cc
@@ -76,7 +76,7 @@ void declareAll(lsst::cpputils::python::WrapperCollection &wrappers) {
 }
 
 void declareConvolveImage(lsst::cpputils::python::WrapperCollection &wrappers) {
-    using PyClass = py::class_<ConvolutionControl, std::shared_ptr<ConvolutionControl>>;
+    using PyClass = py::classh<ConvolutionControl>;
     wrappers.wrapType(PyClass(wrappers.module, "ConvolutionControl"), [](auto &mod, auto &clsl) {
         clsl.def(py::init<bool, bool, int>(), "doNormalize"_a = true, "doCopyEdge"_a = false,
                  "maxInterpolationDistance"_a = 10);

--- a/python/lsst/afw/math/_function.cc
+++ b/python/lsst/afw/math/_function.cc
@@ -42,7 +42,7 @@ template <typename ReturnT>
 void declareFunction(lsst::cpputils::python::WrapperCollection &wrappers, std::string const &suffix) {
     auto const name = "Function" + suffix;
     wrappers.wrapType(
-            py::class_<Function<ReturnT>, std::shared_ptr<Function<ReturnT>>>(wrappers.module, name.c_str()),
+            py::classh<Function<ReturnT>>(wrappers.module, name.c_str()),
             [](auto &mod, auto &cls) {
                 cls.def(py::init<unsigned int>(), "nParams"_a);
                 cls.def(py::init<std::vector<double> const &>(), "params"_a);
@@ -62,7 +62,7 @@ void declareFunction(lsst::cpputils::python::WrapperCollection &wrappers, std::s
 template <typename ReturnT>
 void declareFunction1(lsst::cpputils::python::WrapperCollection &wrappers, const std::string &suffix) {
     auto const name = "Function1" + suffix;
-    using PyClass = py::class_<Function1<ReturnT>, std::shared_ptr<Function1<ReturnT>>, Function<ReturnT>>;
+    using PyClass = py::classh<Function1<ReturnT>, Function<ReturnT>>;
     wrappers.wrapType(PyClass(wrappers.module, name.c_str()), [](auto &mod, auto &cls) {
         table::io::python::addPersistableMethods<Function1<ReturnT>>(cls);
 
@@ -76,7 +76,7 @@ void declareFunction1(lsst::cpputils::python::WrapperCollection &wrappers, const
 template <typename ReturnT>
 void declareFunction2(lsst::cpputils::python::WrapperCollection &wrappers, const std::string &suffix) {
     auto const name = "Function2" + suffix;
-    using PyClass = py::class_<Function2<ReturnT>, std::shared_ptr<Function2<ReturnT>>, Function<ReturnT>>;
+    using PyClass = py::classh<Function2<ReturnT>, Function<ReturnT>>;
     wrappers.wrapType(PyClass(wrappers.module, name.c_str()), [](auto &mod, auto &cls) {
         table::io::python::addPersistableMethods<Function2<ReturnT>>(cls);
 
@@ -91,8 +91,7 @@ template <typename ReturnT>
 void declareBasePolynomialFunction2(lsst::cpputils::python::WrapperCollection &wrappers,
                                     const std::string &suffix) {
     auto const name = "BasePolynomialFunction2" + suffix;
-    using PyClass = py::class_<BasePolynomialFunction2<ReturnT>,
-                               std::shared_ptr<BasePolynomialFunction2<ReturnT>>, Function2<ReturnT>>;
+    using PyClass = py::classh<BasePolynomialFunction2<ReturnT>, Function2<ReturnT>>;
     wrappers.wrapType(PyClass(wrappers.module, name.c_str()), [](auto &mod, auto &cls) {
         cls.def("getOrder", &BasePolynomialFunction2<ReturnT>::getOrder);
         cls.def("isLinearCombination", &BasePolynomialFunction2<ReturnT>::isLinearCombination);
@@ -108,7 +107,7 @@ template <typename ReturnT>
 void declareNullFunction1(lsst::cpputils::python::WrapperCollection &wrappers, const std::string &suffix) {
     auto const name = "NullFunction1" + suffix;
     using PyClass =
-            py::class_<NullFunction1<ReturnT>, std::shared_ptr<NullFunction1<ReturnT>>, Function1<ReturnT>>;
+            py::classh<NullFunction1<ReturnT>, Function1<ReturnT>>;
     wrappers.wrapType(PyClass(wrappers.module, name.c_str()), [](auto &mod, auto &cls) {
         cls.def(py::init<>());
 
@@ -120,7 +119,7 @@ template <typename ReturnT>
 void declareNullFunction2(lsst::cpputils::python::WrapperCollection &wrappers, const std::string &suffix) {
     auto const name = "NullFunction2" + suffix;
     using PyClass =
-            py::class_<NullFunction2<ReturnT>, std::shared_ptr<NullFunction2<ReturnT>>, Function2<ReturnT>>;
+            py::classh<NullFunction2<ReturnT>, Function2<ReturnT>>;
     wrappers.wrapType(PyClass(wrappers.module, name.c_str()), [](auto &mod, auto &cls) {
         cls.def(py::init<>());
         cls.def("clone", &NullFunction2<ReturnT>::clone);

--- a/python/lsst/afw/math/_functionLibrary.cc
+++ b/python/lsst/afw/math/_functionLibrary.cc
@@ -35,8 +35,6 @@
 namespace py = pybind11;
 using namespace pybind11::literals;
 
-PYBIND11_DECLARE_HOLDER_TYPE(MyType, std::shared_ptr<MyType>);
-
 namespace lsst {
 namespace afw {
 namespace math {
@@ -46,7 +44,7 @@ void declarePolynomialFunctions(lsst::cpputils::python::WrapperCollection &wrapp
     /* PolynomialFunction1 */
 
     wrappers.wrapType(
-            py::class_<PolynomialFunction1<ReturnT>, std::shared_ptr<PolynomialFunction1<ReturnT>>,
+            py::classh<PolynomialFunction1<ReturnT>,
                        Function1<ReturnT>>(wrappers.module, ("PolynomialFunction1" + suffix).c_str()),
             [](auto &mod, auto &cls) {
                 cls.def(py::init<std::vector<double> const &>(), "params"_a);
@@ -59,7 +57,7 @@ void declarePolynomialFunctions(lsst::cpputils::python::WrapperCollection &wrapp
                 cls.def("toString", &PolynomialFunction1<ReturnT>::toString, "prefix"_a = "");
             });
     /* PolynomialFunction2 */
-    wrappers.wrapType(py::class_<PolynomialFunction2<ReturnT>, std::shared_ptr<PolynomialFunction2<ReturnT>>,
+    wrappers.wrapType(py::classh<PolynomialFunction2<ReturnT>,
                                  BasePolynomialFunction2<ReturnT>>(wrappers.module,
                                                                    ("PolynomialFunction2" + suffix).c_str()),
                       [](auto &mod, auto &cls) {
@@ -80,7 +78,7 @@ void declareChebyshevFunctions(lsst::cpputils::python::WrapperCollection &wrappe
     /* Chebyshev1Function1 */
 
     wrappers.wrapType(
-            py::class_<Chebyshev1Function1<ReturnT>, std::shared_ptr<Chebyshev1Function1<ReturnT>>,
+            py::classh<Chebyshev1Function1<ReturnT>,
                        Function1<ReturnT>>(wrappers.module, ("Chebyshev1Function1" + suffix).c_str()),
             [](auto &mod, auto &cls) {
                 cls.def(py::init<std::vector<double>, double, double>(), "params"_a, "minX"_a = -1,
@@ -97,7 +95,7 @@ void declareChebyshevFunctions(lsst::cpputils::python::WrapperCollection &wrappe
 
                 /* Chebyshev1Function2 */
             });
-    wrappers.wrapType(py::class_<Chebyshev1Function2<ReturnT>, std::shared_ptr<Chebyshev1Function2<ReturnT>>,
+    wrappers.wrapType(py::classh<Chebyshev1Function2<ReturnT>,
                                  BasePolynomialFunction2<ReturnT>>(wrappers.module,
                                                                    ("Chebyshev1Function2" + suffix).c_str()),
                       [](auto &mod, auto &cls) {
@@ -120,7 +118,7 @@ void declareChebyshevFunctions(lsst::cpputils::python::WrapperCollection &wrappe
 template <typename ReturnT>
 void declareGaussianFunctions(lsst::cpputils::python::WrapperCollection &wrappers, const std::string &suffix) {
     /* GaussianFunction1 */
-    wrappers.wrapType(py::class_<GaussianFunction1<ReturnT>, std::shared_ptr<GaussianFunction1<ReturnT>>,
+    wrappers.wrapType(py::classh<GaussianFunction1<ReturnT>,
                                  Function1<ReturnT>>(wrappers.module, ("GaussianFunction1" + suffix).c_str()),
                       [](auto &mod, auto &cls) {
                           cls.def(py::init<double>(), "sigma"_a);
@@ -130,7 +128,7 @@ void declareGaussianFunctions(lsst::cpputils::python::WrapperCollection &wrapper
                           cls.def("toString", &GaussianFunction1<ReturnT>::toString, "prefix"_a = "");
                       });
 
-    wrappers.wrapType(py::class_<GaussianFunction2<ReturnT>, std::shared_ptr<GaussianFunction2<ReturnT>>,
+    wrappers.wrapType(py::classh<GaussianFunction2<ReturnT>,
                                  Function2<ReturnT>>(wrappers.module, ("GaussianFunction2" + suffix).c_str()),
                       [](auto &mod, auto &cls) {
                           /* GaussianFunction2 */
@@ -146,7 +144,7 @@ void declareGaussianFunctions(lsst::cpputils::python::WrapperCollection &wrapper
     /* DoubleGaussianFunction2 */
 
     wrappers.wrapType(
-            py::class_<DoubleGaussianFunction2<ReturnT>, std::shared_ptr<DoubleGaussianFunction2<ReturnT>>,
+            py::classh<DoubleGaussianFunction2<ReturnT>,
                        Function2<ReturnT>>(wrappers.module, ("DoubleGaussianFunction2" + suffix).c_str()),
             [](auto &mod, auto &cls) {
                 cls.def(py::init<double, double, double>(), "sigma1"_a, "sigma2"_a = 0, "ampl"_a = 0);
@@ -164,7 +162,7 @@ void declareIntegerDeltaFunctions(lsst::cpputils::python::WrapperCollection &wra
     /* IntegerDeltaFunction1 */
 
     wrappers.wrapType(
-            py::class_<IntegerDeltaFunction1<ReturnT>, std::shared_ptr<IntegerDeltaFunction1<ReturnT>>,
+            py::classh<IntegerDeltaFunction1<ReturnT>,
                        Function1<ReturnT>>(wrappers.module, ("IntegerDeltaFunction1" + suffix).c_str()),
             [](auto &mod, auto &cls) {
                 cls.def(py::init<double>(), "xo"_a);
@@ -176,7 +174,7 @@ void declareIntegerDeltaFunctions(lsst::cpputils::python::WrapperCollection &wra
     /* IntegerDeltaFunction2 */
 
     wrappers.wrapType(
-            py::class_<IntegerDeltaFunction2<ReturnT>, std::shared_ptr<IntegerDeltaFunction2<ReturnT>>,
+            py::classh<IntegerDeltaFunction2<ReturnT>,
                        Function2<ReturnT>>(wrappers.module, ("IntegerDeltaFunction2" + suffix).c_str()),
             [](auto &mod, auto &cls) {
                 cls.def(py::init<double, double>(), "xo"_a, "yo"_a);
@@ -191,7 +189,7 @@ template <typename ReturnT>
 void declareLanczosFunctions(lsst::cpputils::python::WrapperCollection &wrappers, const std::string &suffix) {
     /* LanczosFunction1 */
 
-    wrappers.wrapType(py::class_<LanczosFunction1<ReturnT>, std::shared_ptr<LanczosFunction1<ReturnT>>,
+    wrappers.wrapType(py::classh<LanczosFunction1<ReturnT>,
                                  Function1<ReturnT>>(wrappers.module, ("LanczosFunction1" + suffix).c_str()),
                       [](auto &mod, auto &cls) {
                           cls.def(py::init<unsigned int, double>(), "n"_a, "xOffset"_a = 0.0);
@@ -203,7 +201,7 @@ void declareLanczosFunctions(lsst::cpputils::python::WrapperCollection &wrappers
                       });
     /* LanczosFunction2 */
 
-    wrappers.wrapType(py::class_<LanczosFunction2<ReturnT>, std::shared_ptr<LanczosFunction2<ReturnT>>,
+    wrappers.wrapType(py::classh<LanczosFunction2<ReturnT>,
                                  Function2<ReturnT>>(wrappers.module, ("LanczosFunction2" + suffix).c_str()),
                       [](auto &mod, auto &cls) {
                           /* LanczosFunction2 */

--- a/python/lsst/afw/math/_gaussianProcess.cc
+++ b/python/lsst/afw/math/_gaussianProcess.cc
@@ -54,7 +54,7 @@ template <typename T>
 void declareCovariograms(lsst::cpputils::python::WrapperCollection &wrappers, const std::string &suffix) {
     /* Covariogram */
 
-    wrappers.wrapType(py::class_<Covariogram<T>, std::shared_ptr<Covariogram<T>>>(
+    wrappers.wrapType(py::classh<Covariogram<T>>(
                               wrappers.module, ("Covariogram" + suffix).c_str()),
                       [](auto &mod, auto &cls) {
                           cls.def(py::init<>());
@@ -62,7 +62,7 @@ void declareCovariograms(lsst::cpputils::python::WrapperCollection &wrappers, co
                       });
     /* SquaredExpCovariogram */
     wrappers.wrapType(
-            py::class_<SquaredExpCovariogram<T>, std::shared_ptr<SquaredExpCovariogram<T>>, Covariogram<T>>(
+            py::classh<SquaredExpCovariogram<T>, Covariogram<T>>(
                     wrappers.module, ("SquaredExpCovariogram" + suffix).c_str()),
             [](auto &mod, auto &cls) {
                 cls.def(py::init<>());
@@ -71,7 +71,7 @@ void declareCovariograms(lsst::cpputils::python::WrapperCollection &wrappers, co
             });
     /* NeuralNetCovariogram */
     wrappers.wrapType(
-            py::class_<NeuralNetCovariogram<T>, std::shared_ptr<NeuralNetCovariogram<T>>, Covariogram<T>>(
+            py::classh<NeuralNetCovariogram<T>, Covariogram<T>>(
                     wrappers.module, ("NeuralNetCovariogram" + suffix).c_str()),
             [](auto &mod, auto &cls) {
                 cls.def(py::init<>());

--- a/python/lsst/afw/math/_interpolate.cc
+++ b/python/lsst/afw/math/_interpolate.cc
@@ -36,7 +36,7 @@ namespace lsst {
 namespace afw {
 namespace math {
 void wrapInterpolate(lsst::cpputils::python::WrapperCollection &wrappers) {
-    using PyClass = py::class_<Interpolate, std::shared_ptr<Interpolate>>;
+    using PyClass = py::classh<Interpolate>;
 
     auto clsInterpolate = wrappers.wrapType(PyClass(wrappers.module, "Interpolate"), [](auto &mod,
                                                                                         auto &cls) {

--- a/python/lsst/afw/math/_kernel.cc
+++ b/python/lsst/afw/math/_kernel.cc
@@ -37,7 +37,7 @@ namespace lsst {
 namespace afw {
 namespace math {
 void wrapKernel(lsst::cpputils::python::WrapperCollection &wrappers) {
-    using PyKernel = py::class_<Kernel, std::shared_ptr<Kernel>>;
+    using PyKernel = py::classh<Kernel>;
 
     wrappers.addSignatureDependency("lsst.afw.table");
     wrappers.addSignatureDependency("lsst.afw.table.io");
@@ -78,7 +78,7 @@ void wrapKernel(lsst::cpputils::python::WrapperCollection &wrappers) {
         cls.def("getCacheSize", &Kernel::getCacheSize);
     });
 
-    using PyFixedKernel = py::class_<FixedKernel, std::shared_ptr<FixedKernel>, Kernel>;
+    using PyFixedKernel = py::classh<FixedKernel, Kernel>;
     wrappers.wrapType(PyFixedKernel(wrappers.module, "FixedKernel"), [](auto &mod, auto &cls) {
         cls.def(py::init<>());
         cls.def(py::init<lsst::afw::image::Image<Kernel::Pixel> const &>(), "image"_a);
@@ -91,7 +91,7 @@ void wrapKernel(lsst::cpputils::python::WrapperCollection &wrappers) {
         cls.def("isPersistable", &FixedKernel::isPersistable);
     });
 
-    using PyAnalyticKernel = py::class_<AnalyticKernel, std::shared_ptr<AnalyticKernel>, Kernel>;
+    using PyAnalyticKernel = py::classh<AnalyticKernel, Kernel>;
     wrappers.wrapType(PyAnalyticKernel(wrappers.module, "AnalyticKernel"), [](auto &mod, auto &cls) {
         cls.def(py::init<>());
         // Workaround for NullSpatialFunction and py::arg not playing well with Citizen (TODO: no longer
@@ -114,7 +114,7 @@ void wrapKernel(lsst::cpputils::python::WrapperCollection &wrappers) {
     });
 
     using PyDeltaFunctionKernel =
-            py::class_<DeltaFunctionKernel, std::shared_ptr<DeltaFunctionKernel>, Kernel>;
+            py::classh<DeltaFunctionKernel, Kernel>;
     wrappers.wrapType(
             PyDeltaFunctionKernel(wrappers.module, "DeltaFunctionKernel"), [](auto &mod, auto &cls) {
                 cls.def(py::init<int, int, lsst::geom::Point2I const &>(), "width"_a, "height"_a, "point"_a);
@@ -126,7 +126,7 @@ void wrapKernel(lsst::cpputils::python::WrapperCollection &wrappers) {
             });
 
     using PyLinearCombinationKernel =
-            py::class_<LinearCombinationKernel, std::shared_ptr<LinearCombinationKernel>, Kernel>;
+            py::classh<LinearCombinationKernel, Kernel>;
     wrappers.wrapType(
             PyLinearCombinationKernel(wrappers.module, "LinearCombinationKernel"), [](auto &mod, auto &cls) {
                 cls.def(py::init<>());
@@ -149,7 +149,7 @@ void wrapKernel(lsst::cpputils::python::WrapperCollection &wrappers) {
                 cls.def("isPersistable", &LinearCombinationKernel::isPersistable);
             });
 
-    using PySeparableKernel = py::class_<SeparableKernel, std::shared_ptr<SeparableKernel>, Kernel>;
+    using PySeparableKernel = py::classh<SeparableKernel, Kernel>;
     wrappers.wrapType(PySeparableKernel(wrappers.module, "SeparableKernel"), [](auto &mod, auto &cls) {
         cls.def(py::init<>());
         // Workaround for NullSpatialFunction and py::arg not playing well with Citizen (TODO: no longer

--- a/python/lsst/afw/math/_pixelAreaBoundedField.cc
+++ b/python/lsst/afw/math/_pixelAreaBoundedField.cc
@@ -32,7 +32,7 @@ namespace lsst {
 namespace afw {
 namespace math {
 
-using PyClass = py::class_<PixelAreaBoundedField, std::shared_ptr<PixelAreaBoundedField>, BoundedField>;
+using PyClass = py::classh<PixelAreaBoundedField, BoundedField>;
 
 void wrapPixelAreaBoundedField(lsst::cpputils::python::WrapperCollection &wrappers) {
     wrappers.wrapType(PyClass(wrappers.module, "PixelAreaBoundedField"), [](auto &mod, auto &cls) {

--- a/python/lsst/afw/math/_productBoundedField.cc
+++ b/python/lsst/afw/math/_productBoundedField.cc
@@ -32,7 +32,7 @@ using namespace lsst::afw::math;
 namespace lsst {
 namespace afw {
 namespace math {
-using PyClass = py::class_<ProductBoundedField, std::shared_ptr<ProductBoundedField>, BoundedField>;
+using PyClass = py::classh<ProductBoundedField, BoundedField>;
 
 void wrapProductBoundedField(lsst::cpputils::python::WrapperCollection &wrappers) {
     wrappers.wrapType(PyClass(wrappers.module, "ProductBoundedField"), [](auto &mod, auto &cls) {

--- a/python/lsst/afw/math/_spatialCell.cc
+++ b/python/lsst/afw/math/_spatialCell.cc
@@ -44,7 +44,7 @@ using CandidateList = std::vector<std::shared_ptr<SpatialCellCandidate>>;
 
 // Wrap SpatialCellCandidate (an abstract class so no constructor is wrapped)
 void declareSpatialCellCandidate(lsst::cpputils::python::WrapperCollection &wrappers) {
-    using PyClass = py::class_<SpatialCellCandidate, std::shared_ptr<SpatialCellCandidate>>;
+    using PyClass = py::classh<SpatialCellCandidate>;
     auto clsSpatialCellCandidate =
             wrappers.wrapType(PyClass(wrappers.module, "SpatialCellCandidate"), [](auto &mod, auto &cls) {
                 cls.def("getXCenter", &SpatialCellCandidate::getXCenter);
@@ -69,7 +69,7 @@ void declareSpatialCellCandidate(lsst::cpputils::python::WrapperCollection &wrap
 // Wrap SpatialCellCandidateIterator
 void declareSpatialCellCandidateIterator(lsst::cpputils::python::WrapperCollection &wrappers) {
     wrappers.wrapType(
-            py::class_<SpatialCellCandidateIterator>(wrappers.module, "SpatialCellCandidateIterator"),
+            py::classh<SpatialCellCandidateIterator>(wrappers.module, "SpatialCellCandidateIterator"),
             [](auto &mod, auto &cls) {
                 cls.def("__incr__", &SpatialCellCandidateIterator::operator++, py::is_operator());
                 cls.def(
@@ -87,7 +87,7 @@ void declareSpatialCellCandidateIterator(lsst::cpputils::python::WrapperCollecti
 // Wrap SpatialCell
 void declareSpatialCell(lsst::cpputils::python::WrapperCollection &wrappers) {
     wrappers.wrapType(
-            py::class_<SpatialCell, std::shared_ptr<SpatialCell>>(wrappers.module, "SpatialCell"),
+            py::classh<SpatialCell>(wrappers.module, "SpatialCell"),
             [](auto &mod, auto &cls) {
                 cls.def(py::init<std::string const &, lsst::geom::Box2I const &, CandidateList const &>(),
                         "label"_a, "bbox"_a = lsst::geom::Box2I(), "candidateList"_a = CandidateList());
@@ -122,7 +122,7 @@ void declareSpatialCell(lsst::cpputils::python::WrapperCollection &wrappers) {
 // Wrap SpatialCellSet
 void declareSpatialCellSet(lsst::cpputils::python::WrapperCollection &wrappers) {
     wrappers.wrapType(
-            py::class_<SpatialCellSet, std::shared_ptr<SpatialCellSet>>(wrappers.module, "SpatialCellSet"),
+            py::classh<SpatialCellSet>(wrappers.module, "SpatialCellSet"),
             [](auto &mod, auto &cls) {
                 cls.def(py::init<lsst::geom::Box2I const &, int, int>(), "region"_a, "xSize"_a,
                         "ySize"_a = 0);
@@ -146,7 +146,7 @@ void declareSpatialCellSet(lsst::cpputils::python::WrapperCollection &wrappers) 
 
 // Wrap CandidateVisitor
 void declareCandidateVisitor(lsst::cpputils::python::WrapperCollection &wrappers) {
-    wrappers.wrapType(py::class_<CandidateVisitor, std::shared_ptr<CandidateVisitor>>(wrappers.module,
+    wrappers.wrapType(py::classh<CandidateVisitor>(wrappers.module,
                                                                                       "CandidateVisitor"),
                       [](auto &mod, auto &cls) {
                           cls.def(py::init<>());
@@ -156,9 +156,8 @@ void declareCandidateVisitor(lsst::cpputils::python::WrapperCollection &wrappers
                       });
 }
 
-// Wrap class SpatialCellImageCandidate (an abstract class, so no constructor is wrapped)
 void declareSpatialCellImageCandidate(lsst::cpputils::python::WrapperCollection &wrappers) {
-    wrappers.wrapType(py::class_<SpatialCellImageCandidate, std::shared_ptr<SpatialCellImageCandidate>,
+    wrappers.wrapType(py::classh<SpatialCellImageCandidate,
                                  SpatialCellCandidate>(wrappers.module, "SpatialCellImageCandidate"),
                       [](auto &mod, auto &cls) {
                           cls.def_static("setWidth", &SpatialCellImageCandidate::setWidth, "width"_a);
@@ -234,7 +233,7 @@ void declareTestClasses(lsst::cpputils::python::WrapperCollection &wrappers) {
         double _flux;
     };
 
-    wrappers.wrapType(py::class_<TestCandidate, std::shared_ptr<TestCandidate>, SpatialCellCandidate>(
+    wrappers.wrapType(py::classh<TestCandidate, SpatialCellCandidate>(
                               wrappers.module, "TestCandidate"),
                       [](auto &mod, auto &cls) {
                           cls.def(py::init<float const, float const, float const>());
@@ -242,14 +241,14 @@ void declareTestClasses(lsst::cpputils::python::WrapperCollection &wrappers) {
                           cls.def("setCandidateRating", &TestCandidate::setCandidateRating);
                       });
     wrappers.wrapType(
-            py::class_<TestCandidateVisitor, std::shared_ptr<TestCandidateVisitor>, CandidateVisitor>(
+            py::classh<TestCandidateVisitor, CandidateVisitor>(
                     wrappers.module, "TestCandidateVisitor"),
             [](auto &mod, auto &cls) {
                 cls.def(py::init<>());
                 cls.def("getN", &TestCandidateVisitor::getN);
             });
     wrappers.wrapType(
-            py::class_<TestImageCandidate, std::shared_ptr<TestImageCandidate>, SpatialCellImageCandidate>(
+            py::classh<TestImageCandidate, SpatialCellImageCandidate>(
                     wrappers.module, "TestImageCandidate"),
             [](auto &mod, auto &cls) {
                 cls.def(py::init<float const, float const, float const>(), "xCenter"_a, "yCenter"_a,

--- a/python/lsst/afw/math/_statistics.cc
+++ b/python/lsst/afw/math/_statistics.cc
@@ -100,7 +100,7 @@ void declareStatistics(lsst::cpputils::python::WrapperCollection &wrappers) {
 
     wrappers.wrap([](auto &mod) { mod.def("stringToStatisticsProperty", stringToStatisticsProperty); });
 
-    using PyClass = py::class_<StatisticsControl, std::shared_ptr<StatisticsControl>>;
+    using PyClass = py::classh<StatisticsControl>;
     auto control = wrappers.wrapType(PyClass(wrappers.module, "StatisticsControl"), [](auto &mod, auto &cls) {
         cls.def(py::init<double, int, lsst::afw::image::MaskPixel, bool,
                          typename StatisticsControl::WeightsBoolean>(),

--- a/python/lsst/afw/math/_transformBoundedField.cc
+++ b/python/lsst/afw/math/_transformBoundedField.cc
@@ -39,7 +39,7 @@ namespace lsst {
 namespace afw {
 namespace math {
 
-using ClsField = py::class_<TransformBoundedField, std::shared_ptr<TransformBoundedField>, BoundedField>;
+using ClsField = py::classh<TransformBoundedField, BoundedField>;
 
 void declareTransformBoundedField(lsst::cpputils::python::WrapperCollection &wrappers) {
     wrappers.wrapType(ClsField(wrappers.module, "TransformBoundedField"), [](auto &mod, auto &cls) {

--- a/python/lsst/afw/math/_warpExposure.cc
+++ b/python/lsst/afw/math/_warpExposure.cc
@@ -53,7 +53,7 @@ namespace {
 */
 template <typename KernelT>
 void declareWarpingKernel(lsst::cpputils::python::WrapperCollection &wrappers, std::string const &name) {
-    using PyClass = py::class_<KernelT, std::shared_ptr<KernelT>, SeparableKernel>;
+    using PyClass = py::classh<KernelT, SeparableKernel>;
     wrappers.wrapType(PyClass(wrappers.module, name.c_str()), [](auto &mod, auto &cls) {
         cls.def(py::init<int>(), "order"_a);
         cls.def("getOrder", &KernelT::getOrder);
@@ -72,7 +72,7 @@ void declareWarpingKernel(lsst::cpputils::python::WrapperCollection &wrappers, s
 */
 template <typename KernelT>
 void declareSimpleWarpingKernel(lsst::cpputils::python::WrapperCollection &wrappers, std::string const &name) {
-    using PyClass = py::class_<KernelT, std::shared_ptr<KernelT>, SeparableKernel>;
+    using PyClass = py::classh<KernelT, SeparableKernel>;
     wrappers.wrapType(PyClass(wrappers.module, name.c_str()), [](auto &mod, auto &cls) {
         cls.def(py::init<>());
         cls.def("clone", &KernelT::clone);
@@ -139,7 +139,7 @@ void declareWarpingFunctions(lsst::cpputils::python::WrapperCollection &wrappers
 }
 
 void declareWarpExposure(lsst::cpputils::python::WrapperCollection &wrappers) {
-    using PyClass = py::class_<WarpingControl, std::shared_ptr<WarpingControl>>;
+    using PyClass = py::classh<WarpingControl>;
     wrappers.wrapType(PyClass(wrappers.module, "WarpingControl"), [](auto &mod, auto cls) {
         cls.def(py::init<std::string, std::string, int, int, image::MaskPixel>(), "warpingKernelName"_a,
                 "maskWarpingKernelName"_a = "", "cacheSize"_a = 0, "interpLength"_a = 0,

--- a/python/lsst/afw/math/detail/_convolve.cc
+++ b/python/lsst/afw/math/detail/_convolve.cc
@@ -67,7 +67,7 @@ void declareAll(lsst::cpputils::python::WrapperCollection &wrappers) {
 }  // namespace
 
 void declareConvolve(lsst::cpputils::python::WrapperCollection &wrappers) {
-    using PyClass = py::class_<KernelImagesForRegion, std::shared_ptr<KernelImagesForRegion>>;
+    using PyClass = py::classh<KernelImagesForRegion>;
     auto clsKernelImagesForRegion =
             wrappers.wrapType(PyClass(wrappers.module, "KernelImagesForRegion"), [](auto &mod, auto &cls) {
                 cls.def(py::init<KernelImagesForRegion::KernelConstPtr, lsst::geom::Box2I const &,
@@ -99,7 +99,7 @@ void declareConvolve(lsst::cpputils::python::WrapperCollection &wrappers) {
                           enm.export_values();
                       });
 
-    wrappers.wrapType(py::class_<RowOfKernelImagesForRegion, std::shared_ptr<RowOfKernelImagesForRegion>>(
+    wrappers.wrapType(py::classh<RowOfKernelImagesForRegion>(
                               wrappers.module, "RowOfKernelImagesForRegion"),
                       [](auto &mod, auto &cls) {
                           cls.def(py::init<int, int>(), "nx"_a, "ny"_a);

--- a/python/lsst/afw/table/_aggregates.cc
+++ b/python/lsst/afw/table/_aggregates.cc
@@ -54,23 +54,22 @@ namespace {
 // define a CRTP interface in C++ and in Python that's just duck-typing.
 
 template <typename T>
-using PyPointKey = py::class_<PointKey<T>, std::shared_ptr<PointKey<T>>>;
+using PyPointKey = py::classh<PointKey<T>>;
 
 template <typename T>
-using PyPoint3Key = py::class_<Point3Key<T>, std::shared_ptr<Point3Key<T>>>;
+using PyPoint3Key = py::classh<Point3Key<T>>;
 
 template <typename Box>
-using PyBoxKey = py::class_<BoxKey<Box>, std::shared_ptr<BoxKey<Box>>>;
+using PyBoxKey = py::classh<BoxKey<Box>>;
 
-using PyCoordKey = py::class_<CoordKey, std::shared_ptr<CoordKey>>;
+using PyCoordKey = py::classh<CoordKey>;
 
-using PyQuadrupoleKey = py::class_<QuadrupoleKey, std::shared_ptr<QuadrupoleKey>>;
+using PyQuadrupoleKey = py::classh<QuadrupoleKey>;
 
-using PyEllipseKey = py::class_<EllipseKey, std::shared_ptr<EllipseKey>>;
+using PyEllipseKey = py::classh<EllipseKey>;
 
 template <typename T, int N>
-using PyCovarianceMatrixKey =
-        py::class_<CovarianceMatrixKey<T, N>, std::shared_ptr<CovarianceMatrixKey<T, N>>>;
+using PyCovarianceMatrixKey = py::classh<CovarianceMatrixKey<T, N>>;
 
 template <typename T>
 static void declarePointKey(WrapperCollection &wrappers, std::string const &suffix) {

--- a/python/lsst/afw/table/_aliasMap.cc
+++ b/python/lsst/afw/table/_aliasMap.cc
@@ -34,7 +34,7 @@ namespace lsst {
 namespace afw {
 namespace table {
 
-using PyAliasMap = py::class_<AliasMap, std::shared_ptr<AliasMap>>;
+using PyAliasMap = py::classh<AliasMap>;
 
 void wrapAliasMap(cpputils::python::WrapperCollection &wrappers) {
     wrappers.wrapType(PyAliasMap(wrappers.module, "AliasMap"), [](auto &mod, auto &cls) {

--- a/python/lsst/afw/table/_arrays.cc
+++ b/python/lsst/afw/table/_arrays.cc
@@ -47,7 +47,7 @@ namespace {
 // define a CRTP interface in C++ and in Python that's just duck-typing.
 
 template <typename T>
-using PyArrayKey = py::class_<ArrayKey<T>, std::shared_ptr<ArrayKey<T>>>;
+using PyArrayKey = py::classh<ArrayKey<T>>;
 
 template <typename T>
 void declareArrayKey(WrapperCollection &wrappers, std::string const &suffix) {

--- a/python/lsst/afw/table/_base.cc
+++ b/python/lsst/afw/table/_base.cc
@@ -54,8 +54,8 @@ using cpputils::python::WrapperCollection;
 
 namespace {
 
-using PyBaseRecord = py::class_<BaseRecord, std::shared_ptr<BaseRecord>>;
-using PyBaseTable = py::class_<BaseTable, std::shared_ptr<BaseTable>>;
+using PyBaseRecord = py::classh<BaseRecord>;
+using PyBaseTable = py::classh<BaseTable>;
 
 template <typename T>
 void declareBaseRecordOverloads(PyBaseRecord &cls, std::string const &suffix) {

--- a/python/lsst/afw/table/_baseColumnView.cc
+++ b/python/lsst/afw/table/_baseColumnView.cc
@@ -42,9 +42,9 @@ using cpputils::python::WrapperCollection;
 
 namespace {
 
-using PyBaseColumnView = py::class_<BaseColumnView, std::shared_ptr<BaseColumnView>>;
+using PyBaseColumnView = py::classh<BaseColumnView>;
 
-using PyBitsColumn = py::class_<BitsColumn, std::shared_ptr<BitsColumn>>;
+using PyBitsColumn = py::classh<BitsColumn>;
 
 template <typename T, typename PyClass>
 static void declareBaseColumnViewOverloads(PyClass &cls) {

--- a/python/lsst/afw/table/_exposure.cc
+++ b/python/lsst/afw/table/_exposure.cc
@@ -58,11 +58,9 @@ using cpputils::python::WrapperCollection;
 
 namespace {
 
-using PyExposureRecord = py::class_<ExposureRecord, std::shared_ptr<ExposureRecord>, BaseRecord>;
-using PyExposureTable = py::class_<ExposureTable, std::shared_ptr<ExposureTable>, BaseTable>;
-using PyExposureCatalog =
-        py::class_<ExposureCatalogT<ExposureRecord>, std::shared_ptr<ExposureCatalogT<ExposureRecord>>,
-                   SortedCatalogT<ExposureRecord>>;
+using PyExposureRecord = py::classh<ExposureRecord, BaseRecord>;
+using PyExposureTable = py::classh<ExposureTable, BaseTable>;
+using PyExposureCatalog = py::classh<ExposureCatalogT<ExposureRecord>, SortedCatalogT<ExposureRecord>>;
 
 PyExposureRecord declareExposureRecord(WrapperCollection &wrappers) {
     return wrappers.wrapType(PyExposureRecord(wrappers.module, "ExposureRecord"), [](auto &mod, auto &cls) {
@@ -152,7 +150,6 @@ PyExposureCatalog declareExposureCatalog(WrapperCollection &wrappers) {
                 cls.def_static("readFits", (Catalog(*)(fits::MemFileManager &, int, int)) & Catalog::readFits,
                                "manager"_a, "hdu"_a = fits::DEFAULT_HDU, "flags"_a = 0);
                 // readFits taking Fits objects not wrapped, because Fits objects are not wrapped.
-
                 cls.def("subset",
                         (Catalog(Catalog::*)(ndarray::Array<bool const, 1> const &) const) & Catalog::subset,
                         "mask"_a);

--- a/python/lsst/afw/table/_idFactory.cc
+++ b/python/lsst/afw/table/_idFactory.cc
@@ -33,7 +33,7 @@ namespace lsst {
 namespace afw {
 namespace table {
 
-using PyIdFactory = py::class_<IdFactory, std::shared_ptr<IdFactory>>;
+using PyIdFactory = py::classh<IdFactory>;
 
 void wrapIdFactory(cpputils::python::WrapperCollection& wrappers) {
     wrappers.wrapType(PyIdFactory(wrappers.module, "IdFactory"), [](auto& mod, auto& cls) {

--- a/python/lsst/afw/table/_match.cc
+++ b/python/lsst/afw/table/_match.cc
@@ -50,7 +50,7 @@ void declareMatch2(WrapperCollection &wrappers, std::string const &prefix) {
     using MatchList = std::vector<Match<typename Catalog1::Record, typename Catalog2::Record>>;
 
     using Class = Match<Record1, Record2>;
-    using PyClass = py::class_<Class, std::shared_ptr<Class>>;
+    using PyClass = py::classh<Class>;
     wrappers.wrapType(PyClass(wrappers.module, (prefix + "Match").c_str()), [](auto &mod, auto &cls) {
         cls.def(py::init<>());
         cls.def(py::init<std::shared_ptr<Record1> const &, std::shared_ptr<Record2> const &, double>(),

--- a/python/lsst/afw/table/_schemaMapper.cc
+++ b/python/lsst/afw/table/_schemaMapper.cc
@@ -40,7 +40,7 @@ namespace afw {
 namespace table {
 
 using cpputils::python::WrapperCollection;
-using PySchemaMapper = py::class_<SchemaMapper, std::shared_ptr<SchemaMapper>>;
+using PySchemaMapper = py::classh<SchemaMapper>;
 
 namespace {
 

--- a/python/lsst/afw/table/_simple.cc
+++ b/python/lsst/afw/table/_simple.cc
@@ -44,8 +44,8 @@ using cpputils::python::WrapperCollection;
 
 namespace {
 
-using PySimpleTable = py::class_<SimpleTable, std::shared_ptr<SimpleTable>, BaseTable>;
-using PySimpleRecord = py::class_<SimpleRecord, std::shared_ptr<SimpleRecord>, BaseRecord>;
+using PySimpleTable = py::classh<SimpleTable, BaseTable>;
+using PySimpleRecord = py::classh<SimpleRecord, BaseRecord>;
 
 PySimpleRecord declareSimpleRecord(WrapperCollection &wrappers) {
     return wrappers.wrapType(PySimpleRecord(wrappers.module, "SimpleRecord"), [](auto &mod, auto &cls) {

--- a/python/lsst/afw/table/_slots.cc
+++ b/python/lsst/afw/table/_slots.cc
@@ -40,7 +40,7 @@ using cpputils::python::WrapperCollection;
 namespace {
 
 // tiny classes only used in afw::table: no need for shared_ptr.
-using PySlotDefinition = py::class_<SlotDefinition>;
+using PySlotDefinition = py::classh<SlotDefinition>;
 
 void declareSlotDefinition(WrapperCollection &wrappers) {
     wrappers.wrapType(PySlotDefinition(wrappers.module, "SlotDefinition"), [](auto &mod, auto &cls) {
@@ -54,7 +54,7 @@ Declare standard methods for subclasses of SlotDefinition (but not SlotDefinitio
 */
 template <typename Class>
 void declareSlotDefinitionSubclass(WrapperCollection &wrappers, std::string const &name) {
-    wrappers.wrapType(py::class_<Class, SlotDefinition>(wrappers.module, name.c_str()),
+    wrappers.wrapType(py::classh<Class, SlotDefinition>(wrappers.module, name.c_str()),
                       [](auto &mod, auto &cls) {
                           cls.def(py::init<std::string const &>(), "name"_a);
                           cls.def("isValid", &Class::isValid);

--- a/python/lsst/afw/table/_source.cc
+++ b/python/lsst/afw/table/_source.cc
@@ -51,11 +51,9 @@ using cpputils::python::WrapperCollection;
 
 namespace {
 
-using PySourceRecord = py::class_<SourceRecord, std::shared_ptr<SourceRecord>, SimpleRecord>;
-using PySourceTable = py::class_<SourceTable, std::shared_ptr<SourceTable>, SimpleTable>;
-using PySourceColumnView =
-        py::class_<SourceColumnViewT<SourceRecord>, std::shared_ptr<SourceColumnViewT<SourceRecord>>,
-                   ColumnViewT<SourceRecord>>;
+using PySourceRecord = py::classh<SourceRecord, SimpleRecord>;
+using PySourceTable = py::classh<SourceTable, SimpleTable>;
+using PySourceColumnView = py::classh<SourceColumnViewT<SourceRecord>, ColumnViewT<SourceRecord>>;
 
 /*
 Declare member and static functions for a pybind11 wrapper of SourceRecord

--- a/python/lsst/afw/table/io/_inputArchive.cc
+++ b/python/lsst/afw/table/io/_inputArchive.cc
@@ -34,7 +34,7 @@ namespace afw {
 namespace table {
 namespace io {
 
-using PyInputArchive = py::class_<InputArchive, std::shared_ptr<InputArchive>>;
+using PyInputArchive = py::classh<InputArchive>;
 
 void wrapInputArchive(cpputils::python::WrapperCollection &wrappers) {
     wrappers.wrapType(PyInputArchive(wrappers.module, "InputArchive"), [](auto &mod, auto &cls) {

--- a/python/lsst/afw/table/io/_outputArchive.cc
+++ b/python/lsst/afw/table/io/_outputArchive.cc
@@ -35,7 +35,7 @@ namespace afw {
 namespace table {
 namespace io {
 
-using PyOutputArchive = py::class_<OutputArchive, std::shared_ptr<OutputArchive>>;
+using PyOutputArchive = py::classh<OutputArchive>;
 
 void wrapOutputArchive(cpputils::python::WrapperCollection &wrappers) {
     wrappers.wrapType(PyOutputArchive(wrappers.module, "OutputArchive"), [](auto &mod, auto &cls) {

--- a/python/lsst/afw/table/io/_persistable.cc
+++ b/python/lsst/afw/table/io/_persistable.cc
@@ -34,7 +34,7 @@ namespace afw {
 namespace table {
 namespace io {
 
-using PyPersistable = py::class_<Persistable, std::shared_ptr<Persistable>>;
+using PyPersistable = py::classh<Persistable>;
 
 void wrapPersistable(cpputils::python::WrapperCollection &wrappers) {
     // TODO: uncomment once afw.fits uses WrapperCollection

--- a/python/lsst/afw/typehandling/_GenericMap.cc
+++ b/python/lsst/afw/typehandling/_GenericMap.cc
@@ -97,7 +97,7 @@ template <typename K>
 void declareGenericMap(cpputils::python::WrapperCollection& wrappers, std::string const& suffix,
                        std::string const& key) {
     using Class = GenericMap<K>;
-    using PyClass = py::class_<Class, std::shared_ptr<Class>>;
+    using PyClass = py::classh<Class>;
 
     std::string className = "GenericMap" + suffix;
     // Give the class a custom docstring to avoid confusing Python users
@@ -170,7 +170,7 @@ template <typename K>
 void declareMutableGenericMap(cpputils::python::WrapperCollection& wrappers, std::string const& suffix,
                               std::string const& key) {
     using Class = MutableGenericMap<K>;
-    using PyClass = py::class_<Class, std::shared_ptr<Class>, GenericMap<K>>;
+    using PyClass = py::classh<Class, GenericMap<K>>;
 
     std::string className = "MutableGenericMap" + suffix;
     // Give the class a custom docstring to avoid confusing Python users

--- a/python/lsst/afw/typehandling/_SimpleGenericMap.cc
+++ b/python/lsst/afw/typehandling/_SimpleGenericMap.cc
@@ -42,7 +42,7 @@ template <typename K>
 void declareSimpleGenericMap(cpputils::python::WrapperCollection& wrappers, std::string const& suffix,
                              std::string const& key) {
     using Class = SimpleGenericMap<K>;
-    using PyClass = py::class_<Class, std::shared_ptr<Class>, MutableGenericMap<K>>;
+    using PyClass = py::classh<Class, MutableGenericMap<K>>;
 
     std::string className = "SimpleGenericMap" + suffix;
     // Give the class a custom docstring to avoid confusing Python users

--- a/python/lsst/afw/typehandling/_Storable.cc
+++ b/python/lsst/afw/typehandling/_Storable.cc
@@ -24,7 +24,6 @@
 #include "pybind11/pybind11.h"
 
 #include "lsst/cpputils/python.h"
-#include "lsst/cpputils/python/PySharedPtr.h"
 
 #include "lsst/afw/typehandling/Storable.h"
 #include "lsst/afw/typehandling/python.h"
@@ -32,13 +31,11 @@
 namespace py = pybind11;
 using namespace py::literals;
 
-using lsst::cpputils::python::PySharedPtr;
-
 namespace lsst {
 namespace afw {
 namespace typehandling {
 
-using PyStorable = py::class_<Storable, PySharedPtr<Storable>, table::io::Persistable, StorableHelper<>>;
+using PyStorable = py::classh<Storable, table::io::Persistable, StorableHelper<>>;
 
 void wrapStorable(cpputils::python::WrapperCollection& wrappers) {
     wrappers.addInheritanceDependency("lsst.afw.table.io");
@@ -52,7 +49,7 @@ void wrapStorable(cpputils::python::WrapperCollection& wrappers) {
     });
 
     wrappers.wrapType(
-        py::class_<StorableHelperFactory>(
+        py::classh<StorableHelperFactory>(
             wrappers.module, "StorableHelperFactory"
         ),
         [](auto& mod, auto& cls) {

--- a/tests/testGenericMapLib.cc
+++ b/tests/testGenericMapLib.cc
@@ -26,7 +26,6 @@
 #include <memory>
 #include <sstream>
 
-#include "lsst/cpputils/python/PySharedPtr.h"
 #include "lsst/pex/exceptions.h"
 
 #include "lsst/afw/typehandling/GenericMap.h"
@@ -319,8 +318,6 @@ void declareAnyTypeFunctions(py::module& mod) {
 }  // namespace
 
 PYBIND11_MODULE(testGenericMapLib, mod) {
-    using lsst::cpputils::python::PySharedPtr;
-
     py::module::import("lsst.afw.typehandling");
 
     declareAnyTypeFunctions<bool>(mod);
@@ -340,10 +337,10 @@ PYBIND11_MODULE(testGenericMapLib, mod) {
     mod.def("makeInitialMap", &makeInitialMap);
     mod.def("makeCppUpdates", &makeCppUpdates, "testmap"_a);
     mod.def("addCppStorable", &addCppStorable, "testmap"_a);
-    mod.def("keepStaticStorable", &keepStaticStorable, "storable"_a = nullptr);
+    mod.def("keepStaticStorable", &keepStaticStorable, "storable"_a = nullptr, py::keep_alive<0, 1>());
     mod.def("duplicate", &duplicate, "input"_a);
 
-    py::class_<CppStorable, PySharedPtr<CppStorable>, Storable, StorableHelper<CppStorable>> cls(
+    py::classh<CppStorable, Storable, StorableHelper<CppStorable>> cls(
             mod, "CppStorable");
     cls.def(py::init<std::string>());
     cls.def("__eq__", &CppStorable::operator==, py::is_operator());

--- a/tests/testTableArchivesLib.cc
+++ b/tests/testTableArchivesLib.cc
@@ -128,12 +128,10 @@ void DummyPsf::write(OutputArchiveHandle& handle) const {
     handle.saveCatalog(catalog);
 }
 
-PYBIND11_DECLARE_HOLDER_TYPE(MyType, std::shared_ptr<MyType>);
-
 PYBIND11_MODULE(testTableArchivesLib, mod) {
     py::module::import("lsst.afw.detection");
 
-    py::class_<DummyPsf, std::shared_ptr<DummyPsf>, lsst::afw::detection::Psf> cls(mod, "DummyPsf");
+    py::classh<DummyPsf, lsst::afw::detection::Psf> cls(mod, "DummyPsf");
 
     cls.def(py::init<double>());
 


### PR DESCRIPTION
Avoid multi base inheritance for Detector as this breaks pybind with class holders