### PR TITLE
DM-52492: Remove unnecessary global statement

### DIFF
--- a/python/lsst/afw/geom/_python/_transform.py
+++ b/python/lsst/afw/geom/_python/_transform.py
@@ -103,7 +103,6 @@ def addTransformMethods(cls):
     A Transform class or subclass, e.g.
     `lsst.afw.geom.TransformPoint2ToSpherePoint`
     """
-    global transformRegistry
     className = cls.__name__
     if className in transformRegistry:
         raise RuntimeError(f"Class {className!r}={transformRegistry[className]} already registered; "


### PR DESCRIPTION
The dict is being examined and modified but the variable itself is not being changed so the global is unnecessary (and flake8 warns about it now).